### PR TITLE
SWIG-wrap only S2CellId::FromToken(const string&)

### DIFF
--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -41,6 +41,19 @@ class PyWrapS2TestCase(unittest.TestCase):
     self.assertLess(cell, cell.next())
     self.assertGreater(cell.next(), cell)
 
+  def testS2CellIdFromToTokenIsWrappedCorrectly(self):
+    cell = s2.S2CellId.FromToken("487604c489f841c3")
+    self.assertEqual(cell.ToToken(), "487604c489f841c3")
+    self.assertEqual(cell.id(), 0x487604c489f841c3)
+
+    cell = s2.S2CellId.FromToken("487")
+    self.assertEqual(cell.ToToken(), "487")
+    self.assertEqual(cell.id(), 0x4870000000000000)
+
+    cell = s2.S2CellId.FromToken("this is invalid")
+    self.assertEqual(cell.ToToken(), "X")
+    self.assertEqual(cell.id(), 0)
+
   def testS2CellIdGetEdgeNeighborsIsWrappedCorrectly(self):
     cell = s2.S2CellId(0x466d319000000000)
     expected_neighbors = [s2.S2CellId(0x466d31b000000000),

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -5,6 +5,7 @@
 
 %{
 #include <sstream>
+#include <string>
 
 #include "s2/s2cell_id.h"
 #include "s2/s2region.h"
@@ -307,7 +308,7 @@ class S2Point {
 %unignore S2CellId::FromFacePosLevel(int, uint64, int);
 %unignore S2CellId::FromLatLng;
 %unignore S2CellId::FromPoint;
-%unignore S2CellId::FromToken;
+%unignore S2CellId::FromToken(const std::string&);
 %unignore S2CellId::GetCenterSiTi(int*, int*) const;
 %unignore S2CellId::GetEdgeNeighbors;
 %unignore S2CellId::ToFaceIJOrientation(int*, int*, int*) const;

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -364,7 +364,7 @@ class S2CellId {
   // FromToken() returns S2CellId::None() for malformed inputs.
   string ToToken() const;
   static S2CellId FromToken(const char* token, size_t length);
-  static S2CellId FromToken(const string& token);
+  static S2CellId FromToken(const std::string& token);
 
   // Use encoder to generate a serialized representation of this cell id.
   // Can also encode an invalid cell.


### PR DESCRIPTION
Declare `S2CellId::FromToken` with `std::string` instead of `string` to please SWIG.

Fixes #109 

Add tests for SWIG `S2CellId.FromToken`/`ToToken`.