### PR TITLE
Remove platform-specific ssize_t from btree implementation.

### DIFF
--- a/src/s2/util/gtl/btree.h
+++ b/src/s2/util/gtl/btree.h
@@ -248,7 +248,7 @@ struct common_params {
 
   using allocator_type = Alloc;
   using key_type = Key;
-  using size_type = ssize_t;
+  using size_type = std::make_signed<size_t>::type;
   using difference_type = ptrdiff_t;
 
   enum {
@@ -815,7 +815,7 @@ class btree {
   };
 
   struct node_stats {
-    node_stats(ssize_t l, ssize_t i)
+    node_stats(typename Params::size_type l, typename Params::size_type i)
         : leaf_nodes(l),
           internal_nodes(i) {
     }
@@ -826,8 +826,8 @@ class btree {
       return *this;
     }
 
-    ssize_t leaf_nodes;
-    ssize_t internal_nodes;
+    typename Params::size_type leaf_nodes;
+    typename Params::size_type internal_nodes;
   };
 
  public:

--- a/src/s2/util/gtl/btree.h
+++ b/src/s2/util/gtl/btree.h
@@ -814,8 +814,12 @@ class btree {
     kMatchMask = node_type::kMatchMask,
   };
 
+ public:
+  using size_type = typename Params::size_type;
+
+ private:
   struct node_stats {
-    node_stats(typename Params::size_type l, typename Params::size_type i)
+    node_stats(size_type l, size_type i)
         : leaf_nodes(l),
           internal_nodes(i) {
     }
@@ -826,8 +830,8 @@ class btree {
       return *this;
     }
 
-    typename Params::size_type leaf_nodes;
-    typename Params::size_type internal_nodes;
+    size_type leaf_nodes;
+    size_type internal_nodes;
   };
 
  public:
@@ -838,7 +842,6 @@ class btree {
   using const_pointer = typename Params::const_pointer;
   using reference = typename Params::reference;
   using const_reference = typename Params::const_reference;
-  using size_type = typename Params::size_type;
   using difference_type = typename Params::difference_type;
   using iterator = btree_iterator<node_type, reference, pointer>;
   using const_iterator = typename iterator::const_iterator;

--- a/src/s2/util/gtl/btree.h
+++ b/src/s2/util/gtl/btree.h
@@ -55,7 +55,6 @@
 
 #include <cstddef>
 #include <cstring>
-#include <sys/types.h>
 #include <algorithm>
 #include <cassert>
 #include <functional>


### PR DESCRIPTION
Since Windows doesn't have `ssize_t`, converting to the standardized `std::make_signed<size_t>::type` fixes compilation issues there.