### PR TITLE
fix compilation on non-glibc linux

### DIFF
--- a/src/s2/base/port.h
+++ b/src/s2/base/port.h
@@ -159,7 +159,7 @@
 #endif  // defined(__APPLE__)
 
 // __GLIBC_PREREQ
-#if defined OS_LINUX
+#if defined OS_LINUX || defined(__linux__)
 // GLIBC-related macros.
 #include <features.h>
 
@@ -274,7 +274,7 @@ inline void sized_delete_array(void *ptr, size_t size) {
 // -----------------------------------------------------------------------------
 
 // IS_LITTLE_ENDIAN, IS_BIG_ENDIAN
-#if defined OS_LINUX || defined OS_ANDROID || defined(__ANDROID__)
+#if defined OS_LINUX || defined(__linux__) || defined OS_ANDROID || defined(__ANDROID__)
 // _BIG_ENDIAN
 #include <endian.h>
 
@@ -405,7 +405,7 @@ const char PATH_SEPARATOR = '/';
 // -----------------------------------------------------------------------------
 
 // uint, ushort, ulong
-#if defined OS_LINUX
+#if defined OS_LINUX || defined(__linux__)
 // The uint mess:
 // mysql.h sets _GNU_SOURCE which sets __USE_MISC in <features.h>
 // sys/types.h typedefs uint if __USE_MISC


### PR DESCRIPTION
This should fix compilation of s2geometry on Linux when there is no glibc around.
Compilation failed because macro `IS_BIG_ENDIAN` or `IS_LITTLE_ENDIAN` do not seem to get defined in some environments:
```
/work/ArangoDB/3rdParty/s2geometry/src/s2/util/endian/endian.h:111:2: error: #error "Unsupported bytesex: Either IS_BIG_ENDIAN or IS_LITTLE_ENDIAN must be defined"
 #error "Unsupported bytesex: Either IS_BIG_ENDIAN or IS_LITTLE_ENDIAN must be defined"  // NOLINT
  ^~~~~
```
This seems to be because the define `OS_LINUX` also is not defined in this environment.
So I am now checking for the define `__linux__` and not just `OS_LINUX` to detect a Linux OS.