### PR TITLE
Make gtest optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,14 @@ add_library(s2
             src/s2/util/math/exactfloat/exactfloat.cc
             src/s2/util/math/mathutil.cc
             src/s2/util/units/length-units.cc)
+
+if (GTEST_ROOT)
 add_library(s2testing STATIC
             src/s2/s2builderutil_testing.cc
             src/s2/s2shapeutil_testing.cc
             src/s2/s2testing.cc)
+endif()
+
 target_link_libraries(
     s2
     ${GFLAGS_LIBRARIES} ${GLOG_LIBRARIES} ${OPENSSL_LIBRARIES}
@@ -407,7 +411,11 @@ install(FILES src/s2/util/math/mathutil.h
 install(FILES src/s2/util/units/length-units.h
               src/s2/util/units/physical-units.h
         DESTINATION include/s2/util/units)
+if (GTEST_ROOT)
 install(TARGETS s2 s2testing DESTINATION lib)
+else()
+install(TARGETS s2 DESTINATION lib)
+endif()
 
 message("GTEST_ROOT: ${GTEST_ROOT}")
 if (GTEST_ROOT)
@@ -527,7 +535,7 @@ if (GTEST_ROOT)
   endforeach()
 endif()
 
-if (BUILD_EXAMPLES)
+if (BUILD_EXAMPLES AND TARGET s2testing)
   add_subdirectory("doc/examples" examples)
 endif()
 


### PR DESCRIPTION
Don't build s2testing if there's no GTEST.
Don't build examples if s2testing is not a target.