### PR TITLE
Allow compiling with MSVC-compatible compilers, i.e. clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if (WITH_PYTHON)
     find_package(Python3 COMPONENTS Interpreter Development)
 endif()
 
-if (WIN32)
+if (MSVC)
     # Use unsigned characters
     add_definitions(-J)
     # Make sure cmath header defines things like M_PI


### PR DESCRIPTION
In order to be able to compile with [clang-cl](https://clang.llvm.org/docs/UsersManual.html#clang-cl), test for [MSVC](https://cmake.org/cmake/help/latest/variable/MSVC.html) rather than WIN32; the former is true for MSVC-compatible compilers.