### PR TITLE
Update to latest google3 version

### DIFF
--- a/doc/examples/point_index.cc
+++ b/doc/examples/point_index.cc
@@ -42,5 +42,5 @@ int main(int argc, char **argv) {
 
   std::printf("Found %" PRId64 " points in %d queries\n", num_found,
               absl::GetFlag(FLAGS_num_queries));
-  return  0;
+  return 0;
 }

--- a/doc/examples/term_index.cc
+++ b/doc/examples/term_index.cc
@@ -14,7 +14,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <set>
-#include <unordered_map>
 #include <vector>
 
 #include "s2/base/commandlineflags.h"
@@ -37,7 +36,7 @@ S2_DEFINE_double(query_radius_km, 100, "Query radius in kilometers");
 // (e.g. representing words or phrases).
 static const char kPrefix[] = "s2:";
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   // Create a set of "documents" to be indexed.  Each document consists of a
   // single point.  (You can easily substitute any S2Region type here, or even
   // index a mixture of region types using std::unique_ptr<S2Region>.  Other
@@ -100,5 +99,5 @@ int main(int argc, char **argv) {
   }
   std::printf("Found %" PRId64 " points in %d queries\n", num_found,
               absl::GetFlag(FLAGS_num_queries));
-  return  0;
+  return 0;
 }

--- a/src/s2/encoded_s2cell_id_vector.cc
+++ b/src/s2/encoded_s2cell_id_vector.cc
@@ -139,7 +139,9 @@ bool EncodedS2CellIdVector::Init(Decoder* decoder) {
   int shift_code = code_plus_len >> 3;
   if (shift_code == 31) {
     shift_code = 29 + decoder->get8();
+    if (shift_code > 56) return false;  // Valid range 0..56
   }
+
   // Decode the "base_len" most-significant bytes of "base".
   int base_len = code_plus_len & 7;
   if (!DecodeUintWithLength(base_len, decoder, &base_)) return false;

--- a/src/s2/encoded_s2cell_id_vector_test.cc
+++ b/src/s2/encoded_s2cell_id_vector_test.cc
@@ -18,8 +18,10 @@
 #include "s2/encoded_s2cell_id_vector.h"
 
 #include <vector>
+
 #include <gtest/gtest.h>
 #include "absl/memory/memory.h"
+#include "s2/s2cell_id.h"
 #include "s2/s2loop.h"
 #include "s2/s2pointutil.h"
 #include "s2/s2shape_index.h"
@@ -31,6 +33,7 @@ using s2textformat::MakeCellIdOrDie;
 using std::vector;
 
 namespace s2coding {
+namespace {
 
 // Encodes the given vector and returns the corresponding
 // EncodedS2CellIdVector (which points into the Encoder's data buffer).
@@ -139,6 +142,30 @@ TEST(EncodedS2CellIdVector, OneByteRangeWithBaseValue) {
       0x0100500000000000, 0x0100330000000000}, 9);
 }
 
+TEST(EncodedS2CellIdVector, MaxShiftRange) {
+  const std::vector<uint8> bytes = {
+      (31 << 3)  // 31 -> add 29 to bytes[1].
+          + 1,   // Number of encoded cell IDs.
+      27,        // 27+29 is the maximum supported shift.
+      1, 0       // Encoded cell ID. Not important.
+  };
+  Decoder decoder(bytes.data(), bytes.size());
+  EncodedS2CellIdVector cell_ids;
+  EXPECT_TRUE(cell_ids.Init(&decoder));
+}
+
+TEST(EncodedS2CellIdVector, ShiftOutOfRange) {
+  const std::vector<uint8> bytes = {
+      (31 << 3)  // 31 -> add 29 to bytes[1].
+          + 1,   // Number of encoded cell IDs.
+      28,        // 28+29 is greater than the maximum supported shift of 56.
+      1, 0       // Encoded cell ID. Not important.
+  };
+  Decoder decoder(bytes.data(), bytes.size());
+  EncodedS2CellIdVector cell_ids;
+  EXPECT_FALSE(cell_ids.Init(&decoder));
+}
+
 TEST(EncodedS2CellIdVector, SixFaceCells) {
   vector<S2CellId> ids;
   for (int face = 0; face < 6; ++face) {
@@ -229,4 +256,5 @@ TEST(EncodedS2CellIdVector, LowerBoundLimits) {
   EXPECT_EQ(2, cell_ids.lower_bound(S2CellId::Sentinel()));
 }
 
+}  // namespace
 }  // namespace s2coding

--- a/src/s2/encoded_string_vector.cc
+++ b/src/s2/encoded_string_vector.cc
@@ -46,7 +46,7 @@ void StringVectorEncoder::Encode(Span<const string> v, Encoder* encoder) {
 
 bool EncodedStringVector::Init(Decoder* decoder) {
   if (!offsets_.Init(decoder)) return false;
-  data_ = reinterpret_cast<const char*>(decoder->skip(0));
+  data_ = decoder->skip(0);
   if (offsets_.size() > 0) {
     uint64 length = offsets_[offsets_.size() - 1];
     if (decoder->avail() < length) return false;

--- a/src/s2/encoded_uint_vector.h
+++ b/src/s2/encoded_uint_vector.h
@@ -192,7 +192,7 @@ inline T GetUintWithLength(const char* ptr, int length) {
 template <class T>
 bool DecodeUintWithLength(int length, Decoder* decoder, T* result) {
   if (decoder->avail() < length) return false;
-  const char* ptr = reinterpret_cast<const char*>(decoder->skip(0));
+  const char* ptr = decoder->skip(0);
   *result = GetUintWithLength<T>(ptr, length);
   decoder->skip(length);
   return true;
@@ -231,7 +231,7 @@ bool EncodedUintVector<T>::Init(Decoder* decoder) {
   if (size_ > std::numeric_limits<size_t>::max() / sizeof(T)) return false;
   size_t bytes = size_ * len_;
   if (decoder->avail() < bytes) return false;
-  data_ = reinterpret_cast<const char*>(decoder->skip(0));
+  data_ = decoder->skip(0);
   decoder->skip(bytes);
   return true;
 }

--- a/src/s2/r1interval.h
+++ b/src/s2/r1interval.h
@@ -66,8 +66,9 @@ class R1Interval {
     }
   }
 
-  // Accessors methods.
+  // The low bound of the interval.
   double lo() const { return bounds_[0]; }
+  // The high bound of the interval.
   double hi() const { return bounds_[1]; }
 
   // Methods to modify one endpoint of an existing R1Interval.  Do not use
@@ -97,10 +98,12 @@ class R1Interval {
   // is negative.
   double GetLength() const { return hi() - lo(); }
 
+  // Returns true if the given point is in the closed interval [lo, hi].
   bool Contains(double p) const {
     return p >= lo() && p <= hi();
   }
 
+  // Returns true if the given point is in the open interval (lo, hi).
   bool InteriorContains(double p) const {
     return p > lo() && p < hi();
   }

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -82,9 +82,10 @@ class S2LatLng;
 // the default copy constructor and assignment operator.
 class S2CellId {
  public:
-  // The extra position bit (61 rather than 60) let us encode each cell as its
-  // Hilbert curve position at the cell center (which is halfway along the
-  // portion of the Hilbert curve that fills that cell).
+  // Although only 60 bits are needed to represent the index of a leaf cell, the
+  // extra position bit lets us encode each cell as its Hilbert curve position
+  // at the cell center, which is halfway along the portion of the Hilbert curve
+  // that fills that cell.
   static constexpr int kFaceBits = 3;
   static constexpr int kNumFaces = 6;
   static constexpr int kMaxLevel =
@@ -98,7 +99,7 @@ class S2CellId {
   explicit IFNDEF_SWIG(constexpr) S2CellId(uint64 id) : id_(id) {}
 
   // Construct a leaf cell containing the given point "p".  Usually there is
-  // is exactly one such cell, but for points along the edge of a cell, any
+  // exactly one such cell, but for points along the edge of a cell, any
   // adjacent cell may be (deterministically) chosen.  This is because
   // S2CellIds are considered to be closed sets.  The returned cell will
   // always contain the given point, i.e.
@@ -117,6 +118,7 @@ class S2CellId {
 
   // The default constructor returns an invalid cell id.
   IFNDEF_SWIG(constexpr) S2CellId() : id_(0) {}
+  // Returns an invalid cell id.
   static constexpr S2CellId None() { return S2CellId(); }
 
   // Returns an invalid cell id guaranteed to be larger than any

--- a/src/s2/s2centroids.cc
+++ b/src/s2/s2centroids.cc
@@ -57,8 +57,8 @@ S2Point TrueCentroid(const S2Point& a, const S2Point& b, const S2Point& c) {
   // The result is the true centroid of the triangle multiplied by the
   // triangle's area.
   //
-  // TODO(ericv): This code still isn't as numerically stable as it could be.
-  // The biggest potential improvement is to compute B-A and C-A more
+  // TODO(b/205027737): This code still isn't as numerically stable as it could
+  // be.  The biggest potential improvement is to compute B-A and C-A more
   // accurately so that (B-A)x(C-A) is always inside triangle ABC.
   S2Point x(a.x(), b.x() - a.x(), c.x() - a.x());
   S2Point y(a.y(), b.y() - a.y(), c.y() - a.y());

--- a/src/s2/s2closest_cell_query_base.h
+++ b/src/s2/s2closest_cell_query_base.h
@@ -25,6 +25,7 @@
 #include "s2/base/logging.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/inlined_vector.h"
+#include "absl/hash/hash.h"
 #include "s2/s1chord_angle.h"
 #include "s2/s2cap.h"
 #include "s2/s2cell_id.h"

--- a/src/s2/s2edge_crossings.h
+++ b/src/s2/s2edge_crossings.h
@@ -138,10 +138,10 @@ bool AngleContainsVertex(const S2Point& a, const S2Point& b, const S2Point& c);
 
 // Given two edges AB and CD where at least two vertices are identical
 // (i.e. CrossingSign(a,b,c,d) == 0), this function defines whether the
-// two edges "cross" in a such a way that point-in-polygon containment tests
-// can be implemented by counting the number of edge crossings.  The basic
-// rule is that a "crossing" occurs if AB is encountered after CD during a
-// CCW sweep around the shared vertex starting from a fixed reference point.
+// two edges "cross" in such a way that point-in-polygon containment tests can
+// be implemented by counting the number of edge crossings.  The basic rule is
+// that a "crossing" occurs if AB is encountered after CD during a CCW sweep
+// around the shared vertex starting from a fixed reference point.
 //
 // Note that according to this rule, if AB crosses CD then in general CD
 // does not cross AB.  However, this leads to the correct result when

--- a/src/s2/s2edge_distances.h
+++ b/src/s2/s2edge_distances.h
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "s2/base/logging.h"
+#include "absl/base/macros.h"
 #include "s2/s1angle.h"
 #include "s2/s1chord_angle.h"
 #include "s2/s2edge_crossings.h"
@@ -206,12 +207,12 @@ S2Point GetPointOnRay(const S2Point& origin, const S2Point& dir,
 constexpr S1Angle kGetPointOnRayPerpendicularError = S1Angle::Radians(
     3 * s2pred::DBL_ERR);
 
-ABSL_DEPRECATED("Use Interpolate(a, b, t) instead.")
+ABSL_DEPRECATED("Inline the implementation")
 inline S2Point Interpolate(double t, const S2Point& a, const S2Point& b) {
   return Interpolate(a, b, t);
 }
 
-ABSL_DEPRECATED("Use GetPointOnLine(a, b, ax) instead.")
+ABSL_DEPRECATED("Inline the implementation")
 inline S2Point InterpolateAtDistance(S1Angle ax, const S2Point& a,
                                      const S2Point& b) {
   return GetPointOnLine(a, b, ax);

--- a/src/s2/s2edge_vector_shape_test.cc
+++ b/src/s2/s2edge_vector_shape_test.cc
@@ -35,22 +35,23 @@ TEST(S2EdgeVectorShape, EdgeAccess) {
   S2EdgeVectorShape shape;
   S2Testing::rnd.Reset(absl::GetFlag(FLAGS_s2_random_seed));
   const int kNumEdges = 100;
+  std::vector<std::pair<S2Point, S2Point>> edges;
   for (int i = 0; i < kNumEdges; ++i) {
     S2Point a = S2Testing::RandomPoint();  // Control the evaluation order
-    shape.Add(a, S2Testing::RandomPoint());
+    edges.emplace_back(a, S2Testing::RandomPoint());
+    shape.Add(edges.back().first, edges.back().second);
   }
   EXPECT_EQ(kNumEdges, shape.num_edges());
   EXPECT_EQ(kNumEdges, shape.num_chains());
   EXPECT_EQ(1, shape.dimension());
   EXPECT_FALSE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
-  S2Testing::rnd.Reset(absl::GetFlag(FLAGS_s2_random_seed));
   for (int i = 0; i < kNumEdges; ++i) {
     EXPECT_EQ(i, shape.chain(i).start);
     EXPECT_EQ(1, shape.chain(i).length);
     auto edge = shape.edge(i);
-    EXPECT_EQ(S2Testing::RandomPoint(), edge.v0);
-    EXPECT_EQ(S2Testing::RandomPoint(), edge.v1);
+    EXPECT_EQ(edges.at(i).first, edge.v0);
+    EXPECT_EQ(edges.at(i).second, edge.v1);
   }
 }
 

--- a/src/s2/s2lax_polyline_shape.cc
+++ b/src/s2/s2lax_polyline_shape.cc
@@ -18,12 +18,26 @@
 #include "s2/s2lax_polyline_shape.h"
 
 #include <algorithm>
+#include <memory>
+#include <utility>
+
 #include "s2/base/logging.h"
+#include "absl/utility/utility.h"
 #include "s2/s2polyline.h"
 
 using absl::make_unique;
 using absl::MakeSpan;
 using absl::Span;
+
+S2LaxPolylineShape::S2LaxPolylineShape(S2LaxPolylineShape&& other) :
+  num_vertices_(absl::exchange(other.num_vertices_, 0)),
+  vertices_(std::move(other.vertices_)) {}
+
+S2LaxPolylineShape& S2LaxPolylineShape::operator=(S2LaxPolylineShape&& other) {
+  num_vertices_ = absl::exchange(other.num_vertices_, 0);
+  vertices_ = std::move(other.vertices_);
+  return *this;
+}
 
 S2LaxPolylineShape::S2LaxPolylineShape(Span<const S2Point> vertices) {
   Init(vertices);

--- a/src/s2/s2lax_polyline_shape.h
+++ b/src/s2/s2lax_polyline_shape.h
@@ -18,8 +18,10 @@
 #ifndef S2_S2LAX_POLYLINE_SHAPE_H_
 #define S2_S2LAX_POLYLINE_SHAPE_H_
 
+#include <algorithm>
 #include <memory>
 #include <vector>
+
 #include "absl/types/span.h"
 #include "s2/encoded_s2point_vector.h"
 #include "s2/s2polyline.h"
@@ -39,6 +41,12 @@ class S2LaxPolylineShape : public S2Shape {
 
   // Constructs an empty polyline.
   S2LaxPolylineShape() : num_vertices_(0) {}
+
+  // Move constructor.
+  S2LaxPolylineShape(S2LaxPolylineShape&&);
+
+  // Move-assignment operator.
+  S2LaxPolylineShape& operator=(S2LaxPolylineShape&&);
 
   // Constructs an S2LaxPolylineShape with the given vertices.
   explicit S2LaxPolylineShape(absl::Span<const S2Point> vertices);

--- a/src/s2/s2lax_polyline_shape_test.cc
+++ b/src/s2/s2lax_polyline_shape_test.cc
@@ -17,6 +17,8 @@
 
 #include "s2/s2lax_polyline_shape.h"
 
+#include <utility>
+
 #include <gtest/gtest.h>
 #include "s2/s2shapeutil_testing.h"
 #include "s2/s2text_format.h"
@@ -42,6 +44,23 @@ TEST(S2LaxPolylineShape, OneVertex) {
   EXPECT_EQ(1, shape.dimension());
   EXPECT_TRUE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
+}
+
+TEST(S2LaxPolylineShape, MoveConstructor) {
+  std::unique_ptr<S2LaxPolylineShape> original =
+      s2textformat::MakeLaxPolylineOrDie("1:1, 4:4");
+  S2LaxPolylineShape moved(std::move(*original));
+  ASSERT_EQ(0, original->num_vertices());
+  ASSERT_EQ(2, moved.num_vertices());
+}
+
+TEST(S2LaxPolylineShape, MoveAssignmentOperator) {
+  std::unique_ptr<S2LaxPolylineShape> original =
+      s2textformat::MakeLaxPolylineOrDie("1:1, 4:4");
+  S2LaxPolylineShape moved;
+  moved = std::move(*original);
+  ASSERT_EQ(0, original->num_vertices());
+  ASSERT_EQ(2, moved.num_vertices());
 }
 
 TEST(S2LaxPolylineShape, EdgeAccess) {

--- a/src/s2/s2loop.cc
+++ b/src/s2/s2loop.cc
@@ -640,7 +640,7 @@ bool S2Loop::DecodeInternal(Decoder* const decoder,
   bool is_misaligned = false;
 #else
   bool is_misaligned =
-      reinterpret_cast<intptr_t>(decoder->ptr()) % sizeof(double) != 0;
+      reinterpret_cast<intptr_t>(decoder->skip(0)) % sizeof(double) != 0;
 #endif
   if (within_scope && !is_misaligned) {
     vertices_ = const_cast<S2Point *>(reinterpret_cast<const S2Point*>(

--- a/src/s2/s2loop_measures.cc
+++ b/src/s2/s2loop_measures.cc
@@ -52,7 +52,7 @@ double GetArea(S2PointLoopSpan loop) {
 }
 
 double GetSignedArea(S2PointLoopSpan loop) {
-  // It is suprisingly difficult to compute the area of a loop robustly.  The
+  // It is surprisingly difficult to compute the area of a loop robustly.  The
   // main issues are (1) whether degenerate loops are considered to be CCW or
   // not (i.e., whether their area is close to 0 or 4*Pi), and (2) computing
   // the areas of small loops with good relative accuracy.
@@ -228,8 +228,8 @@ double GetCurvatureMaxError(S2PointLoopSpan loop) {
   //  -------------------
   //  11.25 * DBL_EPSILON
   //
-  // TODO(ericv): This error estimate is approximate.  There are two issues:
-  // (1) SignedArea needs some improvements to ensure that its error is
+  // TODO(b/203697029): This error estimate is approximate.  There are two
+  // issues: (1) SignedArea needs some improvements to ensure that its error is
   // actually never higher than GirardArea, and (2) although the number of
   // triangles in the sum is typically N-2, in theory it could be as high as
   // 2*N for pathological inputs.  But in other respects this error bound is

--- a/src/s2/s2metrics.h
+++ b/src/s2/s2metrics.h
@@ -50,24 +50,24 @@ template <int dim> class Metric {
   // particular metric.
   double GetValue(int level) const { return ldexp(deriv_, - dim * level); }
 
-  // Return the level at which the metric has approximately the given
-  // value.  For example, S2::kAvgEdge.GetClosestLevel(0.1) returns the
-  // level at which the average cell edge length is approximately 0.1.
-  // The return value is always a valid level.
+  // Return the level at which the metric has approximately the given value.
+  // For example, S2::kAvgEdge.GetClosestLevel(0.1) returns the level at which
+  // the average cell edge length is approximately 0.1. The return value is
+  // always a valid level.
   int GetClosestLevel(double value) const;
 
-  // Return the minimum level such that the metric is at most the given
-  // value, or S2CellId::kMaxLevel if there is no such level.  For example,
+  // Return the minimum level such that the metric is at most the given value,
+  // or S2CellId::kMaxLevel if there is no such level. For example,
   // S2::kMaxDiag.GetLevelForMaxValue(0.1) returns the minimum level such
   // that all cell diagonal lengths are 0.1 or smaller.  The return value
   // is always a valid level.
   int GetLevelForMaxValue(double value) const;
 
-  // Return the maximum level such that the metric is at least the given
-  // value, or zero if there is no such level.  For example,
-  // S2::kMinWidth.GetLevelForMinValue(0.1) returns the maximum level such
-  // that all cells have a minimum width of 0.1 or larger.  The return value
-  // is always a valid level.
+  // Return the maximum level such that the metric is at least the given value,
+  // or 0 if there is no such level.  For example,
+  // S2::kMinWidth.GetLevelForMinValue(0.1) returns the maximum level such that
+  // all cells have a minimum width of 0.1 or larger.  The return value is
+  // always a valid level.
   int GetLevelForMinValue(double value) const;
 
  private:
@@ -166,9 +166,9 @@ template <int dim>
 int S2::Metric<dim>::GetLevelForMaxValue(double value) const {
   if (value <= 0) return S2::kMaxCellLevel;
 
-  // This code is equivalent to computing a floating-point "level"
-  // value and rounding up.  ilogb() returns the exponent corresponding to a
-  // fraction in the range [1,2).
+  // This code is equivalent to computing a floating-point "level" value and
+  // rounding up.  ilogb() returns the exponent corresponding to a fraction in
+  // the range [1,2).
   int level = ilogb(value / deriv_);
   level = std::max(0, std::min(S2::kMaxCellLevel, -(level >> (dim - 1))));
   S2_DCHECK(level == S2::kMaxCellLevel || GetValue(level) <= value);
@@ -180,8 +180,8 @@ template <int dim>
 int S2::Metric<dim>::GetLevelForMinValue(double value) const {
   if (value <= 0) return S2::kMaxCellLevel;
 
-  // This code is equivalent to computing a floating-point "level"
-  // value and rounding down.
+  // This code is equivalent to computing a floating-point "level" value and
+  // rounding down.
   int level = ilogb(deriv_ / value);
   level = std::max(0, std::min(S2::kMaxCellLevel, level >> (dim - 1)));
   S2_DCHECK(level == 0 || GetValue(level) >= value);

--- a/src/s2/s2metrics_test.cc
+++ b/src/s2/s2metrics_test.cc
@@ -89,13 +89,24 @@ TEST(S2, Metrics) {
   EXPECT_LE(S2::kMaxArea.deriv(),
             S2::kMaxWidth.deriv() * S2::kMaxEdge.deriv() + 1e-15);
 
+  // The minimum level for which the minimum or maximum width of a cell is at
+  // most 0 is kMaxCellLevel, because no cell at any level has width less than
+  // or equal to zero.
+  EXPECT_EQ(S2::kMinWidth.GetLevelForMaxValue(0), S2::kMaxCellLevel);
+  EXPECT_EQ(S2::kMaxWidth.GetLevelForMaxValue(0), S2::kMaxCellLevel);
+
+  // The maximum level for which the minimum or maximum width of a cell is at
+  // least 4 is 0, because no cell at any level has width greater than 4.
+  EXPECT_EQ(S2::kMinWidth.GetLevelForMinValue(4), 0);
+  EXPECT_EQ(S2::kMaxWidth.GetLevelForMinValue(4), 0);
+
   // GetLevelForMaxValue() and friends have built-in assertions, we just need
   // to call these functions to test them.
   //
   // We don't actually check that the metrics are correct here, e.g. that
-  // GetMinWidth(10) is a lower bound on the width of cells at level 10.
-  // It is easier to check these properties in s2cell_test, since
-  // S2Cell has methods to compute the cell vertices, etc.
+  // GetLevelForMaxValue(1) is a lower bound on the level of cells with width 1.
+  // It is easier to check these properties in s2cell_test, since S2Cell has
+  // methods to compute the cell vertices, etc.
 
   for (int level = -2; level <= S2::kMaxCellLevel + 3; ++level) {
     double width = S2::kMinWidth.deriv() * pow(2, -level);

--- a/src/s2/s2point_vector_shape_test.cc
+++ b/src/s2/s2point_vector_shape_test.cc
@@ -41,19 +41,18 @@ TEST(S2PointVectorShape, ConstructionAndAccess) {
   for (int i = 0; i < kNumPoints; ++i) {
     points.push_back(S2Testing::RandomPoint());
   }
-  S2PointVectorShape shape(std::move(points));
+  S2PointVectorShape shape(points);
 
   EXPECT_EQ(kNumPoints, shape.num_edges());
   EXPECT_EQ(kNumPoints, shape.num_chains());
   EXPECT_EQ(0, shape.dimension());
   EXPECT_FALSE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
-  S2Testing::rnd.Reset(absl::GetFlag(FLAGS_s2_random_seed));
   for (int i = 0; i < kNumPoints; ++i) {
     EXPECT_EQ(i, shape.chain(i).start);
     EXPECT_EQ(1, shape.chain(i).length);
     auto edge = shape.edge(i);
-    S2Point pt = S2Testing::RandomPoint();
+    const S2Point& pt = points.at(i);
     EXPECT_EQ(pt, edge.v0);
     EXPECT_EQ(pt, edge.v1);
   }

--- a/src/s2/s2pointutil.h
+++ b/src/s2/s2pointutil.h
@@ -35,6 +35,7 @@ namespace S2 {
 // Returns a unique "origin" on the sphere for operations that need a fixed
 // reference point.  In particular, this is the "point at infinity" used for
 // point-in-polygon testing (by counting the number of edge crossings).
+// To be clear, this is NOT (0,0,0), the origin of the coordinate system.
 inline S2Point Origin();
 
 // Returns true if the given point is approximately unit length

--- a/src/s2/s2polygon.h
+++ b/src/s2/s2polygon.h
@@ -18,9 +18,12 @@
 #ifndef S2_S2POLYGON_H_
 #define S2_S2POLYGON_H_
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <map>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #include "absl/base/attributes.h"

--- a/src/s2/s2region_term_indexer_test.cc
+++ b/src/s2/s2region_term_indexer_test.cc
@@ -34,6 +34,7 @@
 #include "s2/s2cell.h"
 #include "s2/s2cell_id.h"
 #include "s2/s2cell_union.h"
+#include "s2/s2latlng.h"
 #include "s2/s2testing.h"
 
 using std::string;
@@ -167,6 +168,23 @@ TEST(S2RegionTermIndexer, IndexPointsQueryRegionsOptimizeSpace) {
   options.set_index_contains_points_only(true);
   // Use default parameter values.
   TestRandomCaps(options, QueryType::CAP);
+}
+
+TEST(S2RegionTermIndexer, MarkerCharacter) {
+  S2RegionTermIndexer::Options options;
+  options.set_min_level(20);
+  options.set_max_level(20);
+
+  S2RegionTermIndexer indexer(options);
+  S2Point point = S2LatLng::FromDegrees(10, 20).ToPoint();
+  EXPECT_EQ(indexer.options().marker_character(), '$');
+  EXPECT_EQ(indexer.GetQueryTerms(point, ""),
+            vector<string>({"11282087039", "$11282087039"}));
+
+  indexer.mutable_options()->set_marker_character(':');
+  EXPECT_EQ(indexer.options().marker_character(), ':');
+  EXPECT_EQ(indexer.GetQueryTerms(point, ""),
+            vector<string>({"11282087039", ":11282087039"}));
 }
 
 TEST(S2RegionTermIndexer, MaxLevelSetLoosely) {

--- a/src/s2/s2shape_index_region.h
+++ b/src/s2/s2shape_index_region.h
@@ -388,6 +388,7 @@ bool S2ShapeIndexRegion<IndexType>::VisitIntersectingShapes(
       return true;
     }
   }
+  S2_LOG(FATAL) << "Unhandled S2ShapeIndex::CellRelation";
 }
 
 template <class IndexType>

--- a/src/s2/s2text_format.cc
+++ b/src/s2/s2text_format.cc
@@ -202,11 +202,6 @@ bool MakePolyline(string_view str, unique_ptr<S2Polyline>* polyline,
   return true;
 }
 
-std::unique_ptr<S2Polyline> MakePolyline(string_view str,
-                                         S2Debug debug_override) {
-  return MakePolylineOrDie(str, debug_override);
-}
-
 unique_ptr<S2LaxPolylineShape> MakeLaxPolylineOrDie(string_view str) {
   unique_ptr<S2LaxPolylineShape> lax_polyline;
   S2_CHECK(MakeLaxPolyline(str, &lax_polyline)) << ": str == \"" << str << "\"";
@@ -219,10 +214,6 @@ bool MakeLaxPolyline(string_view str,
   if (!ParsePoints(str, &vertices)) return false;
   *lax_polyline = make_unique<S2LaxPolylineShape>(vertices);
   return true;
-}
-
-std::unique_ptr<S2LaxPolylineShape> MakeLaxPolyline(string_view str) {
-  return MakeLaxPolylineOrDie(str);
 }
 
 static bool InternalMakePolygon(string_view str,
@@ -256,11 +247,6 @@ bool MakePolygon(string_view str, unique_ptr<S2Polygon>* polygon,
   return InternalMakePolygon(str, debug_override, true, polygon);
 }
 
-std::unique_ptr<S2Polygon> MakePolygon(string_view str,
-                                       S2Debug debug_override) {
-  return MakePolygonOrDie(str, debug_override);
-}
-
 unique_ptr<S2Polygon> MakeVerbatimPolygonOrDie(string_view str) {
   unique_ptr<S2Polygon> polygon;
   S2_CHECK(MakeVerbatimPolygon(str, &polygon)) << ": str == \"" << str << "\"";
@@ -269,10 +255,6 @@ unique_ptr<S2Polygon> MakeVerbatimPolygonOrDie(string_view str) {
 
 bool MakeVerbatimPolygon(string_view str, unique_ptr<S2Polygon>* polygon) {
   return InternalMakePolygon(str, S2Debug::ALLOW, false, polygon);
-}
-
-std::unique_ptr<S2Polygon> MakeVerbatimPolygon(string_view str) {
-  return MakeVerbatimPolygonOrDie(str);
 }
 
 unique_ptr<S2LaxPolygonShape> MakeLaxPolygonOrDie(string_view str) {
@@ -296,10 +278,6 @@ bool MakeLaxPolygon(string_view str,
   }
   *lax_polygon = make_unique<S2LaxPolygonShape>(loops);
   return true;
-}
-
-std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygon(string_view str) {
-  return MakeLaxPolygonOrDie(str);
 }
 
 unique_ptr<MutableS2ShapeIndex> MakeIndexOrDie(string_view str) {
@@ -332,10 +310,6 @@ bool MakeIndex(string_view str, std::unique_ptr<MutableS2ShapeIndex>* index) {
     (*index)->Add(std::move(lax_polygon));
   }
   return true;
-}
-
-std::unique_ptr<MutableS2ShapeIndex> MakeIndex(string_view str) {
-  return MakeIndexOrDie(str);
 }
 
 static void AppendVertex(const S2LatLng& ll, string* out) {

--- a/src/s2/s2text_format.h
+++ b/src/s2/s2text_format.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "absl/base/attributes.h"
+#include "absl/base/macros.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 
@@ -35,7 +36,11 @@
 #include "s2/s2cell_union.h"
 #include "s2/s2debug.h"
 #include "s2/s2latlng_rect.h"
+#include "s2/s2lax_polygon_shape.h"  // TODO(user,b/207351837): Remove.
+#include "s2/s2lax_polyline_shape.h"  // TODO(user,b/207351837): Remove.
 #include "s2/s2point_span.h"
+#include "s2/s2polygon.h"   // TODO(user,b/207351837): Remove.
+#include "s2/s2polyline.h"  // TODO(user,b/207351837): Remove.
 
 class MutableS2ShapeIndex;
 class S2LaxPolygonShape;
@@ -56,7 +61,7 @@ S2Point MakePointOrDie(absl::string_view str);
 // is successful.
 ABSL_MUST_USE_RESULT bool MakePoint(absl::string_view str, S2Point* point);
 
-ABSL_DEPRECATED("Use MakePointOrDie.")
+ABSL_DEPRECATED("Inline the implementation")
 inline S2Point MakePoint(absl::string_view str) { return MakePointOrDie(str); }
 
 // Parses a string of one or more latitude-longitude coordinates in degrees,
@@ -72,7 +77,7 @@ std::vector<S2LatLng> ParseLatLngsOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool ParseLatLngs(absl::string_view str,
                                        std::vector<S2LatLng>* latlngs);
 
-ABSL_DEPRECATED("Use ParseLatLngsOrDie.")
+ABSL_DEPRECATED("Inline the implementation")
 inline std::vector<S2LatLng> ParseLatLngs(absl::string_view str) {
   return ParseLatLngsOrDie(str);
 }
@@ -86,7 +91,7 @@ std::vector<S2Point> ParsePointsOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool ParsePoints(absl::string_view str,
                                       std::vector<S2Point>* vertices);
 
-ABSL_DEPRECATED("Use ParsePointsOrDie.")
+ABSL_DEPRECATED("Inline the implementation")
 inline std::vector<S2Point> ParsePoints(absl::string_view str) {
   return ParsePointsOrDie(str);
 }
@@ -107,7 +112,7 @@ S2LatLngRect MakeLatLngRectOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeLatLngRect(absl::string_view str,
                                          S2LatLngRect* rect);
 
-ABSL_DEPRECATED("Use MakeLatLngRectOrDie.")
+ABSL_DEPRECATED("Inline the implementation")
 inline S2LatLngRect MakeLatLngRect(absl::string_view str) {
   return MakeLatLngRectOrDie(str);
 }
@@ -162,10 +167,11 @@ ABSL_MUST_USE_RESULT bool MakePolyline(absl::string_view str,
                                        std::unique_ptr<S2Polyline>* polyline,
                                        S2Debug debug_override = S2Debug::ALLOW);
 
-ABSL_DEPRECATED("Use MakePolylineOrDie.")
-std::unique_ptr<S2Polyline> MakePolyline(
-    absl::string_view str,
-    S2Debug debug_override = S2Debug::ALLOW);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<S2Polyline> MakePolyline(
+    absl::string_view str, S2Debug debug_override = S2Debug::ALLOW) {
+  return MakePolylineOrDie(str, debug_override);
+}
 
 // Like MakePolyline, but returns an S2LaxPolylineShape instead.
 std::unique_ptr<S2LaxPolylineShape> MakeLaxPolylineOrDie(absl::string_view str);
@@ -175,8 +181,11 @@ std::unique_ptr<S2LaxPolylineShape> MakeLaxPolylineOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeLaxPolyline(
     absl::string_view str, std::unique_ptr<S2LaxPolylineShape>* lax_polyline);
 
-ABSL_DEPRECATED("Use MakeLaxPolylineOrDie.")
-std::unique_ptr<S2LaxPolylineShape> MakeLaxPolyline(absl::string_view str);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<S2LaxPolylineShape> MakeLaxPolyline(
+    absl::string_view str) {
+  return MakeLaxPolylineOrDie(str);
+}
 
 // Given a sequence of loops separated by semicolons, returns a newly
 // allocated polygon.  Loops are automatically normalized by inverting them
@@ -201,9 +210,11 @@ ABSL_MUST_USE_RESULT bool MakePolygon(absl::string_view str,
                                       std::unique_ptr<S2Polygon>* polygon,
                                       S2Debug debug_override = S2Debug::ALLOW);
 
-ABSL_DEPRECATED("Use MakePolygonOrDie.")
-std::unique_ptr<S2Polygon> MakePolygon(absl::string_view str,
-                                       S2Debug debug_override = S2Debug::ALLOW);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<S2Polygon> MakePolygon(
+    absl::string_view str, S2Debug debug_override = S2Debug::ALLOW) {
+  return MakePolygonOrDie(str, debug_override);
+}
 
 // Like MakePolygon(), except that it does not normalize loops (i.e., it
 // gives you exactly what you asked for).
@@ -214,8 +225,10 @@ std::unique_ptr<S2Polygon> MakeVerbatimPolygonOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeVerbatimPolygon(
     absl::string_view str, std::unique_ptr<S2Polygon>* polygon);
 
-ABSL_DEPRECATED("Use MakeVerbatimPolygonOrDie.")
-std::unique_ptr<S2Polygon> MakeVerbatimPolygon(absl::string_view str);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<S2Polygon> MakeVerbatimPolygon(absl::string_view str) {
+  return MakeVerbatimPolygonOrDie(str);
+}
 
 // Parses a string in the same format as MakePolygon, except that loops must
 // be oriented so that the interior of the loop is always on the left, and
@@ -228,8 +241,11 @@ std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygonOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeLaxPolygon(
     absl::string_view str, std::unique_ptr<S2LaxPolygonShape>* lax_polygon);
 
-ABSL_DEPRECATED("Use MakeLaxPolygonOrDie.")
-std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygon(absl::string_view str);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygon(
+    absl::string_view str) {
+  return MakeLaxPolygonOrDie(str);
+}
 
 // Returns a MutableS2ShapeIndex containing the points, polylines, and loops
 // (in the form of a single polygon) described by the following format:
@@ -256,8 +272,10 @@ std::unique_ptr<MutableS2ShapeIndex> MakeIndexOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeIndex(
     absl::string_view str, std::unique_ptr<MutableS2ShapeIndex>* index);
 
-ABSL_DEPRECATED("Use MakeIndexOrDie.")
-std::unique_ptr<MutableS2ShapeIndex> MakeIndex(absl::string_view str);
+ABSL_DEPRECATED("Inline the implementation")
+inline std::unique_ptr<MutableS2ShapeIndex> MakeIndex(absl::string_view str) {
+  return MakeIndexOrDie(str);
+}
 
 // Convert an S2Point, S2LatLng, S2LatLngRect, S2CellId, S2CellUnion, loop,
 // polyline, or polygon to the string format above.

--- a/src/s2/util/bits/bits.h
+++ b/src/s2/util/bits/bits.h
@@ -77,8 +77,10 @@ class Bits {
     typedef typename UnsignedTypeBySize<sizeof(T)>::Type Type;
   };
 
+  ABSL_DEPRECATED("Inline the implementation")
   static int CountOnes(uint32 n) { return absl::popcount(n); }
 
+  ABSL_DEPRECATED("Inline the implementation")
   static inline int CountOnes64(uint64 n) { return absl::popcount(n); }
 
   // Count bits in uint128
@@ -116,7 +118,9 @@ class Bits {
                               int num_bytes, int cap);
 
   // Return floor(log2(n)) for positive integer n.  Returns -1 iff n == 0.
+  ABSL_DEPRECATED("Inline the implementation")
   static int Log2Floor(uint32 n);
+  ABSL_DEPRECATED("Inline the implementation")
   static int Log2Floor64(uint64 n);
   static int Log2Floor128(absl::uint128 n);
 
@@ -134,6 +138,7 @@ class Bits {
   // Returns true if and only if n is a power of two.
   template <typename IntType,
             absl::enable_if_t<std::is_unsigned<IntType>::value, int> = 0>
+  ABSL_DEPRECATED("Inline the implementation")
   static constexpr bool IsPowerOfTwo(IntType n) {
     return absl::has_single_bit(n);
   }


### PR DESCRIPTION
* EncodedS2CellIdVector: Detect invalid cell levels and return failure
* Use Decoder::skip(0) instead of deprecated ptr()
* Deprecate more functions
* Make S2LaxPolylineShape moveable
* Improve comments