### PR TITLE
Add S2Polygon::InitToSnapped(..., SnapFunction)

### DIFF
--- a/src/s2/s2polygon.cc
+++ b/src/s2/s2polygon.cc
@@ -992,9 +992,14 @@ void S2Polygon::InitFromBuilder(const S2Polygon& a, S2Builder* builder) {
   }
 }
 
+void S2Polygon::InitToSnapped(const S2Polygon& polygon,
+                              const S2Builder::SnapFunction& snap_function) {
+  S2Builder builder{S2Builder::Options(snap_function)};
+  InitFromBuilder(polygon, &builder);
+}
+
 void S2Polygon::InitToSnapped(const S2Polygon* a, int snap_level) {
-  S2Builder builder{S2Builder::Options(S2CellIdSnapFunction(snap_level))};
-  InitFromBuilder(*a, &builder);
+  InitToSnapped(*a, S2CellIdSnapFunction(snap_level));
 }
 
 void S2Polygon::InitToSimplified(const S2Polygon& a,


### PR DESCRIPTION
This was declared, but accidentally not defined.

Reimplement `InitToSnapped(..., level)` using the `SnapFunction` overload.