### PR TITLE
Use local macro names to avoid conflicts with gflags.

### DIFF
--- a/doc/examples/point_index.cc
+++ b/doc/examples/point_index.cc
@@ -14,9 +14,9 @@
 #include "s2/s2point_index.h"
 #include "s2/s2testing.h"
 
-DEFINE_int32(num_index_points, 10000, "Number of points to index");
-DEFINE_int32(num_queries, 10000, "Number of queries");
-DEFINE_double(query_radius_km, 100, "Query radius in kilometers");
+S2_DEFINE_int32(num_index_points, 10000, "Number of points to index");
+S2_DEFINE_int32(num_queries, 10000, "Number of queries");
+S2_DEFINE_double(query_radius_km, 100, "Query radius in kilometers");
 
 int main(int argc, char **argv) {
   // Build an index containing random points anywhere on the Earth.

--- a/doc/examples/term_index.cc
+++ b/doc/examples/term_index.cc
@@ -24,9 +24,9 @@
 #include "s2/s2region_term_indexer.h"
 #include "s2/s2testing.h"
 
-DEFINE_int32(num_documents, 10000, "Number of documents");
-DEFINE_int32(num_queries, 10000, "Number of queries");
-DEFINE_double(query_radius_km, 100, "Query radius in kilometers");
+S2_DEFINE_int32(num_documents, 10000, "Number of documents");
+S2_DEFINE_int32(num_queries, 10000, "Number of queries");
+S2_DEFINE_double(query_radius_km, 100, "Query radius in kilometers");
 
 // A prefix added to spatial terms to distinguish them from other index terms
 // (e.g. representing words or phrases).

--- a/src/s2/base/commandlineflags.h
+++ b/src/s2/base/commandlineflags.h
@@ -20,30 +20,42 @@
 
 #include <gflags/gflags.h>
 
+// Map local macros to GFlags macros.
+#define S2_DEFINE_bool  DEFINE_bool
+#define S2_DECLARE_bool  DECLARE_bool
+
+#define S2_DEFINE_double  DEFINE_double
+#define S2_DECLARE_double  DECLARE_double
+
+#define S2_DEFINE_int32  DEFINE_int32
+#define S2_DECLARE_int32  DECLARE_int32
+
+#define S2_DEFINE_string  DEFINE_string
+#define S2_DECLARE_string  DECLARE_string
+
 #else  // !defined(S2_USE_GFLAGS)
 
 #include <string>
 
 #include "s2/base/integral_types.h"
 
-#define DEFINE_bool(name, default_value, description) \
+#define S2_DEFINE_bool(name, default_value, description) \
   bool FLAGS_##name = default_value
-#define DECLARE_bool(name) \
+#define S2_DECLARE_bool(name) \
   extern bool FLAGS_##name
-
-#define DEFINE_double(name, default_value, description) \
+#define S2_DEFINE_double(name, default_value, description) \
   double FLAGS_##name = default_value
-#define DECLARE_double(name) \
+#define S2_DECLARE_double(name) \
   extern double FLAGS_##name
 
-#define DEFINE_int32(name, default_value, description) \
+#define S2_DEFINE_int32(name, default_value, description) \
   int32 FLAGS_##name = default_value
-#define DECLARE_int32(name) \
+#define S2_DECLARE_int32(name) \
   extern int32 FLAGS_##name
 
-#define DEFINE_string(name, default_value, description) \
+#define S2_DEFINE_string(name, default_value, description) \
   std::string FLAGS_##name = default_value
-#define DECLARE_string(name) \
+#define S2_DECLARE_string(name) \
   extern std::string FLAGS_##name
 
 #endif  // !defined(S2_USE_GFLAGS)

--- a/src/s2/base/commandlineflags.h
+++ b/src/s2/base/commandlineflags.h
@@ -20,7 +20,8 @@
 
 #include <gflags/gflags.h>
 
-// Map local macros to GFlags macros.
+// If the GFlags library is available, map the local macro names to
+// GFlags macros.
 #define S2_DEFINE_bool  DEFINE_bool
 #define S2_DECLARE_bool  DECLARE_bool
 
@@ -38,6 +39,9 @@
 #include <string>
 
 #include "s2/base/integral_types.h"
+
+// Create a set of gflags-like macros for declaring/defining flags. Use
+// a library-specific name to potential minimize clashes with GFlags.
 
 #define S2_DEFINE_bool(name, default_value, description) \
   bool FLAGS_##name = default_value

--- a/src/s2/mutable_s2shape_index.cc
+++ b/src/s2/mutable_s2shape_index.cc
@@ -50,7 +50,7 @@ using std::vector;
 // If a cell has more than this many edges, and it is not a leaf cell, then it
 // is subdivided.  This flag can be overridden via MutableS2ShapeIndex::Options.
 // Reasonable values range from 10 to about 50 or so.
-DEFINE_int32(
+S2_DEFINE_int32(
     s2shape_index_default_max_edges_per_cell, 10,
     "Default maximum number of edges (not counting 'long' edges) per cell; "
     "reasonable values range from 10 to 50.  Small values makes queries "
@@ -70,7 +70,7 @@ DEFINE_int32(
 //      with huge numbers of edges may exceed the budget;
 //  (3) shapes being removed are always processed in a single batch.  (This
 //      could be fixed, but it seems better to keep the code simpler for now.)
-DEFINE_int32(
+S2_DEFINE_int32(
     s2shape_index_tmp_memory_budget_mb, 100,
     "Attempts to limit the amount of temporary memory used by "
     "MutableS2ShapeIndex when creating or updating very large indexes "
@@ -88,7 +88,7 @@ DEFINE_int32(
 // time and memory costs without much benefit, and (2) in pathological cases,
 // many long edges close together could force subdivision to continue all the
 // way to the leaf cell level.
-DEFINE_double(
+S2_DEFINE_double(
     s2shape_index_cell_size_to_long_edge_ratio, 1.0,
     "The cell size relative to the length of an edge at which it is first "
     "considered to be 'long'.  Long edges do not contribute to the decision "

--- a/src/s2/s2builder_test.cc
+++ b/src/s2/s2builder_test.cc
@@ -77,8 +77,8 @@ using InputEdgeId = S2Builder::Graph::InputEdgeId;
 using Graph = S2Builder::Graph;
 using GraphOptions = S2Builder::GraphOptions;;
 
-DEFINE_int32(iteration_multiplier, 1,
-             "Iteration multiplier for randomized tests");
+S2_DEFINE_int32(iteration_multiplier, 1,
+                "Iteration multiplier for randomized tests");
 
 namespace {
 

--- a/src/s2/s2cell_union.cc
+++ b/src/s2/s2cell_union.cc
@@ -35,8 +35,8 @@ using std::max;
 using std::min;
 using std::vector;
 
-DEFINE_int32(s2cell_union_decode_max_num_cells, 1000000,
-             "The maximum number of cells allowed by S2CellUnion::Decode");
+S2_DEFINE_int32(s2cell_union_decode_max_num_cells, 1000000,
+                "The maximum number of cells allowed by S2CellUnion::Decode");
 
 static const unsigned char kCurrentLosslessEncodingVersionNumber = 1;
 

--- a/src/s2/s2cell_union.h
+++ b/src/s2/s2cell_union.h
@@ -35,8 +35,8 @@ class S2Cap;
 class S2Cell;
 class S2LatLngRect;
 
-DECLARE_bool(s2debug);
-DECLARE_int32(s2cell_union_decode_max_num_cells);
+S2_DECLARE_bool(s2debug);
+S2_DECLARE_int32(s2cell_union_decode_max_num_cells);
 
 // An S2CellUnion is a region consisting of cells of various sizes.  Typically
 // a cell union is used to approximate some other shape.  There is a tradeoff

--- a/src/s2/s2cell_union_test.cc
+++ b/src/s2/s2cell_union_test.cc
@@ -37,7 +37,7 @@
 #include "s2/third_party/absl/strings/str_cat.h"
 #include "s2/util/coding/coder.h"
 
-DECLARE_bool(s2debug);
+S2_DECLARE_bool(s2debug);
 
 using absl::StrCat;
 using std::max;

--- a/src/s2/s2debug.cc
+++ b/src/s2/s2debug.cc
@@ -19,5 +19,5 @@
 
 #include "s2/base/logging.h"
 
-DEFINE_bool(s2debug, !!google::DEBUG_MODE,
-            "Enable automatic validity checking in S2 code");
+S2_DEFINE_bool(s2debug, !!google::DEBUG_MODE,
+               "Enable automatic validity checking in S2 code");

--- a/src/s2/s2debug.h
+++ b/src/s2/s2debug.h
@@ -57,7 +57,7 @@
 
 // Command line flag that enables extra validity checking throughout the S2
 // code.  It is turned on by default in debug-mode builds.
-DECLARE_bool(s2debug);
+S2_DECLARE_bool(s2debug);
 
 // Class that allows the --s2debug validity checks to be enabled or disabled
 // for specific objects (e.g., see S2Polygon).

--- a/src/s2/s2loop.cc
+++ b/src/s2/s2loop.cc
@@ -65,7 +65,7 @@ using std::pair;
 using std::set;
 using std::vector;
 
-DEFINE_bool(
+S2_DEFINE_bool(
     s2loop_lazy_indexing, true,
     "Build the S2ShapeIndex only when it is first needed.  This can save "
     "significant amounts of memory and time when geometry is constructed but "
@@ -74,7 +74,7 @@ DEFINE_bool(
 
 // The maximum number of vertices we'll allow when decoding a loop.
 // The default value of 50 million is about 30x bigger than the number of
-DEFINE_int32(
+S2_DEFINE_int32(
     s2polygon_decode_max_num_vertices, 50000000,
     "The upper limit on the number of loops that are allowed by the "
     "S2Polygon::Decode method.");

--- a/src/s2/s2point_compression_test.cc
+++ b/src/s2/s2point_compression_test.cc
@@ -38,9 +38,9 @@ using absl::MakeSpan;
 using absl::Span;
 using std::vector;
 
-DEFINE_int32(s2point_compression_bm_level, 30,
+S2_DEFINE_int32(s2point_compression_bm_level, 30,
              "Level to encode at for benchmarks.");
-DEFINE_double(s2point_compression_bm_radius_km, 1000.0,
+S2_DEFINE_double(s2point_compression_bm_radius_km, 1000.0,
               "Radius to use for loop for benchmarks.");
 
 namespace {

--- a/src/s2/s2polygon.cc
+++ b/src/s2/s2polygon.cc
@@ -84,7 +84,7 @@ using std::sqrt;
 using std::unique_ptr;
 using std::vector;
 
-DEFINE_bool(
+S2_DEFINE_bool(
     s2polygon_lazy_indexing, true,
     "Build the S2ShapeIndex only when it is first needed.  This can save "
     "significant amounts of memory and time when geometry is constructed but "
@@ -92,7 +92,7 @@ DEFINE_bool(
 
 // The maximum number of loops we'll allow when decoding a polygon.
 // The default value of 10 million is 200x bigger than the number of
-DEFINE_int32(
+S2_DEFINE_int32(
     s2polygon_decode_max_num_loops, 10000000,
     "The upper limit on the number of loops that are allowed by the "
     "S2Polygon::Decode method.");

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -33,7 +33,7 @@
 #include "s2/util/math/exactfloat/exactfloat.h"
 #include "s2/util/math/vector.h"
 
-DEFINE_int32(consistency_iters, 5000,
+S2_DEFINE_int32(consistency_iters, 5000,
              "Number of iterations for precision consistency tests");
 
 using std::min;

--- a/src/s2/s2region_coverer_test.cc
+++ b/src/s2/s2region_coverer_test.cc
@@ -53,10 +53,10 @@ using std::priority_queue;
 using std::unordered_map;
 using std::vector;
 
-DEFINE_string(max_cells, "4,8",
+S2_DEFINE_string(max_cells, "4,8",
               "Comma-separated list of values to use for 'max_cells'");
 
-DEFINE_int32(iters, google::DEBUG_MODE ? 1000 : 100000,
+S2_DEFINE_int32(iters, google::DEBUG_MODE ? 1000 : 100000,
              "Number of random caps to try for each max_cells value");
 
 TEST(S2RegionCoverer, RandomCells) {

--- a/src/s2/s2region_term_indexer_test.cc
+++ b/src/s2/s2region_term_indexer_test.cc
@@ -36,7 +36,7 @@
 
 using std::vector;
 
-DEFINE_int32(iters, 400, "number of iterations for testing");
+S2_DEFINE_int32(iters, 400, "number of iterations for testing");
 
 namespace {
 

--- a/src/s2/s2testing.cc
+++ b/src/s2/s2testing.cc
@@ -52,7 +52,7 @@ using std::max;
 using std::unique_ptr;
 using std::vector;
 
-DEFINE_int32(s2_random_seed, 1,
+S2_DEFINE_int32(s2_random_seed, 1,
              "Seed value that can be passed to S2Testing::rnd.Reset()");
 
 const double S2Testing::kEarthRadiusKm = 6371.01;

--- a/src/s2/s2testing.h
+++ b/src/s2/s2testing.h
@@ -51,7 +51,7 @@ class S2Region;
 //
 // This flag currently does *not* affect the initial seed value for
 // S2Testing::rnd.  TODO(user): Fix this.
-DECLARE_int32(s2_random_seed);
+S2_DECLARE_int32(s2_random_seed);
 
 // This class defines various static functions that are useful for writing
 // unit tests.


### PR DESCRIPTION
The gflags macro names (`DEFINE_`) are also used by glog. If you have a setup that uses glog but not gflags, the `glog/logging.h` header will actually undefine these macros. This causes a very difficult-to-find error in S2. This PR changes the names of these macros to a library-specific name to avoid this issue. It follows the pattern of the logging macros.