### PR TITLE
build pip wheel in wrapper cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,7 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then brew install gflags glog swig; fi
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz; fi
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then tar zxvf release-1.8.0.tar.gz; fi
+  - python3 -m pip install setuptools wheel
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
         - GTEST_ROOT=/usr/src/gtest
@@ -29,6 +32,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
         - GTEST_ROOT=/usr/src/gtest
@@ -45,6 +51,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
         - GTEST_ROOT=/usr/src/gtest
@@ -61,6 +70,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10"
         - GTEST_ROOT=/usr/src/gtest
@@ -74,6 +86,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
         - GTEST_ROOT=/usr/src/gtest
@@ -92,6 +107,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
         - GTEST_ROOT=/usr/src/gtest
@@ -110,6 +128,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
         - GTEST_ROOT=/usr/src/gtest
@@ -128,6 +149,9 @@ matrix:
             - libgtest-dev
             - libssl-dev
             - swig3.0
+            - python3-pip
+            - python3-setuptools
+            - python3-wheel
       env:
         - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
         - GTEST_ROOT=/usr/src/gtest
@@ -155,7 +179,6 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then brew install gflags glog swig; fi
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz; fi
   - if [[ "$TRAVIS_OS_NAME" == osx ]]; then tar zxvf release-1.8.0.tar.gz; fi
-  - python3 -m pip install setuptools wheel
 
 script:
   - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ install(FILES src/s2/util/units/length-units.h
         DESTINATION include/s2/util/units)
 install(TARGETS s2 s2testing DESTINATION lib)
 
-message("GTEST_ROOT: ${GTEST_ROOT}")
+message(" * GTEST_ROOT: ${GTEST_ROOT}")
 if (GTEST_ROOT)
   add_subdirectory(${GTEST_ROOT} build_gtest)
   include_directories(${GTEST_ROOT}/include)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Disable building of shared libraries with `-DBUILD_SHARED_LIBS=OFF`.
 If you want the Python interface, you will also need:
 
 * [SWIG](https://github.com/swig/swig) (for Python support, optional)
+* [setuptools](https://github.com/pypa/setuptools) and
+  [wheel](https://github.com/pypa/wheel) (required to build wheel package)
 
 which can be installed via
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,11 +11,31 @@ swig_link_libraries(pywraps2 ${Python3_LIBRARIES} s2)
 enable_testing()
 add_test(NAME pywraps2_test COMMAND
          ${Python3_EXECUTABLE}
-         "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
+        "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
 set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
-# Install the wrapper.
-install(TARGETS _pywraps2 DESTINATION ${Python3_SITELIB})
-install(FILES "${PROJECT_BINARY_DIR}/python/pywraps2.py"
-        DESTINATION ${Python3_SITELIB})
+# Package pip wheel
+set(PYWRAPS2_PKG "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}")
+set(PYWRAPS2_DIST "${CMAKE_CURRENT_BINARY_DIR}/dist")
+set(PYWRAPS2_SETUP "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py" ${PYWRAPS2_SETUP})
+add_custom_command(OUTPUT ${PYWRAPS2_PKG}
+                   COMMAND ${CMAKE_COMMAND} -E
+                     make_directory ${PYWRAPS2_PKG}
+                   COMMAND ${CMAKE_COMMAND} -E
+                     copy $<TARGET_FILE:s2> ${PYWRAPS2_PKG}
+                   COMMAND ${CMAKE_COMMAND} -E
+                     copy "$<TARGET_FILE_DIR:_pywraps2>/*pywraps2.*" ${PYWRAPS2_PKG}
+                   COMMAND ${CMAKE_COMMAND} -E
+                     copy "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" ${PYWRAPS2_PKG}
+                   DEPENDS s2 _pywraps2)
+add_custom_command(OUTPUT ${PYWRAPS2_DIST}
+                   COMMAND ${Python3_EXECUTABLE} ${PYWRAPS2_SETUP} bdist_wheel
+                   DEPENDS ${PYWRAPS2_PKG} ${PYWRAPS2_SETUP})
+add_custom_target(bdist_wheel ALL DEPENDS ${PYWRAPS2_DIST})
+
+# Install the package
+install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} ${PYWRAPS2_SETUP} install
+                              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,7 +11,7 @@ swig_link_libraries(pywraps2 ${Python3_LIBRARIES} s2)
 enable_testing()
 add_test(NAME pywraps2_test COMMAND
          ${Python3_EXECUTABLE}
-        "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
+         "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
 set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
@@ -27,9 +27,11 @@ add_custom_command(OUTPUT ${PYWRAPS2_PKG}
                    COMMAND ${CMAKE_COMMAND} -E
                      copy $<TARGET_FILE:s2> ${PYWRAPS2_PKG}
                    COMMAND ${CMAKE_COMMAND} -E
-                     copy "$<TARGET_FILE_DIR:_pywraps2>/*pywraps2.*" ${PYWRAPS2_PKG}
+                     copy "$<TARGET_FILE_DIR:_pywraps2>/*pywraps2.*"
+                          ${PYWRAPS2_PKG}
                    COMMAND ${CMAKE_COMMAND} -E
-                     copy "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" ${PYWRAPS2_PKG}
+                     copy "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py"
+                          ${PYWRAPS2_PKG}
                    DEPENDS s2 _pywraps2)
 add_custom_command(OUTPUT ${PYWRAPS2_DIST}
                    COMMAND ${Python3_EXECUTABLE} ${PYWRAPS2_SETUP} bdist_wheel
@@ -37,5 +39,6 @@ add_custom_command(OUTPUT ${PYWRAPS2_DIST}
 add_custom_target(bdist_wheel ALL DEPENDS ${PYWRAPS2_DIST})
 
 # Install the package
-install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} ${PYWRAPS2_SETUP} install
-                              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+install(CODE "execute_process(
+                COMMAND ${Python3_EXECUTABLE} ${PYWRAPS2_SETUP} install
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")

--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -1,0 +1,1 @@
+from .pywraps2 import *

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, Distribution
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
+
+
+setup(
+    name="@PROJECT_NAME@",
+    version="@PROJECT_VERSION@",
+    packages=["@PROJECT_NAME@"],
+    package_data={"": ["*.so", "*.dylib", "*.dll"]},
+    distclass=BinaryDistribution
+)


### PR DESCRIPTION
The original `CMakeLists.txt` for python installs the lib and py files directly to python site. They are not versioned and the installation dir is affected by `CMAKE_INSTALL_PREFIX`. While the latter is not necessary bad, the former definitely is and it's bad for redistribution. This PR is partially related to #93.