### PR TITLE
Include stdint.i in s2.i (SWIG)

### DIFF
--- a/src/python/s2.i
+++ b/src/python/s2.i
@@ -1,5 +1,6 @@
 %include "std_vector.i"
 %include "std_string.i"
+%include "stdint.i"
 
 %template() std::vector<unsigned long long>;
 %template() std::vector<S2CellId>;


### PR DESCRIPTION
Try to be forward-compatible with use of `<cstdint>` types, e.g.
`int64 -> std::uint64_t`.  Adding the include now should make
subsequent merges easier and pass travis-ci with fewer SWIG changes /
less SWIG knowledge.