### PR TITLE
Remove use of std::allocator::rebind

### DIFF
--- a/src/s2/util/gtl/compact_array.h
+++ b/src/s2/util/gtl/compact_array.h
@@ -145,7 +145,8 @@ class compact_array_base {
     return const_cast<compact_array_base<T, A>*>(this)->Array();
   }
 
-  typedef typename A::template rebind<T>::other value_allocator_type;
+  using value_allocator_type =
+      typename std::allocator_traits<A>::template rebind_alloc<T>;
 
  public:
   typedef T                                     value_type;

--- a/src/s2/util/gtl/densehashtable.h
+++ b/src/s2/util/gtl/densehashtable.h
@@ -182,7 +182,8 @@ struct dense_hashtable_const_iterator;
 template <class V, class K, class HF, class ExK, class SetK, class EqK, class A>
 struct dense_hashtable_iterator {
  private:
-  typedef typename A::template rebind<V>::other value_alloc_type;
+  using value_alloc_type =
+      typename std::allocator_traits<A>::template rebind_alloc<V>;
 
  public:
   typedef dense_hashtable_iterator<V, K, HF, ExK, SetK, EqK, A>
@@ -245,7 +246,8 @@ struct dense_hashtable_iterator {
 template <class V, class K, class HF, class ExK, class SetK, class EqK, class A>
 struct dense_hashtable_const_iterator {
  private:
-  typedef typename A::template rebind<V>::other value_alloc_type;
+  using value_alloc_type =
+      typename std::allocator_traits<A>::template rebind_alloc<V>;
 
  public:
   typedef dense_hashtable_iterator<V, K, HF, ExK, SetK, EqK, A>
@@ -311,7 +313,8 @@ template <class Value, class Key, class HashFcn,
           class ExtractKey, class SetKey, class EqualKey, class Alloc>
 class dense_hashtable {
  private:
-  typedef typename Alloc::template rebind<Value>::other value_alloc_type;
+  using value_alloc_type =
+      typename std::allocator_traits<Alloc>::template rebind_alloc<Value>;
 
 
  public:


### PR DESCRIPTION
This is deprecated in C++17 and has been removed in C++20.

Use std::allocator_traits::rebind_alloc instead.

https://en.cppreference.com/w/cpp/memory/allocator
https://en.cppreference.com/w/cpp/memory/allocator_traits

Fixes #173.