### PR TITLE
python/CMakeLists.txt: Use swig_add_library

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -5,12 +5,7 @@ set(CMAKE_SWIG_FLAGS "")
 set_property(SOURCE s2.i PROPERTY SWIG_FLAGS "-module" "pywraps2")
 set_property(SOURCE s2.i PROPERTY CPLUSPLUS ON)
 
-# Starting in 3.8, swig_add_module is deprecated in favor of swig_add_library.
-if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
-    swig_add_module(pywraps2 python s2.i)
-else()
-    swig_add_library(pywraps2 LANGUAGE python SOURCES s2.i)
-endif()
+swig_add_library(pywraps2 LANGUAGE python SOURCES s2.i)
 
 swig_link_libraries(pywraps2 ${Python3_LIBRARIES} s2)
 enable_testing()


### PR DESCRIPTION
This should have been part of #128.

swig_add_module has been deprecated since CMake 3.8; we now require 3.12.