### PR TITLE
Add missing full polygon predicates vector clear call in S2Buider.Reset

### DIFF
--- a/src/s2/s2builder.cc
+++ b/src/s2/s2builder.cc
@@ -482,6 +482,7 @@ void S2Builder::Reset() {
   layers_.clear();
   layer_options_.clear();
   layer_begins_.clear();
+  layer_is_full_polygon_predicates_.clear();
   label_set_ids_.clear();
   label_set_lexicon_.Clear();
   label_set_.clear();


### PR DESCRIPTION
While reviewing the code, it appears that `layer_is_full_polygon_predicates_` was not cleared in `S2Builder.Reset` method.
If a `S2Builder` instance was reused after calling `S2Builder.Reset`, the wrong `is_full_polygon_predicate` was invoked.
The `ExpectDegeneracies` function called by `FindPolygonDegeneracies` tests has been modified to check that the correct predicate is invoked : it does reuse 16 times the `S2Builder` instance and check s the correct predicate is being called. 