### PR TITLE
Fix BN_ext_get_uint64 for OpenSSL >= 1.1 32bit

### DIFF
--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -93,6 +93,8 @@ inline static void BN_ext_set_uint64(BIGNUM* bn, uint64 v) {
 #endif
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
 // Return the absolute value of a BIGNUM as a 64-bit unsigned integer.
 // Requires that BIGNUM fits into 64 bits.
 inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
@@ -107,8 +109,6 @@ inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
   return (static_cast<uint64>(bn->d[1]) << 32) + bn->d[0];
 #endif
 }
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 // Count the number of low-order zero bits in the given BIGNUM (ignoring its
 // sign).  Returns 0 if the argument is zero.
@@ -129,6 +129,22 @@ static int BN_ext_count_low_zero_bits(const BIGNUM* bn) {
 }
 
 #else  // OPENSSL_VERSION_NUMBER >= 0x10100000L
+
+// Return the absolute value of a BIGNUM as a 64-bit unsigned integer.
+// Requires that BIGNUM fits into 64 bits.
+inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
+  uint64 r;
+#ifdef IS_LITTLE_ENDIAN
+  S2_CHECK_EQ(BN_bn2lebinpad(bn, reinterpret_cast<unsigned char*>(&r),
+              sizeof(r)), sizeof(r));
+#elif IS_BIG_ENDIAN
+  S2_CHECK_EQ(BN_bn2binpad(bn, reinterpret_cast<unsigned char*>(&r),
+              sizeof(r)), sizeof(r));
+#else
+#error one of IS_LITTLE_ENDIAN or IS_BIG_ENDIAN should be defined!
+#endif
+  return r;
+}
 
 static int BN_ext_count_low_zero_bits(const BIGNUM* bn) {
   // In OpenSSL >= 1.1, BIGNUM is an opaque type, so d and top


### PR DESCRIPTION
Suggested changes fix compilation error with `OpenSSL` >= 1.0 for 32bit target.
The algorithm is similar to what is currently being done in `BN_ext_set_uint64`, but in the opposite direction.