### PR TITLE
Add operator new/delete and ctor for Candidate

### DIFF
--- a/src/s2/s2region_coverer.h
+++ b/src/s2/s2region_coverer.h
@@ -18,6 +18,8 @@
 #ifndef S2_S2REGION_COVERER_H_
 #define S2_S2REGION_COVERER_H_
 
+#include <cstddef>
+#include <new>
 #include <queue>
 #include <utility>
 #include <vector>
@@ -245,9 +247,27 @@ class S2RegionCoverer {
 
  private:
   struct Candidate {
+    void* operator new(std::size_t size, std::size_t max_children) {
+      return ::operator new (size + max_children * sizeof(Candidate *));
+    }
+
+    void operator delete(void* p) {
+      ::operator delete (p);
+    }
+
+    Candidate(const S2Cell& cell, const std::size_t max_children)
+        : cell(cell), is_terminal(max_children == 0) {
+      std::fill_n(&children[0], max_children,
+                  absl::implicit_cast<Candidate*>(nullptr));
+    }
+
+    // Default destructor is fine; Candidate* is trivially destructible.
+    // children must be deleted by DeleteCandidate.
+    ~Candidate() = default;
+
     S2Cell cell;
     bool is_terminal;        // Cell should not be expanded further.
-    int num_children;        // Number of children that intersect the region.
+    int num_children = 0;    // Number of children that intersect the region.
     Candidate* children[0];  // Actual size may be 0, 4, 16, or 64 elements.
   };
 


### PR DESCRIPTION
Inspired by #85, which reports a gcc ubsan violation in `AddCandidate`.

I was not able to reproduce with `-fsanitize=undefined` but the current code
does look suspicious to me.

Current code:
```
Candidate* candidate = static_cast<Candidate*>(
    ::operator new(sizeof(Candidate) + children_size));
```

However, the `Candidate` constructor is never called, and `Candidate` is not
trivially constructible.  Candidate contains `S2Cell`, which contains
`R1Interval`, which is not trivially constructible.

Add `Candidate::operator new` with an extra arg of `max_children`;
this delegates to `::operator new`.  Similarly add `Candidate::operator delete`.

Move the `Candidate` initialization logic to a constructor.