### PR TITLE
Require Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(s2-geometry)
 
@@ -62,8 +62,9 @@ find_package(OpenSSL REQUIRED)
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)
 find_package(SWIG)
-find_package(PythonInterp)
-find_package(PythonLibs)
+# Use Python3_ROOT_DIR to help find python3, if the correct location is not
+# being found by default.
+find_package(Python3 COMPONENTS Interpreter Development)
 
 if (WIN32)
     # Use unsigned characters
@@ -86,7 +87,7 @@ endif()
 # OPENSSL_ROOT_DIR=/usr/local/opt/openssl cmake ..
 include_directories(
     ${GFLAGS_INCLUDE_DIRS} ${GLOG_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR}
-    ${PYTHON_INCLUDE_DIRS})
+    ${Python3_INCLUDE_DIRS})
 include_directories(src)
 
 add_library(s2
@@ -531,6 +532,6 @@ if (BUILD_EXAMPLES)
   add_subdirectory("doc/examples" examples)
 endif()
 
-if (${SWIG_FOUND} AND ${PYTHONLIBS_FOUND})
+if (${SWIG_FOUND} AND ${Python3_FOUND})
   add_subdirectory("src/python" python)
 endif()

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ sudo port install swig
 ```
 Expect to see some warnings if you build with swig 2.0.
 
+Python 3 is required.
+
 ## Other S2 implementations
 
 * [Go](https://github.com/golang/geo) (Approximately 40% complete.)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(${SWIG_USE_FILE})
-include_directories(${PYTHON_INCLUDE_PATH})
+include_directories(${Python3_INCLUDE_DIRS})
 
 set(CMAKE_SWIG_FLAGS "")
 set_property(SOURCE s2.i PROPERTY SWIG_FLAGS "-module" "pywraps2")
@@ -12,21 +12,15 @@ else()
     swig_add_library(pywraps2 LANGUAGE python SOURCES s2.i)
 endif()
 
-swig_link_libraries(pywraps2 ${PYTHON_LIBRARIES} s2)
+swig_link_libraries(pywraps2 ${Python3_LIBRARIES} s2)
 enable_testing()
 add_test(NAME pywraps2_test COMMAND
-         ${PYTHON_EXECUTABLE}
+         ${Python3_EXECUTABLE}
 	 "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
 set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-                  from distutils import sysconfig as sc;
-                  print(sc.get_python_lib(prefix='', plat_specific=True))"
-                OUTPUT_VARIABLE PYTHON_SITE
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 # Install the wrapper.
-install(TARGETS _pywraps2 DESTINATION ${PYTHON_SITE})
+install(TARGETS _pywraps2 DESTINATION ${Python3_SITELIB})
 install(FILES "${PROJECT_BINARY_DIR}/python/pywraps2.py"
-        DESTINATION ${PYTHON_SITE})
+	DESTINATION ${Python3_SITELIB})


### PR DESCRIPTION
This should help solve problems where s2's SWIG module was build with
Python2, but users try to use Python3.

Python2 has been sunsetted as of 2020-01-01.

Increases required CMake version from 3.5 (released 2016-03) to 3.12
(released 2018-07).