### PR TITLE
BN_num_bits takes a uint64_t*, so pass it one.

### DIFF
--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -71,7 +71,7 @@ inline static void BN_ext_set_uint64(BIGNUM* bn, uint64 v) {
 // Return the absolute value of a BIGNUM as a 64-bit unsigned integer.
 // Requires that BIGNUM fits into 64 bits.
 inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
-  std::uint64_t u64;
+  uint64_t u64;
   if (!BN_get_u64(bn, &u64)) {
     S2_DCHECK(false) << "BN has " << BN_num_bits(bn) << " bits";
     return 0;

--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -71,7 +71,7 @@ inline static void BN_ext_set_uint64(BIGNUM* bn, uint64 v) {
 // Return the absolute value of a BIGNUM as a 64-bit unsigned integer.
 // Requires that BIGNUM fits into 64 bits.
 inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
-  uint64 u64;
+  std::uint64_t u64;
   if (!BN_get_u64(bn, &u64)) {
     S2_DCHECK(false) << "BN has " << BN_num_bits(bn) << " bits";
     return 0;


### PR DESCRIPTION
Somehow, on my system `uint64` from port.h and `uint64_t` are typedefs of two different 64-bit types, `unsigned long` and `unsigned long long`.

For the most part this difference would be invisible, however when passing by pointer the pointer must point to the correct type.

No functionality change.