### PR TITLE
CMake: add version information to the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(s2-geometry)
+project(s2-geometry
+	VERSION 0.10.0)
 
 include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
@@ -213,6 +214,11 @@ target_link_libraries(
 # add_subdirectory(<path_to_s2geometry_dir> s2geometry)
 # target_link_libraries(<target_name> s2)
 target_include_directories(s2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Add version information to the target
+set_target_properties(s2 PROPERTIES
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION ${PROJECT_VERSION})
 
 # We don't need to install all headers, only those
 # transitively included by s2 headers we are exporting.


### PR DESCRIPTION
On Linux systems, libraries need to be installed with attached version
information so other packages can depend on specific versions and make
sure they don't compile against a version they're not compatible with

This change installs libs2.so.0.10.0 with appropriate
symlinks as libs2.so.0 and libs2.so.

Do note that for new future versions, the version in CMakeLists.txt will have
to be updated as well