### PR TITLE
Improve the installation of the Python bindings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,3 +26,4 @@ Dan Larkin-York <dan@arangodb.com>
 Eric Veach <ericv@google.com>
 Jesse Rosenstock <jmr@google.com>
 Julien Basch <julienbasch@google.com>
+Phil Elson <pelson.pub@gmail.com>

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,9 +1,18 @@
 include(${SWIG_USE_FILE})
 include_directories(${PYTHON_INCLUDE_PATH})
+
 set(CMAKE_SWIG_FLAGS "")
 set_property(SOURCE s2.i PROPERTY SWIG_FLAGS "-module" "pywraps2")
 set_property(SOURCE s2.i PROPERTY CPLUSPLUS ON)
-swig_add_module(pywraps2 python s2.i)
+
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    swig_add_module(pywraps2 python s2.i)
+else()
+    SWIG_ADD_LIBRARY(pywraps2
+        LANGUAGE python
+        SOURCES s2.i)
+endif()
+
 swig_link_libraries(pywraps2 ${PYTHON_LIBRARIES} s2)
 enable_testing()
 add_test(NAME pywraps2_test COMMAND
@@ -11,6 +20,16 @@ add_test(NAME pywraps2_test COMMAND
 	 "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
 set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
-install(TARGETS _pywraps2 DESTINATION share/python)
+
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
+    from distutils import sysconfig as sc;
+    print(sc.get_python_lib(prefix='', plat_specific=True))"
+  OUTPUT_VARIABLE PYTHON_SITE
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Install the wrapper.
+install(TARGETS _pywraps2 DESTINATION ${PYTHON_SITE})
 install(FILES "${PROJECT_BINARY_DIR}/python/pywraps2.py"
-	DESTINATION share/python)
+    DESTINATION ${PYTHON_SITE})
+


### PR DESCRIPTION
Fix the use of the deprecated swig_add_module in place of SWIG_ADD_LIBRARY.
Fix the installation location from ${prefix}/share/python/ to ${PYTHON_SITE_PACKAGES}/

Closes #6 

I've just signed the CLA.


Note: I'm not particularly strong with CMake, and used this as an excuse to get some more familiarity. 

