### PR TITLE
Make python optional via flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,5 +159,5 @@ install:
 script:
   - mkdir build
   - cd build
-  - cmake -DGTEST_ROOT=$GTEST_ROOT -DWITH_GFLAGS=ON -DWITH_GLOG=ON ..
+  - cmake -DGTEST_ROOT=$GTEST_ROOT -DWITH_GFLAGS=ON -DWITH_GLOG=ON -DWITH_PYTHON=ON ..
   - make && make CTEST_OUTPUT_ON_FAILURE=1 test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,7 @@ include_directories(
     ${GFLAGS_INCLUDE_DIRS} ${GLOG_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 
 if (WITH_PYTHON)
-  include_directories(
-    ${Python3_INCLUDE_DIRS})
+    include_directories(${Python3_INCLUDE_DIRS})
 endif()
 
 include_directories(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ add_feature_info(SHARED_LIBS BUILD_SHARED_LIBS
 
 option(BUILD_EXAMPLES "Build s2 documentation examples." ON)
 
+option(WITH_PYTHON "Add python interface" OFF)
+add_feature_info(PYTHON WITH_PYTHON "provides python interface to S2")
+
 feature_summary(WHAT ALL)
 
 if (WITH_GLOG)
@@ -63,10 +66,13 @@ endif()
 find_package(OpenSSL REQUIRED)
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)
-find_package(SWIG)
-# Use Python3_ROOT_DIR to help find python3, if the correct location is not
-# being found by default.
-find_package(Python3 COMPONENTS Interpreter Development)
+
+if (WITH_PYTHON)
+    find_package(SWIG)
+    # Use Python3_ROOT_DIR to help find python3, if the correct location is not
+    # being found by default.
+    find_package(Python3 COMPONENTS Interpreter Development)
+endif()
 
 if (WIN32)
     # Use unsigned characters
@@ -88,8 +94,13 @@ endif()
 # something like:
 # OPENSSL_ROOT_DIR=/usr/local/opt/openssl cmake ..
 include_directories(
-    ${GFLAGS_INCLUDE_DIRS} ${GLOG_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR}
+    ${GFLAGS_INCLUDE_DIRS} ${GLOG_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
+
+if (WITH_PYTHON)
+  include_directories(
     ${Python3_INCLUDE_DIRS})
+endif()
+
 include_directories(src)
 
 add_library(s2

--- a/README.md
+++ b/README.md
@@ -133,11 +133,12 @@ For more info read: [The CMake Cache](https://cmake.org/cmake/help/latest/guide/
 If you want the Python interface, you will also need:
 
 * [SWIG](https://github.com/swig/swig) (for Python support, optional)
+* python3-dev (for Python support, optional)
 
 which can be installed via
 
 ```
-sudo apt-get install swig
+sudo apt-get install swig python3-dev
 ```
 
 or on macOS:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Enable gflags and glog with `cmake -DWITH_GFLAGS=ON -DWITH_GLOG=ON ...`.
 
 Disable building of shared libraries with `-DBUILD_SHARED_LIBS=OFF`.
 
+Enable the python interface with `-DWITH_PYTHON=ON`.
+
 ## Installing
 
 From `build` subdirectory:
@@ -130,7 +132,8 @@ For more info read: [The CMake Cache](https://cmake.org/cmake/help/latest/guide/
 
 ## Python
 
-If you want the Python interface, you will also need:
+If you want the Python interface, you need to run cmake using
+`-DWITH_PYTHON=ON`. You will also need to install the following dependencies:
 
 * [SWIG](https://github.com/swig/swig) (for Python support, optional)
 * python3-dev (for Python support, optional)


### PR DESCRIPTION
Add a flag to determine if we should install the Python interface, and add additional python3-dev dependency to the install instructions.