### PR TITLE
Expose S2CellId::AppendAllNeighbors in Python (as GetAllNeighbors)

### DIFF
--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -63,6 +63,19 @@ class PyWrapS2TestCase(unittest.TestCase):
     neighbors = cell.GetEdgeNeighbors()
     self.assertEqual(neighbors, expected_neighbors)
 
+  def testS2CellIdGetAllNeighborsIsWrappedCorrectly(self):
+    cell = s2.S2CellId(0x6aa7590000000000)
+    expected_neighbors = (s2.S2CellId(0x2ab3530000000000),
+                          s2.S2CellId(0x2ab34b0000000000),
+                          s2.S2CellId(0x2ab34d0000000000),
+                          s2.S2CellId(0x6aa75b0000000000),
+                          s2.S2CellId(0x6aa7570000000000),
+                          s2.S2CellId(0x6aa75f0000000000),
+                          s2.S2CellId(0x6aa7510000000000),
+                          s2.S2CellId(0x6aa75d0000000000))
+    neighbors = cell.GetAllNeighbors(cell.level())
+    self.assertEqual(neighbors, expected_neighbors)
+
   def testS2CellIdIntersectsIsTrueForOverlap(self):
     cell1 = s2.S2CellId(0x89c259c000000000)
     cell2 = s2.S2CellId(0x89c2590000000000)

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -302,6 +302,8 @@ class S2Point {
 %unignore S2CellId;
 %unignore S2CellId::S2CellId;
 %unignore S2CellId::~S2CellId;
+%unignore S2CellId::AppendAllNeighbors(int, std::vector<S2CellId>*) const;
+%rename(GetAllNeighbors) S2CellId::AppendAllNeighbors(int level, std::vector<S2CellId>* output) const;
 %unignore S2CellId::Begin;
 %unignore S2CellId::End;
 %unignore S2CellId::FromFaceIJ(int, int, int);


### PR DESCRIPTION
This exposes `S2CellId::AppendAllNeighbors` to Python code as `S2CellId.GetAllNeighbors`:

```python
>>> import pywraps2 as s2
>>> p = s2.S2CellId.FromToken('6aa759')
>>> ','.join(_.ToToken() for _ in p.GetAllNeighbors(p.level()))
'2ab353,2ab34b,2ab34d,6aa75b,6aa757,6aa75f,6aa751,6aa75d'
```

I renamed this because "Append" doesn't make sense – SWIG is configured to convert passing a (mutable) output `std::vector` by reference into returning an immutable `tuple`.

This was exposed in the API before 13ab3fc4 removed all members by default.