### PR TITLE
Expand Python Bindings to include S2RegionTermIndexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@
 
 Dan Larkin-York <dan@arangodb.com>
 Google Inc.
+Koordinates Limited

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,3 +27,4 @@ Eric Veach <ericv@google.com>
 Jesse Rosenstock <jmr@google.com>
 Julien Basch <julienbasch@google.com>
 Phil Elson <pelson.pub@gmail.com>
+Robert Coup <robert.coup@koordinates.com>

--- a/doc/examples/term_index.py
+++ b/doc/examples/term_index.py
@@ -1,0 +1,101 @@
+"""
+This example shows how to add spatial data to an information retrieval
+system.  Such systems work by converting documents into a collection of
+"index terms" (e.g., representing words or phrases), and then building an
+"inverted index" that maps each term to a list of documents (and document
+positions) where that term occurs.
+
+This example shows how to convert spatial data into index terms, which can
+then be indexed along with the other document information.
+
+This is a port of the C++ term_index.cc example for the Python API.
+"""
+import argparse
+from collections import defaultdict
+
+import pywraps2 as s2
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "This example shows how to convert spatial data into index terms, "
+            "which can then be indexed along with the other document "
+            "information."
+        )
+    )
+    parser.add_argument(
+        '--num_documents', type=int, default=10000, help="Number of documents"
+    )
+    parser.add_argument(
+        '--num_queries', type=int, default=10000, help="Number of queries"
+    )
+    parser.add_argument(
+        '--query_radius_km', type=float, default=100,
+        help="Query radius in kilometers"
+    )
+
+    args = parser.parse_args()
+
+    # A prefix added to spatial terms to distinguish them from other index terms
+    # (e.g. representing words or phrases).
+    PREFIX = "s2:"
+
+    # Create a set of "documents" to be indexed.  Each document consists of a
+    # single point.  (You can easily substitute any S2Region type here, or even
+    # index a mixture of region types using S2Region.  Other
+    # region types include polygons, polylines, rectangles, discs, buffered
+    # geometry, etc.)
+    documents = []
+    for i in range(args.num_documents):
+        documents.append(s2.S2Testing.RandomPoint())
+
+    # We use a dict as our inverted index.  The key is an index term, and
+    # the value is the set of "document ids" where this index term is present.
+    index = defaultdict(set)
+
+    # Create an indexer suitable for an index that contains points only.
+    # (You may also want to adjust min_level() or max_level() if you plan
+    # on querying very large or very small regions.)
+    indexer = s2.S2RegionTermIndexer()
+    indexer.set_index_contains_points_only(True)
+
+    # Add the documents to the index.
+    for docid, index_region in enumerate(documents):
+        for term in indexer.GetIndexTerms(index_region, PREFIX):
+            index[term].add(docid)
+
+    # Convert the query radius to an angle representation.
+    radius = s2.S1Angle.Radians(s2.S2Earth.KmToRadians(args.query_radius_km))
+
+    # Count the number of documents (points) found in all queries.
+    num_found = 0
+    for i in range(args.num_queries):
+        # Choose a random center for query.
+        query_region = s2.S2Cap(s2.S2Testing.RandomPoint(), radius)
+
+        # Convert the query region to a set of terms, and compute the union of
+        # the document ids associated with those terms.  (An actual information
+        # retrieval system would do something more sophisticated.)
+        candidates = set()
+        for term in indexer.GetQueryTerms(query_region, PREFIX):
+            candidates |= index[term]
+
+        # "candidates" now contains all documents that intersect the query
+        # region, along with some documents that nearly intersect it.  We can
+        # prune the results by retrieving the original "document" and checking
+        # the distance more precisely.
+        result = []
+        for docid in candidates:
+            if query_region.Contains(documents[docid]):
+                result.append(docid)
+
+        # Now do something with the results (in this example we just count
+        # them).
+        num_found += len(result)
+
+    print("Found %d points in %d queries" % (num_found, args.num_queries))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -15,6 +15,8 @@
 #
 
 import unittest
+from collections import defaultdict
+
 import pywraps2 as s2
 
 
@@ -610,6 +612,174 @@ class PyWrapS2TestCase(unittest.TestCase):
     angle = s2.S1Angle.Radians(radius_rad)
     radius_m = s2.S2Earth.RadiansToMeters(angle.radians())
     self.assertEqual(radius_m, 12340.0)
+
+
+class RegionTermIndexerTest(unittest.TestCase):
+  def _randomCaps(self, query_type, **indexer_options):
+    # This function creates an index consisting either of points (if
+    # options.index_contains_points_only() is true) or S2Caps of random size.
+    # It then executes queries consisting of points (if query_type == POINT)
+    # or S2Caps of random size (if query_type == CAP).
+    #
+    # indexer_options are set on both the indexer & coverer (if relevant)
+    # eg. _randomCaps('cap', min_level=0) calls indexer.set_min_level(0)
+    ITERATIONS = 400
+
+    indexer = s2.S2RegionTermIndexer()
+    coverer = s2.S2RegionCoverer()
+
+    # set indexer options
+    for opt_key, opt_value in indexer_options.items():
+      setter = "set_%s" % opt_key
+      getattr(indexer, setter)(opt_value)
+      if hasattr(coverer, setter):
+        getattr(coverer, setter)(opt_value)
+
+    caps = []
+    coverings = []
+    index = defaultdict(set)
+
+    index_terms = 0
+    query_terms = 0
+    for i in range(ITERATIONS):
+      # Choose the region to be indexed: either a single point or a cap
+      # of random size (up to a full sphere).
+      terms = []
+      if indexer.index_contains_points_only():
+        cap = s2.S2Cap.FromPoint(s2.S2Testing.RandomPoint())
+        terms = indexer.GetIndexTerms(cap.center(), "")
+      else:
+        cap = s2.S2Testing.GetRandomCap(
+          0.3 * s2.S2Cell.AverageArea(indexer.max_level()),
+          4.0 * s2.S2Cell.AverageArea(indexer.min_level())
+        )
+        terms = indexer.GetIndexTerms(cap, "")
+
+      caps.append(cap)
+      coverings.append(s2.S2CellUnion(coverer.GetCovering(cap)))
+      for term in terms:
+        index[term].add(i)
+
+      index_terms += len(terms)
+
+    for i in range(ITERATIONS):
+      # Choose the region to be queried: either a random point or a cap of
+      # random size.
+      terms = []
+
+      if query_type == 'cap':
+        cap = s2.S2Cap.FromPoint(s2.S2Testing.RandomPoint())
+        terms = indexer.GetQueryTerms(cap.center(), "")
+      else:
+        cap = s2.S2Testing.GetRandomCap(
+          0.3 * s2.S2Cell.AverageArea(indexer.max_level()),
+          4.0 * s2.S2Cell.AverageArea(indexer.min_level())
+        )
+        terms = indexer.GetQueryTerms(cap, "")
+
+      # Compute the expected results of the S2Cell query by brute force.
+      covering = s2.S2CellUnion(coverer.GetCovering(cap))
+      expected, actual = set(), set()
+      for j in range(len(caps)):
+        if covering.Intersects(coverings[j]):
+          expected.add(j)
+      
+      for term in terms:
+        actual |= index[term]
+
+      self.assertEqual(expected, actual)
+      query_terms += len(terms)
+
+      print("Index terms/doc: %0.2f, Query terms/doc: %0.2f" % (
+        float(index_terms) / ITERATIONS,
+        float(query_terms) / ITERATIONS)
+      )
+
+  # We run one test case for each combination of space vs. time optimization,
+  # and indexing regions vs. only points.
+
+  def testIndexRegionsQueryRegionsOptimizeTime(self):
+    self._randomCaps("cap",
+      optimize_for_space=False,
+      min_level=0,
+      max_level=16,
+      max_cells=20,
+    )
+
+  def testIndexRegionsQueryPointsOptimizeTime(self):
+    self._randomCaps("point",
+      optimize_for_space=False,
+      min_level=0,
+      max_level=16,
+      max_cells=20,
+    )
+
+  def testIndexRegionsQueryRegionsOptimizeTimeWithLevelMod(self):
+    self._randomCaps("cap",
+      optimize_for_space=False,
+      min_level=6,
+      max_level=12,
+      level_mod=3,
+    )
+
+  def testIndexRegionsQueryRegionsOptimizeSpace(self):
+    self._randomCaps("cap",
+      optimize_for_space=True,
+      min_level=4,
+      max_level=s2.S2CellId.kMaxLevel,
+      max_cells=8,
+    )
+
+  def testIndexPointsQueryRegionsOptimizeTime(self):
+    self._randomCaps("cap",
+      optimize_for_space=False,
+      min_level=0,
+      max_level=s2.S2CellId.kMaxLevel,
+      level_mod=2,
+      max_cells=20,
+      index_contains_points_only=True,
+    )
+
+  def testIndexPointsQueryRegionsOptimizeSpace(self):
+    self._randomCaps("cap",
+      optimize_for_space=True,
+      index_contains_points_only=True,
+    )
+
+  def testMaxLevelSetLoosely(self):
+    # Test that correct terms are generated even when (max_level - min_level)
+    # is not a multiple of level_mod.
+    indexer1 = s2.S2RegionTermIndexer()
+    indexer1.set_min_level(1)
+    indexer1.set_level_mod(2)
+    indexer1.set_max_level(19)
+
+    indexer2 = s2.S2RegionTermIndexer()
+    indexer2.set_min_level(1)
+    indexer2.set_level_mod(2)
+    indexer2.set_max_level(19)
+    indexer2.set_max_level(20)
+
+    point = s2.S2Testing.RandomPoint()
+
+    self.assertEqual(
+      indexer1.GetIndexTerms(point, ""),
+      indexer2.GetIndexTerms(point, "")
+    )
+    self.assertEqual(
+      indexer1.GetQueryTerms(point, ""),
+      indexer2.GetQueryTerms(point, "")
+    )
+
+    cap = s2.S2Testing.GetRandomCap(0.0, 1.0)
+    self.assertEqual(
+      indexer1.GetIndexTerms(cap, ""),
+      indexer2.GetIndexTerms(cap, "")
+    )
+    self.assertEqual(
+      indexer1.GetQueryTerms(cap, ""),
+      indexer2.GetQueryTerms(cap, "")
+    )
 
 
 if __name__ == "__main__":

--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-
-
 import unittest
 import pywraps2 as s2
 

--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -606,5 +606,13 @@ class PyWrapS2TestCase(unittest.TestCase):
     self.assertEqual(1234, i)
     self.assertEqual(5678, j)
 
+  def testS2EarthMetricRadians(self):
+    radius_rad = s2.S2Earth.KmToRadians(12.34)
+    self.assertAlmostEqual(radius_rad, 0.0019368985451286374)
+    angle = s2.S1Angle.Radians(radius_rad)
+    radius_m = s2.S2Earth.RadiansToMeters(angle.radians())
+    self.assertEqual(radius_m, 12340.0)
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/src/python/s2.i
+++ b/src/python/s2.i
@@ -3,6 +3,7 @@
 %include "stdint.i"
 
 %template() std::vector<unsigned long long>;
+%template() std::vector<string>;
 %template() std::vector<S2CellId>;
 %template() std::vector<S2Point>;
 %template() std::vector<S2LatLng>;

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -11,6 +11,7 @@
 #include "s2/s2region.h"
 #include "s2/s2cap.h"
 #include "s2/s2edge_crossings.h"
+#include "s2/s2earth.h"
 #include "s2/s2latlng.h"
 #include "s2/s2latlng_rect.h"
 #include "s2/s2loop.h"
@@ -362,6 +363,41 @@ class S2Point {
 %unignore S2CellUnion::cell_ids;
 %unignore S2CellUnion::empty;
 %unignore S2CellUnion::num_cells;
+%unignore S2Earth;
+%unignore S2Earth::GetDistance(const S2LatLng&, const S2LatLng&);
+%unignore S2Earth::GetDistance(const S2Point&, const S2Point&);
+%unignore S2Earth::GetDistanceKm(const S2LatLng&, const S2LatLng&);
+%unignore S2Earth::GetDistanceKm(const S2Point&, const S2Point&);
+%unignore S2Earth::GetDistanceMeters(const S2LatLng&, const S2LatLng&);
+%unignore S2Earth::GetDistanceMeters(const S2Point&, const S2Point&);
+%unignore S2Earth::GetInitialBearing(const S2LatLng&, const S2LatLng&);
+%unignore S2Earth::HighestAltitude();
+%unignore S2Earth::HighestAltitudeKm();
+%unignore S2Earth::HighestAltitudeMeters();
+%unignore S2Earth::KmToRadians(double);
+%unignore S2Earth::LowestAltitude();
+%unignore S2Earth::LowestAltitudeKm();
+%unignore S2Earth::LowestAltitudeMeters();
+%unignore S2Earth::MetersToRadians(double);
+%unignore S2Earth::RadiansToKm(double);
+%unignore S2Earth::RadiansToMeters(double);
+%unignore S2Earth::Radius();
+%unignore S2Earth::RadiusKm();
+%unignore S2Earth::RadiusMeters();
+%unignore S2Earth::SquareKmToSteradians(double);
+%unignore S2Earth::SquareMetersToSteradians(double);
+%unignore S2Earth::SteradiansToSquareKm(double);
+%unignore S2Earth::SteradiansToSquareMeters(double);
+%unignore S2Earth::ToAngle(const util::units::Meters&);
+%unignore S2Earth::ToChordAngle(const util::units::Meters&);
+%unignore S2Earth::ToDistance(const S1Angle&);
+%unignore S2Earth::ToDistance(const S1ChordAngle&);
+%unignore S2Earth::ToKm(const S1Angle&);
+%unignore S2Earth::ToKm(const S1ChordAngle&);
+%unignore S2Earth::ToLongitudeRadians(const util::units::Meters&, double);
+%unignore S2Earth::ToMeters(const S1Angle&);
+%unignore S2Earth::ToMeters(const S1ChordAngle&);
+%unignore S2Earth::ToRadians(const util::units::Meters&);
 %unignore S2LatLng;
 %unignore S2LatLng::S2LatLng;
 %unignore S2LatLng::~S2LatLng;
@@ -511,6 +547,7 @@ class S2Point {
 %include "s2/s1interval.h"
 %include "s2/s2cell_id.h"
 %include "s2/s2edge_crossings.h"
+%include "s2/s2earth.h"
 %include "s2/s2region.h"
 %include "s2/s2cap.h"
 %include "s2/s2latlng.h"

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -20,6 +20,7 @@
 #include "s2/s2polygon.h"
 #include "s2/s2polyline.h"
 #include "s2/s2region_coverer.h"
+#include "s2/s2region_term_indexer.h"
 #include "s2/s2cell.h"
 #include "s2/s2cell_union.h"
 %}
@@ -34,6 +35,16 @@
 %apply std::vector<S2CellId> *OUTPUT {std::vector<S2CellId> *covering};
 %apply std::vector<S2CellId> *OUTPUT {std::vector<S2CellId> *interior};
 %apply std::vector<S2CellId> *OUTPUT {std::vector<S2CellId> *output};
+
+%typemap(in) absl::string_view {
+  if (PyUnicode_Check($input)) {
+    $1 = absl::string_view(PyUnicode_AsUTF8($input));
+  } else {
+    SWIG_exception(SWIG_TypeError, "string expected");
+  }
+}
+%typemap(typecheck) absl::string_view = char *;
+
 
 %typemap(in, numinputs=0) S2CellId *OUTPUT_ARRAY_4(S2CellId temp[4]) {
   $1 = temp;
@@ -233,6 +244,57 @@ class S2Point {
   void set_level_mod(int level_mod) {
     $self->mutable_options()->set_level_mod(level_mod);
   }
+
+  int true_max_level() const { return $self->options().true_max_level(); }
+}
+
+// Expose Options functions on S2RegionTermIndexer until we figure out
+// nested classes in SWIG.
+%extend S2RegionTermIndexer {
+  int max_cells() const { return $self->options().max_cells(); }
+  void set_max_cells(int max_cells) {
+    $self->mutable_options()->set_max_cells(max_cells);
+  }
+
+  int min_level() const { return $self->options().min_level(); }
+  void set_min_level(int min_level) {
+    $self->mutable_options()->set_min_level(min_level);
+  }
+
+  int max_level() const { return $self->options().max_level(); }
+  void set_max_level(int max_level) {
+    $self->mutable_options()->set_max_level(max_level);
+  }
+
+  void set_fixed_level(int fixed_level) {
+    $self->mutable_options()->set_fixed_level(fixed_level);
+  }
+
+  int level_mod() const { return $self->options().level_mod(); }
+  void set_level_mod(int level_mod) {
+    $self->mutable_options()->set_level_mod(level_mod);
+  }
+
+  int true_max_level() const { return $self->options().true_max_level(); }
+
+  bool index_contains_points_only() const {
+    return $self->options().index_contains_points_only();
+  }
+  void set_index_contains_points_only(bool value) {
+    $self->mutable_options()->set_index_contains_points_only(value);
+  }
+
+  bool optimize_for_space() const {
+    return $self->options().optimize_for_space();
+  }
+  void set_optimize_for_space(bool value) {
+    $self->mutable_options()->set_optimize_for_space(value);
+  }
+
+  char marker_character() const { return $self->options().marker_character(); }
+  void set_marker_character(char ch) {
+    $self->mutable_options()->set_marker_character(ch);
+  }
 }
 
 %ignoreall
@@ -295,6 +357,7 @@ class S2Point {
 %unignore S2Cell::S2Cell;
 %unignore S2Cell::~S2Cell;
 %unignore S2Cell::ApproxArea;
+%unignore S2Cell::AverageArea;
 %unignore S2Cell::Clone;
 %unignore S2Cell::Contains;
 %unignore S2Cell::Decode;
@@ -552,6 +615,19 @@ class S2Point {
 %unignore S2RegionCoverer::GetCovering(const S2Region&, std::vector<S2CellId>*);
 %unignore S2RegionCoverer::GetInteriorCovering(const S2Region&,
                                                std::vector<S2CellId>*);
+%unignore S2RegionTermIndexer;
+%unignore S2RegionTermIndexer::S2RegionTermIndexer;
+%unignore S2RegionTermIndexer::~S2RegionTermIndexer;
+%unignore S2RegionTermIndexer::GetIndexTerms(const S2Point&, absl::string_view);
+%unignore S2RegionTermIndexer::GetIndexTerms(const S2Region&,
+                                             absl::string_view);
+%unignore S2RegionTermIndexer::GetIndexTermsForCanonicalCovering(
+    const S2CellUnion&, absl::string_view);
+%unignore S2RegionTermIndexer::GetQueryTerms(const S2Point&, absl::string_view);
+%unignore S2RegionTermIndexer::GetQueryTerms(const S2Region&,
+                                             absl::string_view);
+%unignore S2RegionTermIndexer::GetQueryTermsForCanonicalCovering(
+    const S2CellUnion&, absl::string_view);
 
 %include "s2/r1interval.h"
 %include "s2/s1angle.h"
@@ -570,6 +646,7 @@ class S2Point {
 %include "s2/s2polygon.h"
 %include "s2/s2polyline.h"
 %include "s2/s2region_coverer.h"
+%include "s2/s2region_term_indexer.h"
 %include "s2/s2cell.h"
 %include "s2/s2cell_union.h"
 


### PR DESCRIPTION
* Make it possible to follow the _Indexing for Search_ and _Querying for Search_ sections in the [Quickstart guide](https://s2geometry.io/devguide/cpp/quickstart#indexing-for-search) from Python.
* Primarily expand the Python bindings to include `S2RegionTermIndexer`
* And related changes for testing
* Port the `term_index.cc` example to Python as well for good measure.
* Add some `repr()` methods

Fixes #84