### PR TITLE
Fully qualify std::string or add using statements

### DIFF
--- a/doc/examples/term_index.cc
+++ b/doc/examples/term_index.cc
@@ -24,6 +24,8 @@
 #include "s2/s2region_term_indexer.h"
 #include "s2/s2testing.h"
 
+using std::string;
+
 S2_DEFINE_int32(num_documents, 10000, "Number of documents");
 S2_DEFINE_int32(num_queries, 10000, "Number of queries");
 S2_DEFINE_double(query_radius_km, 100, "Query radius in kilometers");

--- a/src/s2/base/stringprintf.cc
+++ b/src/s2/base/stringprintf.cc
@@ -29,7 +29,7 @@ enum { IS__MSC_VER = 1 };
 enum { IS__MSC_VER = 0 };
 #endif
 
-void StringAppendV(string* dst, const char* format, va_list ap) {
+void StringAppendV(std::string* dst, const char* format, va_list ap) {
   // First try with a small fixed size buffer
   static const int kSpaceLength = 1024;
   char space[kSpaceLength];
@@ -81,16 +81,16 @@ void StringAppendV(string* dst, const char* format, va_list ap) {
 }
 
 
-string StringPrintf(const char* format, ...) {
+std::string StringPrintf(const char* format, ...) {
   va_list ap;
   va_start(ap, format);
-  string result;
+  std::string result;
   StringAppendV(&result, format, ap);
   va_end(ap);
   return result;
 }
 
-const string& SStringPrintf(string* dst, const char* format, ...) {
+const std::string& SStringPrintf(std::string* dst, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   dst->clear();
@@ -99,7 +99,7 @@ const string& SStringPrintf(string* dst, const char* format, ...) {
   return *dst;
 }
 
-void StringAppendF(string* dst, const char* format, ...) {
+void StringAppendF(std::string* dst, const char* format, ...) {
   va_list ap;
   va_start(ap, format);
   StringAppendV(dst, format, ap);

--- a/src/s2/base/stringprintf.h
+++ b/src/s2/base/stringprintf.h
@@ -24,22 +24,21 @@
 
 #include <cstdarg>
 #include <string>
-#include <vector>
 
-#include "s2/base/port.h"
+#include "absl/base/attributes.h"
 
 // Return a C++ string
-extern string StringPrintf(const char* format, ...)
+extern std::string StringPrintf(const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(1, 2);
 
 // Store result into a supplied string and return it
-extern const string& SStringPrintf(string* dst, const char* format, ...)
+extern const std::string& SStringPrintf(std::string* dst, const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(2, 3);
 
 // Append result to a supplied string
-extern void StringAppendF(string* dst, const char* format, ...)
+extern void StringAppendF(std::string* dst, const char* format, ...)
     // Tell the compiler to do printf format string checking.
     ABSL_PRINTF_ATTRIBUTE(2, 3);
 
@@ -48,6 +47,6 @@ extern void StringAppendF(string* dst, const char* format, ...)
 //
 // Implementation note: the va_list is never modified, this implementation
 // always operates on copies.
-extern void StringAppendV(string* dst, const char* format, va_list ap);
+extern void StringAppendV(std::string* dst, const char* format, va_list ap);
 
 #endif  // S2_BASE_STRINGPRINTF_H_

--- a/src/s2/base/strtoint.h
+++ b/src/s2/base/strtoint.h
@@ -95,11 +95,11 @@ inline int64 atoi64(const char *nptr) {
 }
 
 // Convenience versions of the above that take a string argument.
-inline int32 atoi32(const string &s) {
+inline int32 atoi32(const std::string &s) {
   return atoi32(s.c_str());
 }
 
-inline int64 atoi64(const string &s) {
+inline int64 atoi64(const std::string &s) {
   return atoi64(s.c_str());
 }
 

--- a/src/s2/encoded_string_vector.cc
+++ b/src/s2/encoded_string_vector.cc
@@ -20,6 +20,7 @@
 using absl::MakeSpan;
 using absl::Span;
 using absl::string_view;
+using std::string;
 using std::vector;
 
 namespace s2coding {

--- a/src/s2/encoded_string_vector.h
+++ b/src/s2/encoded_string_vector.h
@@ -43,7 +43,7 @@ class StringVectorEncoder {
   StringVectorEncoder();
 
   // Adds a string to the encoded vector.
-  void Add(const string& str);
+  void Add(const std::string& str);
 
   // Adds a string to the encoded vector by means of the given Encoder.  The
   // string consists of all output added to the encoder before the next call
@@ -61,7 +61,7 @@ class StringVectorEncoder {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  static void Encode(absl::Span<const string> v, Encoder* encoder);
+  static void Encode(absl::Span<const std::string> v, Encoder* encoder);
 
  private:
   // A vector consisting of the starting offset of each string in the
@@ -122,7 +122,7 @@ class EncodedStringVector {
 //////////////////   Implementation details follow   ////////////////////
 
 
-inline void StringVectorEncoder::Add(const string& str) {
+inline void StringVectorEncoder::Add(const std::string& str) {
   offsets_.push_back(data_.length());
   data_.Ensure(str.size());
   data_.putn(str.data(), str.size());

--- a/src/s2/encoded_string_vector_test.cc
+++ b/src/s2/encoded_string_vector_test.cc
@@ -22,6 +22,7 @@
 #include "absl/strings/string_view.h"
 
 using absl::string_view;
+using std::string;
 using std::vector;
 
 namespace s2coding {

--- a/src/s2/s2boolean_operation_test.cc
+++ b/src/s2/s2boolean_operation_test.cc
@@ -37,6 +37,7 @@ namespace {
 
 using absl::make_unique;
 using s2builderutil::LaxPolygonLayer;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2builder_test.cc
+++ b/src/s2/s2builder_test.cc
@@ -60,6 +60,7 @@ using std::endl;
 using std::make_pair;
 using std::min;
 using std::pair;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 using s2builderutil::GraphClone;

--- a/src/s2/s2builderutil_closed_set_normalizer_test.cc
+++ b/src/s2/s2builderutil_closed_set_normalizer_test.cc
@@ -34,6 +34,7 @@
 #include "s2/s2text_format.h"
 
 using absl::make_unique;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
+++ b/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
@@ -33,6 +33,7 @@
 #include "s2/s2text_format.h"
 
 using absl::make_unique;
+using std::string;
 using std::vector;
 
 using EdgeType = S2Builder::EdgeType;

--- a/src/s2/s2builderutil_lax_polygon_layer_test.cc
+++ b/src/s2/s2builderutil_lax_polygon_layer_test.cc
@@ -39,6 +39,7 @@ using s2textformat::MakePointOrDie;
 using s2textformat::MakePolylineOrDie;
 using std::map;
 using std::set;
+using std::string;
 using std::vector;
 
 using EdgeType = S2Builder::EdgeType;

--- a/src/s2/s2builderutil_s2point_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2point_vector_layer_test.cc
@@ -30,6 +30,7 @@ using absl::make_unique;
 using s2builderutil::IndexedS2PointVectorLayer;
 using s2builderutil::S2PointVectorLayer;
 using s2textformat::MakePointOrDie;
+using std::string;
 using std::vector;
 
 using EdgeType = S2Builder::EdgeType;

--- a/src/s2/s2builderutil_s2polygon_layer_test.cc
+++ b/src/s2/s2builderutil_s2polygon_layer_test.cc
@@ -37,6 +37,7 @@ using s2textformat::MakePolylineOrDie;
 using std::map;
 using std::set;
 using std::unique_ptr;
+using std::string;
 using std::vector;
 
 using EdgeType = S2Builder::EdgeType;

--- a/src/s2/s2builderutil_s2polyline_layer_test.cc
+++ b/src/s2/s2builderutil_s2polyline_layer_test.cc
@@ -30,6 +30,7 @@ using absl::make_unique;
 using s2builderutil::IndexedS2PolylineLayer;
 using s2builderutil::S2PolylineLayer;
 using s2textformat::MakePolylineOrDie;
+using std::string;
 using std::vector;
 
 using EdgeType = S2Builder::EdgeType;

--- a/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
@@ -32,6 +32,7 @@ using absl::make_unique;
 using s2builderutil::IndexedS2PolylineVectorLayer;
 using s2builderutil::S2PolylineVectorLayer;
 using s2textformat::MakePolylineOrDie;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2cell_id.cc
+++ b/src/s2/s2cell_id.cc
@@ -41,6 +41,7 @@ using S2::internal::kPosToOrientation;
 using std::fabs;
 using std::max;
 using std::min;
+using std::string;
 using std::vector;
 
 // The following lookup tables are used to convert efficiently between an

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -362,7 +362,7 @@ class S2CellId {
   // These methods guarantee that FromToken(ToToken(x)) == x even when
   // "x" is an invalid cell id.  All tokens are alphanumeric strings.
   // FromToken() returns S2CellId::None() for malformed inputs.
-  string ToToken() const;
+  std::string ToToken() const;
   static S2CellId FromToken(const char* token, size_t length);
   static S2CellId FromToken(const std::string& token);
 
@@ -381,7 +381,7 @@ class S2CellId {
   //
   // For example "4/" represents S2CellId::FromFace(4), and "3/02" represents
   // S2CellId::FromFace(3).child(0).child(2).
-  string ToString() const;
+  std::string ToString() const;
 
   // Converts a string in the format returned by ToString() to an S2CellId.
   // Returns S2CellId::None() if the string could not be parsed.

--- a/src/s2/s2cell_id_test.cc
+++ b/src/s2/s2cell_id_test.cc
@@ -40,6 +40,7 @@
 using S2::internal::kPosToOrientation;
 using std::fabs;
 using std::min;
+using std::string;
 using std::unordered_map;
 using std::vector;
 

--- a/src/s2/s2cell_index_test.cc
+++ b/src/s2/s2cell_index_test.cc
@@ -28,6 +28,7 @@
 
 using std::pair;
 using std::set;
+using std::string;
 using std::vector;
 
 using Label = S2CellIndex::Label;

--- a/src/s2/s2crossing_edge_query_test.cc
+++ b/src/s2/s2crossing_edge_query_test.cc
@@ -49,6 +49,7 @@ using s2textformat::MakePoint;
 using s2textformat::MakePolyline;
 using std::is_sorted;
 using std::pair;
+using std::string;
 using std::vector;
 
 namespace {

--- a/src/s2/s2edge_distances_test.cc
+++ b/src/s2/s2edge_distances_test.cc
@@ -28,6 +28,7 @@
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
 
+using std::string;
 using std::unique_ptr;
 
 // Checks that the error returned by S2::GetUpdateMinDistanceMaxError() for

--- a/src/s2/s2edge_tessellator_test.cc
+++ b/src/s2/s2edge_tessellator_test.cc
@@ -34,6 +34,7 @@ using std::endl;
 using std::fabs;
 using std::min;
 using std::max;
+using std::string;
 using std::vector;
 
 namespace {

--- a/src/s2/s2error.h
+++ b/src/s2/s2error.h
@@ -25,7 +25,7 @@
 #include <ostream>
 #include <string>
 
-#include "s2/base/port.h"
+#include "absl/base/attributes.h"
 
 // This class is intended to be copied by value as desired.  It uses
 // the default copy constructor and assignment operator.
@@ -121,14 +121,14 @@ class S2Error {
 
   bool ok() const { return code_ == OK; }
   Code code() const { return code_; }
-  string text() const { return text_; }
+  std::string text() const { return text_; }
 
   // Clear the error to contain the OK code and no error message.
   void Clear();
 
  private:
   Code code_;
-  string text_;
+  std::string text_;
 };
 
 

--- a/src/s2/s2latlng.cc
+++ b/src/s2/s2latlng.cc
@@ -25,6 +25,7 @@
 
 using std::max;
 using std::min;
+using std::string;
 
 S2LatLng S2LatLng::Normalized() const {
   // remainder(x, 2 * M_PI) reduces its argument to the range [-M_PI, M_PI]

--- a/src/s2/s2latlng_test.cc
+++ b/src/s2/s2latlng_test.cc
@@ -31,6 +31,7 @@
 
 using absl::StrCat;
 using std::fabs;
+using std::string;
 
 TEST(S2LatLng, TestBasic) {
   S2LatLng ll_rad = S2LatLng::FromRadians(M_PI_4, M_PI_2);

--- a/src/s2/s2loop_measures_test.cc
+++ b/src/s2/s2loop_measures_test.cc
@@ -31,6 +31,7 @@
 using s2textformat::ParsePointsOrDie;
 using std::fabs;
 using std::min;
+using std::string;
 using std::vector;
 
 namespace {

--- a/src/s2/s2loop_test.cc
+++ b/src/s2/s2loop_test.cc
@@ -60,6 +60,7 @@ using std::map;
 using std::max;
 using std::min;
 using std::set;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2polygon_test.cc
+++ b/src/s2/s2polygon_test.cc
@@ -74,6 +74,7 @@ using s2builderutil::S2PolygonLayer;
 using std::max;
 using std::min;
 using std::numeric_limits;
+using std::string;
 using std::swap;
 using std::unique_ptr;
 using std::vector;

--- a/src/s2/s2polyline_alignment.cc
+++ b/src/s2/s2polyline_alignment.cc
@@ -28,6 +28,8 @@
 #include "absl/memory/memory.h"
 #include "s2/util/math/mathutil.h"
 
+using std::string;
+
 namespace s2polyline_alignment {
 
 Window::Window(const std::vector<ColumnStride>& strides) {

--- a/src/s2/s2polyline_alignment_internal.h
+++ b/src/s2/s2polyline_alignment_internal.h
@@ -137,7 +137,7 @@ class Window {
   Window Dilate(const int radius) const;
 
   // Return a string representation of this window.
-  string DebugString() const;
+  std::string DebugString() const;
 
  private:
   int rows_;

--- a/src/s2/s2polyline_alignment_test.cc
+++ b/src/s2/s2polyline_alignment_test.cc
@@ -28,6 +28,8 @@
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
 
+using std::string;
+
 namespace s2polyline_alignment {
 
 // PRIVATE API TESTS

--- a/src/s2/s2polyline_test.cc
+++ b/src/s2/s2polyline_test.cc
@@ -39,6 +39,7 @@
 using absl::StrCat;
 using absl::make_unique;
 using std::fabs;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -39,6 +39,7 @@ S2_DEFINE_int32(consistency_iters, 5000,
 using std::min;
 using std::numeric_limits;
 using std::pow;
+using std::string;
 using std::vector;
 
 namespace s2pred {

--- a/src/s2/s2region_coverer_test.cc
+++ b/src/s2/s2region_coverer_test.cc
@@ -50,6 +50,7 @@ using absl::StrCat;
 using std::max;
 using std::min;
 using std::priority_queue;
+using std::string;
 using std::unordered_map;
 using std::vector;
 

--- a/src/s2/s2region_term_indexer.cc
+++ b/src/s2/s2region_term_indexer.cc
@@ -84,6 +84,7 @@
 #include "absl/strings/str_cat.h"
 
 using absl::string_view;
+using std::string;
 using std::vector;
 
 S2RegionTermIndexer::Options::Options() {

--- a/src/s2/s2region_term_indexer.h
+++ b/src/s2/s2region_term_indexer.h
@@ -215,14 +215,14 @@ class S2RegionTermIndexer {
     //
     // REQUIRES: "ch" is non-alphanumeric.
     // DEFAULT: '$'
-    const string& marker() const { return marker_; }
+    const std::string& marker() const { return marker_; }
     char marker_character() const { return marker_[0]; }
     void set_marker_character(char ch);
 
    private:
     bool points_only_ = false;
     bool optimize_for_space_ = false;
-    string marker_ = string(1, '$');
+    std::string marker_ = std::string(1, '$');
   };
 
   // Default constructor.  Options can be set using mutable_options().
@@ -250,26 +250,26 @@ class S2RegionTermIndexer {
   // multiple types of location information (e.g. store footprint, entrances,
   // parking lots, etc).  The prefix should be kept short since it is
   // prepended to every term.
-  std::vector<string> GetIndexTerms(const S2Region& region,
-                                    absl::string_view prefix);
+  std::vector<std::string> GetIndexTerms(const S2Region& region,
+                                         absl::string_view prefix);
 
   // Converts a given query region into a set of terms.  If you compute the
   // union of all the documents associated with these terms, the result will
   // include all documents whose index region intersects the query region.
   //
   // "prefix" should match the corresponding value used when indexing.
-  std::vector<string> GetQueryTerms(const S2Region& region,
-                                    absl::string_view prefix);
+  std::vector<std::string> GetQueryTerms(const S2Region& region,
+                                         absl::string_view prefix);
 
   // Convenience methods that accept an S2Point rather than S2Region.  (These
   // methods are also faster.)
   //
   // Note that you can index an S2LatLng by converting it to an S2Point first:
   //     auto terms = GetIndexTerms(S2Point(latlng), ...);
-  std::vector<string> GetIndexTerms(const S2Point& point,
-                                    absl::string_view prefix);
-  std::vector<string> GetQueryTerms(const S2Point& point,
-                                    absl::string_view prefix);
+  std::vector<std::string> GetIndexTerms(const S2Point& point,
+                                         absl::string_view prefix);
+  std::vector<std::string> GetQueryTerms(const S2Point& point,
+                                         absl::string_view prefix);
 
   // Low-level methods that accept an S2CellUnion covering of the region to be
   // indexed or queried.
@@ -281,16 +281,16 @@ class S2RegionTermIndexer {
   // you can either call the regular S2Region methods (since S2CellUnion is a
   // type of S2Region), or "canonicalize" the covering first by calling
   // S2RegionCoverer::CanonicalizeCovering() with the same options.
-  std::vector<string> GetIndexTermsForCanonicalCovering(
+  std::vector<std::string> GetIndexTermsForCanonicalCovering(
       const S2CellUnion& covering, absl::string_view prefix);
-  std::vector<string> GetQueryTermsForCanonicalCovering(
+  std::vector<std::string> GetQueryTermsForCanonicalCovering(
       const S2CellUnion& covering, absl::string_view prefix);
 
  private:
   enum TermType { ANCESTOR, COVERING };
 
-  string GetTerm(TermType term_type, const S2CellId& id,
-                 absl::string_view prefix) const;
+  std::string GetTerm(TermType term_type, const S2CellId& id,
+                      absl::string_view prefix) const;
 
   Options options_;
   S2RegionCoverer coverer_;

--- a/src/s2/s2region_term_indexer_test.cc
+++ b/src/s2/s2region_term_indexer_test.cc
@@ -34,6 +34,7 @@
 #include "s2/s2cell_union.h"
 #include "s2/s2testing.h"
 
+using std::string;
 using std::vector;
 
 S2_DEFINE_int32(iters, 400, "number of iterations for testing");

--- a/src/s2/s2region_test.cc
+++ b/src/s2/s2region_test.cc
@@ -37,6 +37,7 @@
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
 
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2shape_index_buffered_region_test.cc
+++ b/src/s2/s2shape_index_buffered_region_test.cc
@@ -34,6 +34,7 @@ using absl::make_unique;
 using s2textformat::MakeIndexOrDie;
 using s2textformat::MakePointOrDie;
 using std::cout;
+using std::string;
 
 TEST(S2ShapeIndexBufferedRegion, EmptyIndex) {
   // Test buffering an empty S2ShapeIndex.

--- a/src/s2/s2shape_index_region_test.cc
+++ b/src/s2/s2shape_index_region_test.cc
@@ -20,6 +20,7 @@
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2lax_loop_shape.h"
 
+using std::string;
 using std::vector;
 
 namespace {

--- a/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
+++ b/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
@@ -23,6 +23,7 @@
 #include "s2/s2lax_loop_shape.h"
 #include "s2/s2text_format.h"
 
+using std::string;
 using std::vector;
 
 namespace s2shapeutil {

--- a/src/s2/s2shapeutil_edge_iterator.cc
+++ b/src/s2/s2shapeutil_edge_iterator.cc
@@ -17,6 +17,8 @@
 
 #include "absl/strings/str_cat.h"
 
+using std::string;
+
 namespace s2shapeutil {
 
 EdgeIterator::EdgeIterator(const S2ShapeIndex* index)

--- a/src/s2/s2shapeutil_edge_iterator.h
+++ b/src/s2/s2shapeutil_edge_iterator.h
@@ -58,7 +58,7 @@ class EdgeIterator {
 
   bool operator!=(const EdgeIterator& other) const { return !(*this == other); }
 
-  string DebugString() const;
+  std::string DebugString() const;
 
  private:
   const S2ShapeIndex* index_;

--- a/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
+++ b/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
@@ -33,6 +33,7 @@
 #include "s2/s2text_format.h"
 
 using absl::make_unique;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2testing.h
+++ b/src/s2/s2testing.h
@@ -317,7 +317,7 @@ bool CheckResultSet(const std::vector<std::pair<Distance, Id>>& x,
                     int max_size, Distance max_distance,
                     typename Distance::Delta max_error,
                     typename Distance::Delta max_pruning_error,
-                    const string& label) {
+                    const std::string& label) {
   using Result = std::pair<Distance, Id>;
   // Results should be sorted by distance, but not necessarily then by Id.
   EXPECT_TRUE(std::is_sorted(x.begin(), x.end(),

--- a/src/s2/s2text_format.cc
+++ b/src/s2/s2text_format.cc
@@ -37,6 +37,7 @@
 using absl::make_unique;
 using absl::string_view;
 using std::pair;
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/s2text_format.h
+++ b/src/s2/s2text_format.h
@@ -263,26 +263,27 @@ std::unique_ptr<MutableS2ShapeIndex> MakeIndex(absl::string_view str);
 
 // Convert an S2Point, S2LatLng, S2LatLngRect, S2CellId, S2CellUnion, loop,
 // polyline, or polygon to the string format above.
-string ToString(const S2Point& point);
-string ToString(const S2LatLng& latlng);
-string ToString(const S2LatLngRect& rect);
-string ToString(const S2CellId& cell_id);
-string ToString(const S2CellUnion& cell_union);
-string ToString(const S2Loop& loop);
-string ToString(S2PointLoopSpan loop);
-string ToString(const S2Polyline& polyline);
-string ToString(const S2Polygon& polygon, const char* loop_separator = ";\n");
-string ToString(const std::vector<S2Point>& points);
-string ToString(const std::vector<S2LatLng>& points);
-string ToString(const S2LaxPolylineShape& polyline);
-string ToString(const S2LaxPolygonShape& polygon,
-                const char* loop_separator = ";\n");
+std::string ToString(const S2Point& point);
+std::string ToString(const S2LatLng& latlng);
+std::string ToString(const S2LatLngRect& rect);
+std::string ToString(const S2CellId& cell_id);
+std::string ToString(const S2CellUnion& cell_union);
+std::string ToString(const S2Loop& loop);
+std::string ToString(S2PointLoopSpan loop);
+std::string ToString(const S2Polyline& polyline);
+std::string ToString(const S2Polygon& polygon,
+                     const char* loop_separator = ";\n");
+std::string ToString(const std::vector<S2Point>& points);
+std::string ToString(const std::vector<S2LatLng>& points);
+std::string ToString(const S2LaxPolylineShape& polyline);
+std::string ToString(const S2LaxPolygonShape& polygon,
+                     const char* loop_separator = ";\n");
 
 // Convert the contents of an S2ShapeIndex to the format above.  The index may
 // contain S2Shapes of any type.  Shapes are reordered if necessary so that
 // all point geometry (shapes of dimension 0) are first, followed by all
 // polyline geometry, followed by all polygon geometry.
-string ToString(const S2ShapeIndex& index);
+std::string ToString(const S2ShapeIndex& index);
 
 }  // namespace s2textformat
 

--- a/src/s2/s2text_format_test.cc
+++ b/src/s2/s2text_format_test.cc
@@ -28,6 +28,7 @@
 #include "s2/s2polyline.h"
 #include "s2/s2testing.h"
 
+using std::string;
 using std::unique_ptr;
 using std::vector;
 

--- a/src/s2/util/coding/varint.cc
+++ b/src/s2/util/coding/varint.cc
@@ -276,13 +276,13 @@ const char* Varint::Skip64BackwardSlow(const char* p, const char* b) {
   return nullptr; // value is too long to be a varint64
 }
 
-void Varint::Append32Slow(string* s, uint32 value) {
+void Varint::Append32Slow(std::string* s, uint32 value) {
   const size_t start = s->size();
   s->resize(start + Varint::Length32(value));
   Varint::Encode32(&((*s)[start]), value);
 }
 
-void Varint::Append64Slow(string* s, uint64 value) {
+void Varint::Append64Slow(std::string* s, uint64 value) {
   const size_t start = s->size();
   s->resize(start + Varint::Length64(value));
   Varint::Encode64(&((*s)[start]), value);

--- a/src/s2/util/coding/varint.h
+++ b/src/s2/util/coding/varint.h
@@ -119,8 +119,8 @@ class Varint {
   static int Length64(uint64 v);
 
   // EFFECTS    Appends the varint representation of "value" to "*s".
-  static void Append32(string* s, uint32 value);
-  static void Append64(string* s, uint64 value);
+  static void Append32(std::string* s, uint32 value);
+  static void Append64(std::string* s, uint64 value);
 
   // EFFECTS    Encodes a pair of values to "*s".  The encoding
   //            is done by weaving together 4 bit groups of
@@ -129,7 +129,7 @@ class Varint {
   //            that if both a and b are small, both values can be
   //            encoded in a single byte.
   ABSL_DEPRECATED("Use TwoValuesVarint::Encode32.")
-  static void EncodeTwo32Values(string* s, uint32 a, uint32 b);
+  static void EncodeTwo32Values(std::string* s, uint32 a, uint32 b);
   ABSL_DEPRECATED("Use TwoValuesVarint::Decode32.")
   static const char* DecodeTwo32Values(const char* ptr, uint32* a, uint32* b);
   ABSL_DEPRECATED("Use TwoValuesVarint::Decode32WithLimit.")
@@ -167,8 +167,8 @@ class Varint {
   static const char* Skip32BackwardSlow(const char* ptr, const char* base);
   static const char* Skip64BackwardSlow(const char* ptr, const char* base);
 
-  static void Append32Slow(string* s, uint32 value);
-  static void Append64Slow(string* s, uint64 value);
+  static void Append32Slow(std::string* s, uint32 value);
+  static void Append64Slow(std::string* s, uint64 value);
 
 };
 
@@ -397,7 +397,7 @@ inline int Varint::Length64(uint64 v) {
   return static_cast<int>((log2value * 9 + 73) / 64);
 }
 
-inline void Varint::Append32(string* s, uint32 value) {
+inline void Varint::Append32(std::string* s, uint32 value) {
   // Inline the fast-path for single-character output, but fall back to the .cc
   // file for the full version. The size<capacity check is so the compiler can
   // optimize out the string resize code.
@@ -408,7 +408,7 @@ inline void Varint::Append32(string* s, uint32 value) {
   }
 }
 
-inline void Varint::Append64(string* s, uint64 value) {
+inline void Varint::Append64(std::string* s, uint64 value) {
   // Inline the fast-path for single-character output, but fall back to the .cc
   // file for the full version. The size<capacity check is so the compiler can
   // optimize out the string resize code.

--- a/src/s2/util/gtl/container_logging.h
+++ b/src/s2/util/gtl/container_logging.h
@@ -200,8 +200,8 @@ class RangeLogger {
 
   // operator<< above is generally recommended. However, some situations may
   // require a string, so a convenience str() method is provided as well.
-  string str() const {
-    string s;
+  std::string str() const {
+    std::string s;
     ::strings::OStringStream(&s) << *this;
     return s;
   }

--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -34,6 +34,7 @@
 
 using std::max;
 using std::min;
+using std::string;
 
 // Define storage for constants.
 const int ExactFloat::kMinExp;

--- a/src/s2/util/math/exactfloat/exactfloat.h
+++ b/src/s2/util/math/exactfloat/exactfloat.h
@@ -299,17 +299,17 @@ class ExactFloat {
   // Note that if two values have different precisions, they may have the same
   // ToString() value even though their values are slightly different.  If you
   // need to distinguish such values, use ToUniqueString() intead.
-  string ToString() const;
+  std::string ToString() const;
 
   // Return a string formatted according to printf("%Ng") where N is the given
   // maximum number of significant digits.
-  string ToStringWithMaxDigits(int max_digits) const;
+  std::string ToStringWithMaxDigits(int max_digits) const;
 
   // Return a human-readable string such that if two ExactFloats have different
   // values, then their string representations are always different.  This
   // method is useful for debugging.  The string has the form "value<prec>",
   // where "prec" is the actual precision of the ExactFloat (e.g., "0.215<50>").
-  string ToUniqueString() const;
+  std::string ToUniqueString() const;
 
   // Return an upper bound on the number of significant digits required to
   // distinguish any two floating-point numbers with the given precision when
@@ -563,7 +563,7 @@ class ExactFloat {
   // Convert the ExactFloat to a decimal value of the form 0.ddd * (10 ** x),
   // with at most "max_digits" significant digits (trailing zeros are removed).
   // Set (*digits) to the ASCII digits and return the decimal exponent "x".
-  int GetDecimalDigits(int max_digits, string* digits) const;
+  int GetDecimalDigits(int max_digits, std::string* digits) const;
 
   // Return a_sign * fabs(a) + b_sign * fabs(b).  Used to implement addition
   // and subtraction.


### PR DESCRIPTION
Prepares for removing `using std::string` from `base/port.h`.