### PR TITLE
Allow encoded_uint_vector_test for 32-bit target

### DIFF
--- a/src/s2/encoded_uint_vector_test.cc
+++ b/src/s2/encoded_uint_vector_test.cc
@@ -24,7 +24,7 @@ using std::vector;
 
 namespace s2coding {
 
-static_assert(sizeof(EncodedUintVector<uint64>) == 16, "too big");
+static_assert(sizeof(EncodedUintVector<uint64>) <= 16, "too big");
 
 template <class T>
 void TestEncodedUintVector(const vector<T>& expected, size_t expected_bytes) {


### PR DESCRIPTION
This small change fix compilation error for 32-bit target.
And all checks from the `encoded_uint_vector_test` is passed for this case too.