### PR TITLE
build: add options in cmake to skip some building parts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,8 @@ find_package(OpenSSL REQUIRED)
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)
 
-option(BULID_PYTHON "Build Python interfaces" ON)
-if (BULID_PYTHON)
+option(BUILD_PYTHON "Build Python interfaces" ON)
+if (BUILD_PYTHON)
     find_package(SWIG)
     find_package(PythonInterp)
     find_package(PythonLibs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,13 @@ endif()
 find_package(OpenSSL REQUIRED)
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)
-find_package(SWIG)
-find_package(PythonInterp)
-find_package(PythonLibs)
+
+option(BULID_PYTHON "Build Python interfaces" ON)
+if (BULID_PYTHON)
+    find_package(SWIG)
+    find_package(PythonInterp)
+    find_package(PythonLibs)
+endif()
 
 if (WIN32)
     # Use unsigned characters
@@ -515,22 +519,25 @@ if (GTEST_ROOT)
       src/s2/sequence_lexicon_test.cc
       src/s2/value_lexicon_test.cc)
 
-  enable_testing()
+  option(BUILD_TESTING "Build s2 unit tests" ON)
+  if (BUILD_TESTING)
+    enable_testing()
+    foreach (test_cc ${S2TestFiles})
+        get_filename_component(test ${test_cc} NAME_WE)
+        add_executable(${test} ${test_cc})
+        target_link_libraries(
+            ${test}
+            s2testing s2 gtest_main)
+        add_test(${test} ${test})
+    endforeach()
+  endif()
 
-  foreach (test_cc ${S2TestFiles})
-    get_filename_component(test ${test_cc} NAME_WE)
-    add_executable(${test} ${test_cc})
-    target_link_libraries(
-        ${test}
-        s2testing s2 gtest_main)
-    add_test(${test} ${test})
-  endforeach()
 endif()
 
 if (BUILD_EXAMPLES)
   add_subdirectory("doc/examples" examples)
 endif()
 
-if (${SWIG_FOUND} AND ${PYTHONLIBS_FOUND})
+if (${BUILD_PYTHON} AND ${SWIG_FOUND} AND ${PYTHONLIBS_FOUND})
   add_subdirectory("src/python" python)
 endif()


### PR DESCRIPTION
Hi, we included s2geometry as one of the dependencies for our project. To reduce the building time (and complexity) of s2geometry, we want to make some building parts optional and skippable. So in this PR, I add several CMake options, including:

1. `BUILD_TESTING` for unit tests.
2.  `BULID_PYTHON` for Python interfaces.

This PR is tested on my platform:

```
cmake .. -DBUILD_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF -DGTEST_ROOT=/home/wutao1/git/googletest/googletest
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The following features have been disabled:

 * GFLAGS, allows changing command line flags.
 * GLOG, provides logging configurability.
 * SHARED_LIBS, builds shared libraries instead of static.

-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found version "1.0.2n")  
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
GTEST_ROOT: /home/wutao1/git/googletest/googletest
-- Found PythonInterp: /usr/bin/python (found version "2.7.17") 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/wutao1/git/s2geometry/build
```
