### PR TITLE
travis: change osx_image from xcode8.3 to xcode12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
         - GTEST_ROOT=/usr/src/gtest
 
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode12
       env:
         - MATRIX_EVAL=""
         - GTEST_ROOT="$( /bin/pwd )/googletest-release-1.8.0/googletest"


### PR DESCRIPTION
With some luck, this will also get us a newer swig version.