### PR TITLE
fix ubuntu dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ S2 documentation can be found on [s2geometry.io](http://s2geometry.io).
 On Ubuntu, all of these can be installed via apt-get:
 
 ```
-sudo apt-get install cmake libgflags-dev libgoogle-glog-dev libgtest-dev openssl
+sudo apt-get install cmake libgflags-dev libgoogle-glog-dev libgtest-dev libssl-dev
 ```
 
 Otherwise, you may need to install some from source.


### PR DESCRIPTION
the library name for openssl headers/libraries is `libssl-dev` and not `openssl` (which is the executables)