### PR TITLE
Update to latest google3 version

### DIFF
--- a/doc/examples/term_index.cc
+++ b/doc/examples/term_index.cc
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "s2/base/commandlineflags.h"

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -647,7 +647,7 @@ class S2Point {
 %unignore S2Polygon::GetCentroid;
 %unignore S2Polygon::GetDistance;
 %unignore S2Polygon::GetLastDescendant(int) const;
-%unignore S2Polygon::GetOverlapFractions(const S2Polygon*, const S2Polygon*);
+%unignore S2Polygon::GetOverlapFractions(const S2Polygon&, const S2Polygon&);
 %unignore S2Polygon::GetRectBound;
 %unignore S2Polygon::Init;
 %unignore S2Polygon::InitNested;

--- a/src/s2/encoded_s2cell_id_vector.cc
+++ b/src/s2/encoded_s2cell_id_vector.cc
@@ -17,6 +17,8 @@
 
 #include "s2/encoded_s2cell_id_vector.h"
 
+#include <algorithm>
+
 #include "s2/util/bits/bits.h"
 
 using absl::Span;

--- a/src/s2/encoded_s2point_vector.cc
+++ b/src/s2/encoded_s2point_vector.cc
@@ -17,6 +17,8 @@
 
 #include "s2/encoded_s2point_vector.h"
 
+#include <algorithm>
+
 #include "absl/base/internal/unaligned_access.h"
 #include "s2/util/bits/bits.h"
 #include "s2/s2cell_id.h"

--- a/src/s2/encoded_s2point_vector.h
+++ b/src/s2/encoded_s2point_vector.h
@@ -19,6 +19,7 @@
 #define S2_ENCODED_S2POINT_VECTOR_H_
 
 #include <atomic>
+
 #include "absl/types/span.h"
 #include "s2/encoded_string_vector.h"
 #include "s2/encoded_uint_vector.h"

--- a/src/s2/encoded_s2shape_index_test.cc
+++ b/src/s2/encoded_s2shape_index_test.cc
@@ -17,10 +17,13 @@
 
 #include "s2/encoded_s2shape_index.h"
 
+#include <algorithm>
 #include <map>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/base/call_once.h"
 #include "absl/flags/flag.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
@@ -162,7 +165,7 @@ TEST(EncodedS2ShapeIndex, OverlappingPolylines) {
       vector<S2Point> vertices;
       int n = test_case.num_shape_edges;
       for (int j = 0; j <= n; ++j) {
-        vertices.push_back(S2::InterpolateAtDistance(j * edge_len, a, b));
+        vertices.push_back(S2::GetPointOnLine(a, b, j * edge_len));
       }
       index.Add(make_unique<S2LaxPolylineShape>(vertices));
     }

--- a/src/s2/encoded_string_vector.h
+++ b/src/s2/encoded_string_vector.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "s2/encoded_uint_vector.h"

--- a/src/s2/encoded_string_vector_test.cc
+++ b/src/s2/encoded_string_vector_test.cc
@@ -18,6 +18,7 @@
 #include "s2/encoded_string_vector.h"
 
 #include <vector>
+
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
 

--- a/src/s2/encoded_uint_vector_test.cc
+++ b/src/s2/encoded_uint_vector_test.cc
@@ -18,6 +18,7 @@
 #include "s2/encoded_uint_vector.h"
 
 #include <vector>
+
 #include <gtest/gtest.h>
 
 using std::vector;

--- a/src/s2/id_set_lexicon.cc
+++ b/src/s2/id_set_lexicon.cc
@@ -18,6 +18,7 @@
 #include "s2/id_set_lexicon.h"
 
 #include <algorithm>
+#include <utility>
 #include <vector>
 
 #include "s2/base/logging.h"

--- a/src/s2/mutable_s2shape_index.cc
+++ b/src/s2/mutable_s2shape_index.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <utility>
 
 #include "s2/base/casts.h"
 #include "s2/base/commandlineflags.h"

--- a/src/s2/mutable_s2shape_index_test.cc
+++ b/src/s2/mutable_s2shape_index_test.cc
@@ -17,10 +17,13 @@
 
 #include "s2/mutable_s2shape_index.h"
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <numeric>
 #include <thread>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -720,7 +723,7 @@ TEST_F(MutableS2ShapeIndexTest, LinearSpace) {
   }
   // Create the clusters of short edges.
   for (int k = 0; k < num_clusters; ++k) {
-    S2Point p = S2::Interpolate(k / (num_clusters - 1.0), a, b);
+    S2Point p = S2::Interpolate(a, b, k / (num_clusters - 1.0));
     vector<S2Point> points(edges_per_cluster, p);
     index_.Add(make_unique<S2PointVectorShape>(points));
   }

--- a/src/s2/r1interval.h
+++ b/src/s2/r1interval.h
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <iosfwd>
 #include <iostream>
+#include <ostream>
 
 #include "s2/base/logging.h"
 #include "s2/_fp_contract_off.h"

--- a/src/s2/r2rect.h
+++ b/src/s2/r2rect.h
@@ -19,6 +19,7 @@
 #define S2_R2RECT_H_
 
 #include <iosfwd>
+#include <ostream>
 
 #include "s2/base/logging.h"
 #include "s2/_fp_contract_off.h"

--- a/src/s2/s1angle.h
+++ b/src/s2/s1angle.h
@@ -165,9 +165,9 @@ class S1Angle {
   // Normalize this angle to the range (-180, 180] degrees.
   void Normalize();
 
-  // When S1Angle is used as a key in one of the btree container types
-  // (util/btree), indicate that linear rather than binary search should be
-  // used.  This is much faster when the comparison function is cheap.
+  // When S1Angle is used as a key in one of the absl::btree container types,
+  // indicate that linear rather than binary search should be used.  This is
+  // much faster when the comparison function is cheap.
   typedef std::true_type absl_btree_prefer_linear_node_search;
 
  private:

--- a/src/s2/s1chord_angle.cc
+++ b/src/s2/s1chord_angle.cc
@@ -17,6 +17,7 @@
 
 #include "s2/s1chord_angle.h"
 
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
 

--- a/src/s2/s1chord_angle.h
+++ b/src/s2/s1chord_angle.h
@@ -18,6 +18,7 @@
 #ifndef S2_S1CHORD_ANGLE_H_
 #define S2_S1CHORD_ANGLE_H_
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <ostream>
@@ -286,9 +287,9 @@ class S1ChordAngle {
   // Infinity() are both considered valid.
   bool is_valid() const;
 
-  // When S1ChordAngle is used as a key in one of the btree container types
-  // (util/btree), indicate that linear rather than binary search should be
-  // used.  This is much faster when the comparison function is cheap.
+  // When S1ChordAngle is used as a key in one of the absl::btree container
+  // types, indicate that linear rather than binary search should be used.
+  // This is much faster when the comparison function is cheap.
   typedef std::true_type absl_btree_prefer_linear_node_search;
 
  private:

--- a/src/s2/s1chord_angle_test.cc
+++ b/src/s2/s1chord_angle_test.cc
@@ -210,7 +210,7 @@ TEST(S1ChordAngle, GetS2PointConstructorMaxError) {
     if (rnd.OneIn(10)) {
       // Occasionally test a point pair that is nearly identical or antipodal.
       S1Angle r = S1Angle::Radians(1e-15 * rnd.RandDouble());
-      y = S2::InterpolateAtDistance(r, x, y);
+      y = S2::GetPointOnLine(x, y, r);
       if (rnd.OneIn(2)) y = -y;
     }
     S1ChordAngle dist = S1ChordAngle(x, y);

--- a/src/s2/s2boolean_operation_test.cc
+++ b/src/s2/s2boolean_operation_test.cc
@@ -348,8 +348,8 @@ TEST(S2BooleanOperation, PointSemiOpenPolygonVertex) {
   // not the other under PolygonModel::SEMI_OPEN.  (The same vertices are used
   // for all three PolygonModel options.)
   auto polygon = s2textformat::MakePolygonOrDie("0:0, 0:1, 1:0");
-  ASSERT_TRUE(polygon->Contains(s2textformat::MakePoint("0:1")));
-  ASSERT_FALSE(polygon->Contains(s2textformat::MakePoint("1:0")));
+  ASSERT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("0:1")));
+  ASSERT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("1:0")));
   auto a = "0:1 | 1:0 # #";
   auto b = "# # 0:0, 0:1, 1:0";
   ExpectResult(OpType::UNION, options, a, b,
@@ -519,14 +519,14 @@ TEST(S2BooleanOperation, TestSemiOpenPolygonVerticesContained) {
   // Verify whether certain vertices of the test polygon are contained under
   // the semi-open boundary model (for use in the tests below).
   auto polygon = s2textformat::MakePolygonOrDie(kVertexTestPolygonStr());
-  EXPECT_TRUE(polygon->Contains(s2textformat::MakePoint("0:1")));
-  EXPECT_TRUE(polygon->Contains(s2textformat::MakePoint("0:2")));
-  EXPECT_TRUE(polygon->Contains(s2textformat::MakePoint("0:3")));
-  EXPECT_TRUE(polygon->Contains(s2textformat::MakePoint("0:4")));
-  EXPECT_FALSE(polygon->Contains(s2textformat::MakePoint("5:1")));
-  EXPECT_FALSE(polygon->Contains(s2textformat::MakePoint("5:2")));
-  EXPECT_FALSE(polygon->Contains(s2textformat::MakePoint("5:3")));
-  EXPECT_FALSE(polygon->Contains(s2textformat::MakePoint("5:4")));
+  EXPECT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("0:1")));
+  EXPECT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("0:2")));
+  EXPECT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("0:3")));
+  EXPECT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("0:4")));
+  EXPECT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("5:1")));
+  EXPECT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("5:2")));
+  EXPECT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("5:3")));
+  EXPECT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("5:4")));
 }
 
 // Don't bother testing every PolylineModel with every PolygonModel for vertex
@@ -777,10 +777,10 @@ TEST(S2BooleanOperation, PolylineEdgeOpenPolygonEdgeOverlap) {
 
 TEST(S2BooleanOperation, PolylineEdgeSemiOpenPolygonEdgeOverlap) {
   auto polygon = s2textformat::MakePolygonOrDie("1:1, 1:3, 3:3, 3:1");
-  ASSERT_FALSE(polygon->Contains(s2textformat::MakePoint("1:1")));
-  ASSERT_TRUE(polygon->Contains(s2textformat::MakePoint("1:3")));
-  ASSERT_FALSE(polygon->Contains(s2textformat::MakePoint("3:3")));
-  ASSERT_FALSE(polygon->Contains(s2textformat::MakePoint("3:1")));
+  ASSERT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("1:1")));
+  ASSERT_TRUE(polygon->Contains(s2textformat::MakePointOrDie("1:3")));
+  ASSERT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("3:3")));
+  ASSERT_FALSE(polygon->Contains(s2textformat::MakePointOrDie("3:1")));
   S2BooleanOperation::Options options;
   options.set_polygon_model(PolygonModel::SEMI_OPEN);
   auto a = "# 1:1, 1:3, 3:3 | 3:3, 1:3 # ";
@@ -1695,7 +1695,7 @@ TEST(S2BooleanOperation, SelfIntersectingPolylines) {
 
 // Subtracts a degenerate loop along the 180 degree meridian from the given
 // input geometry, and compares the result to "expected_str".  The inputs should
-// be in the format expected by s2textformat::MakeIndex().
+// be in the format expected by s2textformat::MakeIndexOrDie().
 void TestMeridianSplitting(const char* input_str, const char* expected_str) {
   auto input = s2textformat::MakeIndexOrDie(input_str);
   MutableS2ShapeIndex meridian;
@@ -2053,7 +2053,7 @@ TEST(S2BooleanOperation, GetCrossedVertexIndexBug6) {
 }
 
 // Performs the given operation and compares the result to "expected_str".  All
-// arguments are in s2textformat::MakeLaxPolygon() format.
+// arguments are in s2textformat::MakeLaxPolygonOrDie() format.
 void ExpectPolygon(S2BooleanOperation::OpType op_type, const string& a_str,
                    const string& b_str, const string& expected_str) {
   auto a = s2textformat::MakeIndexOrDie(string("# # ") + a_str);
@@ -2072,7 +2072,8 @@ void ExpectPolygon(S2BooleanOperation::OpType op_type, const string& a_str,
 }
 
 TEST(S2BooleanOperation, FullAndEmptyResults) {
-  // The following constants are all in s2textformat::MakeLaxPolygon() format.
+  // The following constants are all in s2textformat::MakeLaxPolygonOrDie()
+  // format.
   string kEmpty = "";
   string kFull = "full";
 

--- a/src/s2/s2builderutil_closed_set_normalizer.h
+++ b/src/s2/s2builderutil_closed_set_normalizer.h
@@ -19,6 +19,7 @@
 #define S2_S2BUILDERUTIL_CLOSED_SET_NORMALIZER_H_
 
 #include <vector>
+
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder_graph.h"
 #include "s2/s2builderutil_find_polygon_degeneracies.h"

--- a/src/s2/s2builderutil_closed_set_normalizer_test.cc
+++ b/src/s2/s2builderutil_closed_set_normalizer_test.cc
@@ -18,6 +18,8 @@
 #include "s2/s2builderutil_closed_set_normalizer.h"
 
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -114,7 +116,7 @@ void NormalizeTest::Run(const string& input_str,
 void NormalizeTest::AddLayers(absl::string_view str,
                               const vector<GraphOptions>& graph_options,
                               vector<Graph>* graphs_out, S2Builder* builder) {
-  auto index = s2textformat::MakeIndex(str);
+  auto index = s2textformat::MakeIndexOrDie(str);
   for (int dim = 0; dim < 3; ++dim) {
     builder->StartLayer(make_unique<GraphAppendingLayer>(
         graph_options[dim], graphs_out, &graph_clones_));
@@ -246,11 +248,11 @@ TEST(ComputeUnion, MixedGeometry) {
   //  - Degenerate polygon holes are removed
   //  - Points coincident with polyline or polygon edges are removed
   //  - Polyline edges coincident with polygon edges are removed
-  auto a = s2textformat::MakeIndex(
+  auto a = s2textformat::MakeIndexOrDie(
       "0:0 | 10:10 | 20:20 # "
       "0:0, 0:10 | 0:0, 10:0 | 15:15, 16:16 # "
       "0:0, 0:10, 10:10, 10:0; 0:0, 1:1; 2:2; 10:10, 11:11; 12:12");
-  auto b = s2textformat::MakeIndex(
+  auto b = s2textformat::MakeIndexOrDie(
       "0:10 | 10:0 | 3:3 | 16:16 # "
       "10:10, 0:10 | 10:10, 10:0 | 5:5, 6:6 # "
       "19:19, 19:21, 21:21, 21:19");

--- a/src/s2/s2builderutil_find_polygon_degeneracies.cc
+++ b/src/s2/s2builderutil_find_polygon_degeneracies.cc
@@ -17,6 +17,7 @@
 
 #include "s2/s2builderutil_find_polygon_degeneracies.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <utility>
 #include <vector>

--- a/src/s2/s2builderutil_lax_polygon_layer_test.cc
+++ b/src/s2/s2builderutil_lax_polygon_layer_test.cc
@@ -351,7 +351,7 @@ TEST(IndexedLaxPolygonLayer, AddsShape) {
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedLaxPolygonLayer>(&index));
   const string& polygon_str = "0:0, 0:10, 10:0";
-  builder.AddPolygon(*s2textformat::MakePolygon(polygon_str));
+  builder.AddPolygon(*s2textformat::MakePolygonOrDie(polygon_str));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
   EXPECT_EQ(1, index.num_shape_ids());

--- a/src/s2/s2builderutil_s2point_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2point_vector_layer_test.cc
@@ -47,7 +47,7 @@ void VerifyS2PointVectorLayerResults(
     absl::string_view str_expected_points,
     const vector<vector<int32>>& expected_labels) {
   vector<S2Point> expected_points =
-      s2textformat::ParsePoints(str_expected_points);
+      s2textformat::ParsePointsOrDie(str_expected_points);
 
   ASSERT_EQ(expected_labels.size(), label_set_ids.size());
   for (int i = 0; i < output.size(); ++i) {

--- a/src/s2/s2builderutil_s2polygon_layer_test.cc
+++ b/src/s2/s2builderutil_s2polygon_layer_test.cc
@@ -62,7 +62,7 @@ void TestS2Polygon(const vector<const char*>& input_strs,
   ASSERT_TRUE(builder.Build(&error));
   // The input strings in tests may not be in normalized form, so we build an
   // S2Polygon and convert it back to a string.
-  unique_ptr<S2Polygon> expected(s2textformat::MakePolygon(expected_str));
+  unique_ptr<S2Polygon> expected(s2textformat::MakePolygonOrDie(expected_str));
   EXPECT_EQ(s2textformat::ToString(*expected),
             s2textformat::ToString(output));
 }
@@ -311,7 +311,7 @@ TEST(IndexedS2PolygonLayer, AddsShape) {
   MutableS2ShapeIndex index;
   builder.StartLayer(make_unique<IndexedS2PolygonLayer>(&index));
   const string& polygon_str = "0:0, 0:10, 10:0";
-  builder.AddPolygon(*s2textformat::MakePolygon(polygon_str));
+  builder.AddPolygon(*s2textformat::MakePolygonOrDie(polygon_str));
   S2Error error;
   ASSERT_TRUE(builder.Build(&error));
   EXPECT_EQ(1, index.num_shape_ids());

--- a/src/s2/s2cap.cc
+++ b/src/s2/s2cap.cc
@@ -127,10 +127,9 @@ S2Cap S2Cap::Union(const S2Cap& other) const {
     return *this;
   } else {
     S1Angle result_radius = 0.5 * (distance + this_radius + other_radius);
-    S2Point result_center = S2::GetPointOnLine(
-        center(),
-        other.center(),
-        0.5 * (distance - this_radius + other_radius));
+    S2Point result_center =
+        S2::GetPointOnLine(center(), other.center(),
+                           0.5 * (distance - this_radius + other_radius));
     return S2Cap(result_center, result_radius);
   }
 }

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -456,9 +456,9 @@ class S2CellId {
   // the leaf cell with the given (i,j)-coordinates.
   static R2Rect IJLevelToBoundUV(int ij[2], int level);
 
-  // When S2CellId is used as a key in one of the btree container types
-  // (util/btree), indicate that linear rather than binary search should be
-  // used.  This is much faster when the comparison function is cheap.
+  // When S2CellId is used as a key in one of the absl::btree container types,
+  // indicate that linear rather than binary search should be used.  This is
+  // much faster when the comparison function is cheap.
   typedef std::true_type absl_btree_prefer_linear_node_search;
 
  private:

--- a/src/s2/s2cell_index.h
+++ b/src/s2/s2cell_index.h
@@ -18,6 +18,8 @@
 #ifndef S2_S2CELL_INDEX_H_
 #define S2_S2CELL_INDEX_H_
 
+#include <algorithm>
+#include <functional>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"

--- a/src/s2/s2cell_index_test.cc
+++ b/src/s2/s2cell_index_test.cc
@@ -17,7 +17,9 @@
 
 #include "s2/s2cell_index.h"
 
+#include <algorithm>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -32,7 +34,6 @@
 
 using absl::flat_hash_set;
 using std::pair;
-using std::set;
 using std::string;
 using std::vector;
 

--- a/src/s2/s2cell_test.cc
+++ b/src/s2/s2cell_test.cc
@@ -440,7 +440,7 @@ TEST(S2Cell, RectBoundIsLargeEnough) {
     S2Point v1 = cell.GetVertex(i);
     S2Point v2 = S2Testing::SamplePoint(
         S2Cap(cell.GetVertex(i + 1), S1Angle::Radians(1e-15)));
-    S2Point p = S2::Interpolate(S2Testing::rnd.RandDouble(), v1, v2);
+    S2Point p = S2::Interpolate(v1, v2, S2Testing::rnd.RandDouble());
     if (S2Loop(cell).Contains(p)) {
       EXPECT_TRUE(cell.GetRectBound().Contains(S2LatLng(p)));
       ++iter;
@@ -458,7 +458,7 @@ TEST(S2Cell, ConsistentWithS2CellIdFromPoint) {
     S2Point v1 = cell.GetVertex(i);
     S2Point v2 = S2Testing::SamplePoint(
         S2Cap(cell.GetVertex(i + 1), S1Angle::Radians(1e-15)));
-    S2Point p = S2::Interpolate(S2Testing::rnd.RandDouble(), v1, v2);
+    S2Point p = S2::Interpolate(v1, v2, S2Testing::rnd.RandDouble());
     EXPECT_TRUE(S2Cell(S2CellId(p)).Contains(p));
   }
 }
@@ -639,8 +639,8 @@ TEST(S2Cell, GetMaxDistanceToEdge) {
   // Test an edge for which its antipode crosses the cell. Validates both the
   // standard and brute force implementations for this case.
   S2Cell cell = S2Cell::FromFacePosLevel(0, 0, 20);
-  S2Point a = -S2::Interpolate(2.0, cell.GetCenter(), cell.GetVertex(0));
-  S2Point b = -S2::Interpolate(2.0, cell.GetCenter(), cell.GetVertex(2));
+  S2Point a = -S2::Interpolate(cell.GetCenter(), cell.GetVertex(0), 2.0);
+  S2Point b = -S2::Interpolate(cell.GetCenter(), cell.GetVertex(2), 2.0);
 
   S1ChordAngle actual = cell.GetMaxDistance(a, b);
   S1ChordAngle expected = GetMaxDistanceToEdgeBruteForce(cell, a, b);

--- a/src/s2/s2cell_union.cc
+++ b/src/s2/s2cell_union.cc
@@ -18,6 +18,8 @@
 #include "s2/s2cell_union.h"
 
 #include <algorithm>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/flags/flag.h"

--- a/src/s2/s2cell_union.h
+++ b/src/s2/s2cell_union.h
@@ -18,6 +18,9 @@
 #ifndef S2_S2CELL_UNION_H_
 #define S2_S2CELL_UNION_H_
 
+#include <ostream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/base/macros.h"

--- a/src/s2/s2cell_union_test.cc
+++ b/src/s2/s2cell_union_test.cc
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/src/s2/s2closest_cell_query.cc
+++ b/src/s2/s2closest_cell_query.cc
@@ -18,6 +18,7 @@
 #include "s2/s2closest_cell_query.h"
 
 #include <memory>
+
 #include "absl/memory/memory.h"
 #include "s2/s1angle.h"
 #include "s2/s2cap.h"

--- a/src/s2/s2closest_cell_query.h
+++ b/src/s2/s2closest_cell_query.h
@@ -18,6 +18,7 @@
 #ifndef S2_S2CLOSEST_CELL_QUERY_H_
 #define S2_S2CLOSEST_CELL_QUERY_H_
 
+#include <utility>
 #include <vector>
 
 #include "s2/base/logging.h"

--- a/src/s2/s2closest_cell_query_base.h
+++ b/src/s2/s2closest_cell_query_base.h
@@ -55,7 +55,7 @@
 // The Distance template argument is used to represent distances.  Usually it
 // is a thin wrapper around S1ChordAngle, but another distance type may be
 // used as long as it implements the Distance concept described in
-// s2distance_targets.h.  For example this can be used to measure maximum
+// s2distance_target.h.  For example this can be used to measure maximum
 // distances, to get more accuracy, or to measure non-spheroidal distances.
 template <class Distance>
 class S2ClosestCellQueryBase {

--- a/src/s2/s2closest_cell_query_test.cc
+++ b/src/s2/s2closest_cell_query_test.cc
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <set>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -43,7 +44,6 @@ using absl::make_unique;
 using s2testing::FractalLoopShapeIndexFactory;
 using s2textformat::MakeCellIdOrDie;
 using s2textformat::MakePointOrDie;
-using std::min;
 using std::pair;
 using std::unique_ptr;
 using std::vector;

--- a/src/s2/s2closest_edge_query.cc
+++ b/src/s2/s2closest_edge_query.cc
@@ -18,6 +18,7 @@
 #include "s2/s2closest_edge_query.h"
 
 #include <memory>
+
 #include "absl/memory/memory.h"
 #include "s2/s1angle.h"
 #include "s2/s2cap.h"

--- a/src/s2/s2closest_edge_query_base.h
+++ b/src/s2/s2closest_edge_query_base.h
@@ -63,7 +63,7 @@
 // The Distance template argument is used to represent distances.  Usually it
 // is a thin wrapper around S1ChordAngle, but another distance type may be
 // used as long as it implements the Distance concept described in
-// s2distance_targets.h.  For example this can be used to measure maximum
+// s2distance_target.h.  For example this can be used to measure maximum
 // distances, to get more accuracy, or to measure non-spheroidal distances.
 template <class Distance>
 class S2ClosestEdgeQueryBase {
@@ -569,7 +569,7 @@ void S2ClosestEdgeQueryBase<Distance>::FindClosestEdgesInternal(
     absl::btree_set<int32> shape_ids;
     (void) target->VisitContainingShapes(
         *index_, [&shape_ids, &options](S2Shape* containing_shape,
-                                        const S2Point& target_point) {
+                                        const S2Point& /*target_point*/) {
           shape_ids.insert(containing_shape->id());
           return shape_ids.size() < options.max_results();
         });

--- a/src/s2/s2closest_edge_query_base_test.cc
+++ b/src/s2/s2closest_edge_query_base_test.cc
@@ -43,11 +43,11 @@ class FurthestPointTarget final : public S2MaxDistancePointTarget {
 };
 
 TEST(S2ClosestEdgeQueryBase, MaxDistance) {
-  auto index = s2textformat::MakeIndex("0:0 | 1:0 | 2:0 | 3:0 # #");
+  auto index = s2textformat::MakeIndexOrDie("0:0 | 1:0 | 2:0 | 3:0 # #");
   FurthestEdgeQuery query(index.get());
   FurthestEdgeQuery::Options options;
   options.set_max_results(1);
-  FurthestPointTarget target(s2textformat::MakePoint("4:0"));
+  FurthestPointTarget target(s2textformat::MakePointOrDie("4:0"));
   auto results = query.FindClosestEdges(&target, options);
   ASSERT_EQ(1, results.size());
   EXPECT_EQ(0, results[0].shape_id());

--- a/src/s2/s2closest_edge_query_test.cc
+++ b/src/s2/s2closest_edge_query_test.cc
@@ -46,7 +46,6 @@ using absl::make_unique;
 using s2shapeutil::ShapeEdgeId;
 using s2textformat::MakeIndexOrDie;
 using s2textformat::MakePointOrDie;
-using s2textformat::MakePolygonOrDie;
 using std::min;
 using std::pair;
 using std::string;
@@ -290,7 +289,7 @@ TEST(S2ClosestEdgeQuery, IsConservativeDistanceLessOrEqual) {
     S2Point x = S2Testing::RandomPoint();
     S2Point dir = S2Testing::RandomPoint();
     S1Angle r = S1Angle::Radians(M_PI * pow(1e-30, rnd.RandDouble()));
-    S2Point y = S2::InterpolateAtDistance(r, x, dir);
+    S2Point y = S2::GetPointOnLine(x, dir, r);
     S1ChordAngle limit(r);
     if (s2pred::CompareDistance(x, y, limit) <= 0) {
       MutableS2ShapeIndex index;

--- a/src/s2/s2closest_point_query_base.h
+++ b/src/s2/s2closest_point_query_base.h
@@ -139,7 +139,7 @@ class S2ClosestPointQueryBaseOptions {
 // The Distance template argument is used to represent distances.  Usually it
 // is a thin wrapper around S1ChordAngle, but another distance type may be
 // used as long as it implements the Distance concept described in
-// s2distance_targets.h.  For example this can be used to measure maximum
+// s2distance_target.h.  For example this can be used to measure maximum
 // distances, to get more accuracy, or to measure non-spheroidal distances.
 template <class Distance, class Data>
 class S2ClosestPointQueryBase {

--- a/src/s2/s2closest_point_query_base_test.cc
+++ b/src/s2/s2closest_point_query_base_test.cc
@@ -51,7 +51,7 @@ TEST(S2ClosestPointQueryBase, MaxDistance) {
   FurthestPointQuery<int> query(&index);
   FurthestPointQuery<int>::Options options;
   options.set_max_results(1);
-  FurthestPointTarget target(s2textformat::MakePoint("4:0"));
+  FurthestPointTarget target(s2textformat::MakePointOrDie("4:0"));
   auto results = query.FindClosestPoints(&target, options);
   ASSERT_EQ(1, results.size());
   EXPECT_EQ(points[0], results[0].point());

--- a/src/s2/s2contains_point_query.h
+++ b/src/s2/s2contains_point_query.h
@@ -18,6 +18,7 @@
 #ifndef S2_S2CONTAINS_POINT_QUERY_H_
 #define S2_S2CONTAINS_POINT_QUERY_H_
 
+#include <functional>
 #include <vector>
 
 #include "s2/s2edge_crosser.h"

--- a/src/s2/s2contains_point_query_test.cc
+++ b/src/s2/s2contains_point_query_test.cc
@@ -28,7 +28,6 @@
 #include "s2/s2text_format.h"
 
 using absl::make_unique;
-using s2shapeutil::ShapeEdge;
 using s2shapeutil::ShapeEdgeId;
 using s2textformat::MakeIndexOrDie;
 using s2textformat::MakePointOrDie;

--- a/src/s2/s2contains_vertex_query_test.cc
+++ b/src/s2/s2contains_vertex_query_test.cc
@@ -24,40 +24,40 @@
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
 
-using s2textformat::MakePoint;
+using s2textformat::MakePointOrDie;
 
 TEST(S2ContainsVertexQuery, Undetermined) {
-  S2ContainsVertexQuery q(MakePoint("1:2"));
-  q.AddEdge(MakePoint("3:4"), 1);
-  q.AddEdge(MakePoint("3:4"), -1);
+  S2ContainsVertexQuery q(MakePointOrDie("1:2"));
+  q.AddEdge(MakePointOrDie("3:4"), 1);
+  q.AddEdge(MakePointOrDie("3:4"), -1);
   EXPECT_EQ(0, q.ContainsSign());
 }
 
 TEST(S2ContainsVertexQuery, ContainedWithDuplicates) {
   // The S2::RefDir reference direction points approximately due west.
   // Containment is determined by the unmatched edge immediately clockwise.
-  S2ContainsVertexQuery q(MakePoint("0:0"));
-  q.AddEdge(MakePoint("3:-3"), -1);
-  q.AddEdge(MakePoint("1:-5"), 1);
-  q.AddEdge(MakePoint("2:-4"), 1);
-  q.AddEdge(MakePoint("1:-5"), -1);
+  S2ContainsVertexQuery q(MakePointOrDie("0:0"));
+  q.AddEdge(MakePointOrDie("3:-3"), -1);
+  q.AddEdge(MakePointOrDie("1:-5"), 1);
+  q.AddEdge(MakePointOrDie("2:-4"), 1);
+  q.AddEdge(MakePointOrDie("1:-5"), -1);
   EXPECT_EQ(1, q.ContainsSign());
 }
 
 TEST(S2ContainsVertexQuery, NotContainedWithDuplicates) {
   // The S2::RefDir reference direction points approximately due west.
   // Containment is determined by the unmatched edge immediately clockwise.
-  S2ContainsVertexQuery q(MakePoint("1:1"));
-  q.AddEdge(MakePoint("1:-5"), 1);
-  q.AddEdge(MakePoint("2:-4"), -1);
-  q.AddEdge(MakePoint("3:-3"), 1);
-  q.AddEdge(MakePoint("1:-5"), -1);
+  S2ContainsVertexQuery q(MakePointOrDie("1:1"));
+  q.AddEdge(MakePointOrDie("1:-5"), 1);
+  q.AddEdge(MakePointOrDie("2:-4"), -1);
+  q.AddEdge(MakePointOrDie("3:-3"), 1);
+  q.AddEdge(MakePointOrDie("1:-5"), -1);
   EXPECT_EQ(-1, q.ContainsSign());
 }
 
 // Tests that S2ContainsVertexQuery is compatible with S2::AngleContainsVertex.
 TEST(S2ContainsVertexQuery, CompatibleWithAngleContainsVertex) {
-  auto points = S2Testing::MakeRegularPoints(MakePoint("89:1"),
+  auto points = S2Testing::MakeRegularPoints(MakePointOrDie("89:1"),
                                              S1Angle::Degrees(5), 10);
   S2PointLoopSpan loop(points);
   for (int i = 0; i < loop.size(); ++i) {

--- a/src/s2/s2crossing_edge_query_test.cc
+++ b/src/s2/s2crossing_edge_query_test.cc
@@ -46,7 +46,7 @@ using absl::make_unique;
 using absl::StrCat;
 using s2shapeutil::ShapeEdge;
 using s2shapeutil::ShapeEdgeId;
-using s2textformat::MakePoint;
+using s2textformat::MakePointOrDie;
 using s2textformat::MakePolylineOrDie;
 using std::is_sorted;
 using std::pair;
@@ -60,7 +60,7 @@ using CrossingType = s2shapeutil::CrossingType;
 
 S2Point PerturbAtDistance(S1Angle distance, const S2Point& a0,
                           const S2Point& b0) {
-  S2Point x = S2::InterpolateAtDistance(distance, a0, b0);
+  S2Point x = S2::GetPointOnLine(a0, b0, distance);
   if (S2Testing::rnd.OneIn(2)) {
     for (int i = 0; i < 3; ++i) {
       x[i] = nextafter(x[i], S2Testing::rnd.OneIn(2) ? 1 : -1);
@@ -310,8 +310,8 @@ TEST(GetCrossings, PolylineCrossings) {
       MakePolylineOrDie("1:0, 3:1, 1:2, 3:3, 1:4, 3:5, 1:6")));
   index.Add(make_unique<S2Polyline::OwningShape>(
       MakePolylineOrDie("2:0, 4:1, 2:2, 4:3, 2:4, 4:5, 2:6")));
-  TestPolylineCrossings(index, MakePoint("1:0"), MakePoint("1:4"));
-  TestPolylineCrossings(index, MakePoint("5:5"), MakePoint("6:6"));
+  TestPolylineCrossings(index, MakePointOrDie("1:0"), MakePointOrDie("1:4"));
+  TestPolylineCrossings(index, MakePointOrDie("5:5"), MakePointOrDie("6:6"));
 }
 
 TEST(GetCrossings, ShapeIdsAreCorrect) {
@@ -320,11 +320,11 @@ TEST(GetCrossings, ShapeIdsAreCorrect) {
   MutableS2ShapeIndex index;
   index.Add(make_unique<S2Polyline::OwningShape>(
       make_unique<S2Polyline>(S2Testing::MakeRegularPoints(
-          MakePoint("0:0"), S1Angle::Degrees(5), 100))));
+          MakePointOrDie("0:0"), S1Angle::Degrees(5), 100))));
   index.Add(make_unique<S2Polyline::OwningShape>(
       make_unique<S2Polyline>(S2Testing::MakeRegularPoints(
-          MakePoint("0:20"), S1Angle::Degrees(5), 100))));
-  TestPolylineCrossings(index, MakePoint("1:-10"), MakePoint("1:30"));
+          MakePointOrDie("0:20"), S1Angle::Degrees(5), 100))));
+  TestPolylineCrossings(index, MakePointOrDie("1:-10"), MakePointOrDie("1:30"));
 }
 
 // Verifies that when VisitCells() is called with a specified root cell and a

--- a/src/s2/s2earth.h
+++ b/src/s2/s2earth.h
@@ -48,7 +48,7 @@ class S2Earth {
 
   // Like the above, but where distances are expressed in kilometers:
   static constexpr S1Angle KmToAngle(double km);
-  static inline S1ChordAngle KmToChordAngle(double meters);
+  static inline S1ChordAngle KmToChordAngle(double km);
   static constexpr double KmToRadians(double km);
   static constexpr double ToKm(const S1Angle& angle);
   static inline double ToKm(const S1ChordAngle& cangle);

--- a/src/s2/s2edge_crosser_test.cc
+++ b/src/s2/s2edge_crosser_test.cc
@@ -241,8 +241,8 @@ TEST(S2, CollinearEdgesThatDontTouch) {
   for (int iter = 0; iter < kIters; ++iter) {
     S2Point a = S2Testing::RandomPoint();
     S2Point d = S2Testing::RandomPoint();
-    S2Point b = S2::Interpolate(0.05, a, d);
-    S2Point c = S2::Interpolate(0.95, a, d);
+    S2Point b = S2::Interpolate(a, d, 0.05);
+    S2Point c = S2::Interpolate(a, d, 0.95);
     EXPECT_GT(0, S2::CrossingSign(a, b, c, d));
     EXPECT_GT(0, S2::CrossingSign(a, b, c, d));
     S2EdgeCrosser crosser(&a, &b, &c);

--- a/src/s2/s2edge_crossings_test.cc
+++ b/src/s2/s2edge_crossings_test.cc
@@ -305,7 +305,7 @@ TEST(S2, RobustCrossProdError) {
       S1Angle r = S1Angle::Radians(M_PI_2 * pow(2, -53 * rnd.RandDouble()));
       // Occasionally perturb the point by a tiny distance.
       if (rnd.OneIn(3)) r *= pow(2, -1022 * rnd.RandDouble());
-      b = PerturbLength(S2::InterpolateAtDistance(r, a, dir));
+      b = PerturbLength(S2::GetPointOnLine(a, dir, r));
       if (rnd.OneIn(2)) b = -b;
     } while (a == b);
     auto prec = TestRobustCrossProdError(a, b);

--- a/src/s2/s2edge_distances.h
+++ b/src/s2/s2edge_distances.h
@@ -212,13 +212,6 @@ inline S2Point Interpolate(double t, const S2Point& a, const S2Point& b) {
   return Interpolate(a, b, t);
 }
 
-ABSL_DEPRECATED("Inline the implementation")
-inline S2Point InterpolateAtDistance(S1Angle ax, const S2Point& a,
-                                     const S2Point& b) {
-  return GetPointOnLine(a, b, ax);
-}
-
-
 /////////////////////////////////////////////////////////////////////////////
 ///////////////            (edge, edge) functions             ///////////////
 

--- a/src/s2/s2edge_tessellator_test.cc
+++ b/src/s2/s2edge_tessellator_test.cc
@@ -18,6 +18,7 @@
 #include "s2/s2edge_tessellator.h"
 
 #include <iostream>
+
 #include <gtest/gtest.h>
 
 #include "absl/strings/str_cat.h"
@@ -86,7 +87,7 @@ S1Angle GetMaxDistance(const S2::Projection& proj,
       S2::UpdateMinDistance(p, x, y, &dist);
     } else {
       S2_DCHECK(dist_type == DistType::PARAMETRIC);
-      dist = S1ChordAngle(p, S2::Interpolate(f, x, y));
+      dist = S1ChordAngle(p, S2::Interpolate(x, y, f));
     }
     if (dist > max_dist) max_dist = dist;
   }
@@ -384,8 +385,9 @@ void TestEdgeError(const S2::Projection& proj, double t) {
     if (max_dist_p <= S2EdgeTessellator::kMinTolerance()) continue;
 
     // Compute the estimated error bound.
-    S1Angle d1(S2::Interpolate(t, a, b), proj.Unproject((1-t) * pa + t * pb));
-    S1Angle d2(S2::Interpolate(1-t, a, b), proj.Unproject(t * pa + (1-t) * pb));
+    S1Angle d1(S2::Interpolate(a, b, t), proj.Unproject((1 - t) * pa + t * pb));
+    S1Angle d2(S2::Interpolate(a, b, 1 - t),
+               proj.Unproject(t * pa + (1 - t) * pb));
     S1Angle dist = kScaleFactor * max(S1Angle::Radians(1e-300), max(d1, d2));
 
     // Compute the ratio of the true geometric/parametric errors to the

--- a/src/s2/s2edge_vector_shape.h
+++ b/src/s2/s2edge_vector_shape.h
@@ -20,6 +20,7 @@
 
 #include <utility>
 #include <vector>
+
 #include "s2/s2shape.h"
 
 // S2EdgeVectorShape is an S2Shape representing an arbitrary set of edges.  It

--- a/src/s2/s2latlng_rect_bounder_test.cc
+++ b/src/s2/s2latlng_rect_bounder_test.cc
@@ -131,12 +131,12 @@ S2Point PerturbATowardsB(const S2Point& a, const S2Point& b) {
   }
   if (choice < 0.5) {
     // Return a point such that the distance squared to A will underflow.
-    return S2::InterpolateAtDistance(S1Angle::Radians(1e-300), a, b);
+    return S2::GetPointOnLine(a, b, S1Angle::Radians(1e-300));
   }
   // Otherwise return a point whose distance from A is near DBL_EPSILON such
   // that the log of the pdf is uniformly distributed.
   double distance = DBL_EPSILON * 1e-5 * pow(1e6, rnd->RandDouble());
-  return S2::InterpolateAtDistance(S1Angle::Radians(distance), a, b);
+  return S2::GetPointOnLine(a, b, S1Angle::Radians(distance));
 }
 
 S2Point RandomPole() {

--- a/src/s2/s2lax_loop_shape.cc
+++ b/src/s2/s2lax_loop_shape.cc
@@ -17,9 +17,13 @@
 
 #include "s2/s2lax_loop_shape.h"
 
+#include <memory>
+
+#include "absl/memory/memory.h"
 #include "s2/s2loop.h"
 #include "s2/s2shapeutil_get_reference_point.h"
 
+using absl::make_unique;
 using absl::Span;
 using ReferencePoint = S2Shape::ReferencePoint;
 
@@ -33,7 +37,7 @@ S2LaxLoopShape::S2LaxLoopShape(const S2Loop& loop) {
 
 void S2LaxLoopShape::Init(Span<const S2Point> vertices) {
   num_vertices_ = vertices.size();
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   std::copy(vertices.begin(), vertices.end(), vertices_.get());
 }
 
@@ -44,7 +48,7 @@ void S2LaxLoopShape::Init(const S2Loop& loop) {
     vertices_ = nullptr;
   } else {
     num_vertices_ = loop.num_vertices();
-    vertices_.reset(new S2Point[num_vertices_]);
+    vertices_ = make_unique<S2Point[]>(num_vertices_);
     std::copy(&loop.vertex(0), &loop.vertex(0) + num_vertices_,
               vertices_.get());
   }

--- a/src/s2/s2lax_loop_shape_test.cc
+++ b/src/s2/s2lax_loop_shape_test.cc
@@ -41,7 +41,8 @@ TEST(S2LaxLoopShape, EmptyLoop) {
 
 TEST(S2LaxLoopShape, NonEmptyLoop) {
   // Test vector<S2Point> constructor.
-  vector<S2Point> vertices = s2textformat::ParsePoints("0:0, 0:1, 1:1, 1:0");
+  vector<S2Point> vertices =
+      s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1, 1:0");
   S2LaxLoopShape shape(vertices);
   EXPECT_EQ(vertices.size(), shape.num_vertices());
   EXPECT_EQ(vertices.size(), shape.num_edges());
@@ -61,7 +62,8 @@ TEST(S2LaxLoopShape, NonEmptyLoop) {
 }
 
 TEST(S2LaxClosedPolylineShape, NoInterior) {
-  vector<S2Point> vertices = s2textformat::ParsePoints("0:0, 0:1, 1:1, 1:0");
+  vector<S2Point> vertices =
+      s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1, 1:0");
   S2LaxClosedPolylineShape shape(vertices);
   EXPECT_EQ(1, shape.dimension());
   EXPECT_FALSE(shape.is_empty());
@@ -82,7 +84,7 @@ TEST(S2VertexIdLaxLoopShape, EmptyLoop) {
 
 TEST(S2VertexIdLaxLoopShape, InvertedLoop) {
   vector<S2Point> vertex_array =
-      s2textformat::ParsePoints("0:0, 0:1, 1:1, 1:0");
+      s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1, 1:0");
   vector<int32> vertex_ids { 0, 3, 2, 1 };  // Inverted.
   S2VertexIdLaxLoopShape shape(vertex_ids, &vertex_array[0]);
   EXPECT_EQ(4, shape.num_edges());

--- a/src/s2/s2lax_polygon_shape_test.cc
+++ b/src/s2/s2lax_polygon_shape_test.cc
@@ -117,7 +117,7 @@ TEST(S2LaxPolygonShape, SingleVertexPolygon) {
   // S2Polygon doesn't support single-vertex loops, so we need to construct
   // the S2LaxPolygonShape directly.
   vector<vector<S2Point>> loops;
-  loops.push_back(s2textformat::ParsePoints("0:0"));
+  loops.push_back(s2textformat::ParsePointsOrDie("0:0"));
   S2LaxPolygonShape shape(loops);
   EXPECT_EQ(1, shape.num_loops());
   EXPECT_EQ(1, shape.num_vertices());
@@ -138,7 +138,8 @@ TEST(S2LaxPolygonShape, SingleVertexPolygon) {
 
 TEST(S2LaxPolygonShape, SingleLoopPolygon) {
   // Test S2Polygon constructor.
-  vector<S2Point> vertices = s2textformat::ParsePoints("0:0, 0:1, 1:1, 1:0");
+  vector<S2Point> vertices =
+      s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1, 1:0");
   S2LaxPolygonShape shape(S2Polygon(make_unique<S2Loop>(vertices)));
   EXPECT_EQ(1, shape.num_loops());
   EXPECT_EQ(vertices.size(), shape.num_vertices());
@@ -166,8 +167,8 @@ TEST(S2LaxPolygonShape, MultiLoopPolygon) {
   // Test vector<vector<S2Point>> constructor.  Make sure that the loops are
   // oriented so that the interior of the polygon is always on the left.
   vector<S2LaxPolygonShape::Loop> loops = {
-    s2textformat::ParsePoints("0:0, 0:3, 3:3"),  // CCW
-    s2textformat::ParsePoints("1:1, 2:2, 1:2")   // CW
+      s2textformat::ParsePointsOrDie("0:0, 0:3, 3:3"),  // CCW
+      s2textformat::ParsePointsOrDie("1:1, 2:2, 1:2")   // CW
   };
   S2LaxPolygonShape shape(loops);
 
@@ -263,10 +264,9 @@ TEST(S2LaxPolygonShape, ManyLoopPolygon) {
 
 TEST(S2LaxPolygonShape, DegenerateLoops) {
   vector<S2LaxPolygonShape::Loop> loops = {
-    s2textformat::ParsePoints("1:1, 1:2, 2:2, 1:2, 1:3, 1:2, 1:1"),
-    s2textformat::ParsePoints("0:0, 0:3, 0:6, 0:9, 0:6, 0:3, 0:0"),
-    s2textformat::ParsePoints("5:5, 6:6")
-  };
+      s2textformat::ParsePointsOrDie("1:1, 1:2, 2:2, 1:2, 1:3, 1:2, 1:1"),
+      s2textformat::ParsePointsOrDie("0:0, 0:3, 0:6, 0:9, 0:6, 0:3, 0:0"),
+      s2textformat::ParsePointsOrDie("5:5, 6:6")};
   S2LaxPolygonShape shape(loops);
   EXPECT_FALSE(shape.GetReferencePoint().contained);
   TestEncodedS2LaxPolygonShape(shape);
@@ -274,9 +274,8 @@ TEST(S2LaxPolygonShape, DegenerateLoops) {
 
 TEST(S2LaxPolygonShape, InvertedLoops) {
   vector<S2LaxPolygonShape::Loop> loops = {
-    s2textformat::ParsePoints("1:2, 1:1, 2:2"),
-    s2textformat::ParsePoints("3:4, 3:3, 4:4")
-  };
+      s2textformat::ParsePointsOrDie("1:2, 1:1, 2:2"),
+      s2textformat::ParsePointsOrDie("3:4, 3:3, 4:4")};
   S2LaxPolygonShape shape(loops);
   EXPECT_TRUE(s2shapeutil::ContainsBruteForce(shape, S2::Origin()));
   TestEncodedS2LaxPolygonShape(shape);

--- a/src/s2/s2lax_polyline_shape.cc
+++ b/src/s2/s2lax_polyline_shape.cc
@@ -51,7 +51,7 @@ void S2LaxPolylineShape::Init(Span<const S2Point> vertices) {
   num_vertices_ = vertices.size();
   S2_LOG_IF(WARNING, num_vertices_ == 1)
       << "s2shapeutil::S2LaxPolylineShape with one vertex has no edges";
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   std::copy(vertices.begin(), vertices.end(), vertices_.get());
 }
 
@@ -59,7 +59,7 @@ void S2LaxPolylineShape::Init(const S2Polyline& polyline) {
   num_vertices_ = polyline.num_vertices();
   S2_LOG_IF(WARNING, num_vertices_ == 1)
       << "s2shapeutil::S2LaxPolylineShape with one vertex has no edges";
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   std::copy(&polyline.vertex(0), &polyline.vertex(0) + num_vertices_,
             vertices_.get());
 }

--- a/src/s2/s2lax_polyline_shape_test.cc
+++ b/src/s2/s2lax_polyline_shape_test.cc
@@ -64,7 +64,7 @@ TEST(S2LaxPolylineShape, MoveAssignmentOperator) {
 }
 
 TEST(S2LaxPolylineShape, EdgeAccess) {
-  vector<S2Point> vertices = s2textformat::ParsePoints("0:0, 0:1, 1:1");
+  vector<S2Point> vertices = s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1");
   S2LaxPolylineShape shape(vertices);
   EXPECT_EQ(2, shape.num_edges());
   EXPECT_EQ(1, shape.num_chains());
@@ -82,7 +82,7 @@ TEST(S2LaxPolylineShape, EdgeAccess) {
 }
 
 TEST(EncodedS2LaxPolylineShape, RoundtripEncoding) {
-  vector<S2Point> vertices = s2textformat::ParsePoints("0:0, 0:1, 1:1");
+  vector<S2Point> vertices = s2textformat::ParsePointsOrDie("0:0, 0:1, 1:1");
   S2LaxPolylineShape shape(vertices);
 
   Encoder encoder;

--- a/src/s2/s2loop.h
+++ b/src/s2/s2loop.h
@@ -300,21 +300,21 @@ class S2Loop final : public S2Region {
 
   // Returns true if the region contained by this loop is a superset of the
   // region contained by the given other loop.
-  bool Contains(const S2Loop* b) const;
+  bool Contains(const S2Loop& b) const;
 
   // Returns true if the region contained by this loop intersects the region
   // contained by the given other loop.
-  bool Intersects(const S2Loop* b) const;
+  bool Intersects(const S2Loop& b) const;
 
   // Returns true if two loops have the same vertices in the same linear order
   // (i.e., cyclic rotations are not allowed).
-  bool Equals(const S2Loop* b) const;
+  bool Equals(const S2Loop& b) const;
 
   // Returns true if two loops have the same boundary.  This is true if and
   // only if the loops have the same vertices in the same cyclic order (i.e.,
   // the vertices may be cyclically rotated).  The empty and full loops are
   // considered to have different boundaries.
-  bool BoundaryEquals(const S2Loop* b) const;
+  bool BoundaryEquals(const S2Loop& b) const;
 
   // Returns true if two loops have the same boundary except for vertex
   // perturbations.  More precisely, the vertices in the two loops must be in
@@ -333,6 +333,17 @@ class S2Loop final : public S2Region {
   // within "max_error" of each other.
   bool BoundaryNear(const S2Loop& b,
                     S1Angle max_error = S1Angle::Radians(1e-15)) const;
+
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Contains(const S2Loop* b) const { return Contains(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Intersects(const S2Loop* b) const { return Intersects(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Equals(const S2Loop* b) const { return Equals(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool BoundaryEquals(const S2Loop* b) const { return BoundaryEquals(*b); }
+#endif
 
   // This method computes the oriented surface integral of some quantity f(x)
   // over the loop interior, given a function f_tri(A,B,C) that returns the
@@ -428,7 +439,7 @@ class S2Loop final : public S2Region {
   // The loops must meet all the S2Polygon requirements; for example this
   // implies that their boundaries may not cross or have any shared edges
   // (although they may have shared vertices).
-  bool ContainsNested(const S2Loop* b) const;
+  bool ContainsNested(const S2Loop& b) const;
 
   // Returns +1 if A contains the boundary of B, -1 if A excludes the boundary
   // of B, and 0 if the boundaries of A and B cross.  Shared edges are handled
@@ -445,7 +456,7 @@ class S2Loop final : public S2Region {
   //
   // REQUIRES: neither loop is empty.
   // REQUIRES: if b->is_full(), then !b->is_hole().
-  int CompareBoundary(const S2Loop* b) const;
+  int CompareBoundary(const S2Loop& b) const;
 
   // Given two loops whose boundaries do not cross (see CompareBoundary),
   // return true if A contains the boundary of B.  If "reverse_b" is true, the
@@ -455,7 +466,18 @@ class S2Loop final : public S2Region {
   //
   // REQUIRES: neither loop is empty.
   // REQUIRES: if b->is_full(), then reverse_b == false.
-  bool ContainsNonCrossingBoundary(const S2Loop* b, bool reverse_b) const;
+  bool ContainsNonCrossingBoundary(const S2Loop& b, bool reverse_b) const;
+
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool ContainsNested(const S2Loop* b) const { return ContainsNested(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  int CompareBoundary(const S2Loop* b) const { return CompareBoundary(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool ContainsNonCrossingBoundary(const S2Loop* b, bool reverse_b) const {
+    return ContainsNonCrossingBoundary(*b, reverse_b);
+  }
+#endif
 
   // Wrapper class for indexing a loop (see S2ShapeIndex).  Once this object
   // is inserted into an S2ShapeIndex it is owned by that index, and will be

--- a/src/s2/s2loop_measures.cc
+++ b/src/s2/s2loop_measures.cc
@@ -20,6 +20,7 @@
 #include <cfloat>
 #include <cmath>
 #include <vector>
+
 #include "s2/base/logging.h"
 #include "absl/container/inlined_vector.h"
 #include "s2/s1angle.h"

--- a/src/s2/s2loop_test.cc
+++ b/src/s2/s2loop_test.cc
@@ -222,10 +222,10 @@ class S2LoopTestBase : public testing::Test {
       loop_i_(AddLoop("10:34, 0:34, -10:34, -10:36, 0:36, 10:36")) {
     // Like loop_a, but the vertices are at leaf cell centers.
     vector<S2Point> snapped_loop_a_vertices = {
-        S2CellId(s2textformat::MakePoint("0:178")).ToPoint(),
-        S2CellId(s2textformat::MakePoint("-1:180")).ToPoint(),
-        S2CellId(s2textformat::MakePoint("0:-179")).ToPoint(),
-        S2CellId(s2textformat::MakePoint("1:-180")).ToPoint()};
+        S2CellId(s2textformat::MakePointOrDie("0:178")).ToPoint(),
+        S2CellId(s2textformat::MakePointOrDie("-1:180")).ToPoint(),
+        S2CellId(s2textformat::MakePointOrDie("0:-179")).ToPoint(),
+        S2CellId(s2textformat::MakePointOrDie("1:-180")).ToPoint()};
     snapped_loop_a_ = AddLoop(make_unique<S2Loop>(snapped_loop_a_vertices));
   }
 
@@ -450,7 +450,7 @@ TEST_F(S2LoopTestBase, GetCurvature) {
 // Checks that if a loop is normalized, it doesn't contain a
 // point outside of it, and vice versa.
 static void CheckNormalizeAndContains(const S2Loop& loop) {
-  S2Point p = s2textformat::MakePoint("40:40");
+  S2Point p = s2textformat::MakePointOrDie("40:40");
 
   unique_ptr<S2Loop> flip(loop.Clone());
   flip->Invert();
@@ -918,8 +918,8 @@ TEST(S2Loop, BoundsForLoopContainment) {
     // below B (i.e., ABC is CCW).
     S2Point b = (S2Testing::RandomPoint() + S2Point(0, 0, 1)).Normalize();
     S2Point v = b.CrossProd(S2Point(0, 0, 1)).Normalize();
-    S2Point a = S2::Interpolate(rnd->RandDouble(), -v, b);
-    S2Point c = S2::Interpolate(rnd->RandDouble(), b, v);
+    S2Point a = S2::Interpolate(-v, b, rnd->RandDouble());
+    S2Point c = S2::Interpolate(b, v, rnd->RandDouble());
     if (s2pred::Sign(a, b, c) < 0) {
       --iter; continue;
     }

--- a/src/s2/s2max_distance_targets.cc
+++ b/src/s2/s2max_distance_targets.cc
@@ -16,6 +16,7 @@
 #include "s2/s2max_distance_targets.h"
 
 #include <memory>
+
 #include "absl/memory/memory.h"
 #include "s2/s1angle.h"
 #include "s2/s2cap.h"

--- a/src/s2/s2min_distance_targets.cc
+++ b/src/s2/s2min_distance_targets.cc
@@ -18,6 +18,7 @@
 #include "s2/s2min_distance_targets.h"
 
 #include <memory>
+
 #include "absl/memory/memory.h"
 #include "s2/s1angle.h"
 #include "s2/s2cap.h"

--- a/src/s2/s2point_vector_shape.h
+++ b/src/s2/s2point_vector_shape.h
@@ -19,11 +19,12 @@
 #define S2_S2POINT_VECTOR_SHAPE_H_
 
 #include <vector>
+
 #include "s2/encoded_s2point_vector.h"
 #include "s2/s2shape.h"
 
 // S2PointVectorShape is an S2Shape representing a set of S2Points. Each point
-// is reprsented as a degenerate edge with the same starting and ending
+// is represented as a degenerate edge with the same starting and ending
 // vertices.
 //
 // This class is useful for adding a collection of points to an S2ShapeIndex.
@@ -64,8 +65,12 @@ class S2PointVectorShape : public S2Shape {
     return true;
   }
 
-  // S2Shape interface:
+  // S2Shape interface.
+
+  // Returns the number of points.
   int num_edges() const final { return num_points(); }
+
+  // Returns a point represented as a degenerate edge.
   Edge edge(int e) const final { return Edge(points_[e], points_[e]); }
   int dimension() const final { return 0; }
   ReferencePoint GetReferencePoint() const final {

--- a/src/s2/s2pointutil_test.cc
+++ b/src/s2/s2pointutil_test.cc
@@ -79,8 +79,7 @@ TEST(S2, Rotate) {
     double distance = M_PI * pow(1e-15, S2Testing::rnd.RandDouble());
     // Sometimes choose points near the far side of the axis.
     if (S2Testing::rnd.OneIn(5)) distance = M_PI - distance;
-    S2Point p = S2::InterpolateAtDistance(S1Angle::Radians(distance),
-                                                  axis, target);
+    S2Point p = S2::GetPointOnLine(axis, target, S1Angle::Radians(distance));
     // Choose the rotation angle.
     double angle = 2 * M_PI * pow(1e-15, S2Testing::rnd.RandDouble());
     if (S2Testing::rnd.OneIn(3)) angle = -angle;

--- a/src/s2/s2polygon.cc
+++ b/src/s2/s2polygon.cc
@@ -131,18 +131,18 @@ S2Debug S2Polygon::s2debug_override() const {
   return s2debug_override_;
 }
 
-void S2Polygon::Copy(const S2Polygon* src) {
+void S2Polygon::Copy(const S2Polygon& src) {
   ClearLoops();
-  for (int i = 0; i < src->num_loops(); ++i) {
-    loops_.emplace_back(src->loop(i)->Clone());
+  for (int i = 0; i < src.num_loops(); ++i) {
+    loops_.emplace_back(src.loop(i)->Clone());
   }
-  s2debug_override_ = src->s2debug_override_;
+  s2debug_override_ = src.s2debug_override_;
   // Don't copy error_inconsistent_loop_orientations_, since this is not a
   // property of the polygon but only of the way the polygon was constructed.
-  num_vertices_ = src->num_vertices();
+  num_vertices_ = src.num_vertices();
   unindexed_contains_calls_.store(0, std::memory_order_relaxed);
-  bound_ = src->bound_;
-  subregion_bound_ = src->subregion_bound_;
+  bound_ = src.bound_;
+  subregion_bound_ = src.subregion_bound_;
   InitIndex();  // TODO(ericv): Copy the index efficiently.
 }
 
@@ -527,12 +527,12 @@ S1Angle S2Polygon::GetDistanceToBoundary(const S2Point& x) const {
 }
 
 /*static*/ pair<double, double> S2Polygon::GetOverlapFractions(
-    const S2Polygon* a, const S2Polygon* b) {
+    const S2Polygon& a, const S2Polygon& b) {
   S2Polygon intersection;
   intersection.InitToIntersection(a, b);
   double intersection_area = intersection.GetArea();
-  double a_area = a->GetArea();
-  double b_area = b->GetArea();
+  double a_area = a.GetArea();
+  double b_area = b.GetArea();
   return std::make_pair(
       intersection_area >= a_area ? 1 : intersection_area / a_area,
       intersection_area >= b_area ? 1 : intersection_area / b_area);
@@ -552,11 +552,11 @@ S2Point S2Polygon::ProjectToBoundary(const S2Point& x) const {
   return q.Project(x, edge);
 }
 
-bool S2Polygon::Contains(const S2Polygon* b) const {
+bool S2Polygon::Contains(const S2Polygon& b) const {
   // It's worth checking bounding rectangles, since they are precomputed.
   // Note that the first bound has been expanded to account for possible
   // numerical errors in the second bound.
-  if (!subregion_bound_.Contains(b->bound_)) {
+  if (!subregion_bound_.Contains(b.bound_)) {
     // It is possible that A contains B even though Bound(A) does not contain
     // Bound(B).  This can only happen when polygon B has at least two outer
     // shells and the union of the two bounds spans all longitudes.  For
@@ -567,7 +567,7 @@ bool S2Polygon::Contains(const S2Polygon* b) const {
     //
     // For convenience we just check whether B has at least two loops rather
     // than two outer shells.
-    if (b->num_loops() == 1 || !bound_.lng().Union(b->bound_.lng()).is_full()) {
+    if (b.num_loops() == 1 || !bound_.lng().Union(b.bound_.lng()).is_full()) {
       return false;
     }
   }
@@ -575,21 +575,21 @@ bool S2Polygon::Contains(const S2Polygon* b) const {
   // The following case is not handled by S2BooleanOperation because it only
   // determines whether the boundary of the result is empty (which does not
   // distinguish between the full and empty polygons).
-  if (is_empty() && b->is_full()) return false;
+  if (is_empty() && b.is_full()) return false;
 
-  return S2BooleanOperation::Contains(index_, b->index_);
+  return S2BooleanOperation::Contains(index_, b.index_);
 }
 
-bool S2Polygon::Intersects(const S2Polygon* b) const {
+bool S2Polygon::Intersects(const S2Polygon& b) const {
   // It's worth checking bounding rectangles, since they are precomputed.
-  if (!bound_.Intersects(b->bound_)) return false;
+  if (!bound_.Intersects(b.bound_)) return false;
 
   // The following case is not handled by S2BooleanOperation because it only
   // determines whether the boundary of the result is empty (which does not
   // distinguish between the full and empty polygons).
-  if (is_full() && b->is_full()) return true;
+  if (is_full() && b.is_full()) return true;
 
-  return S2BooleanOperation::Intersects(index_, b->index_);
+  return S2BooleanOperation::Intersects(index_, b.index_);
 }
 
 S2Cap S2Polygon::GetCapBound() const {
@@ -604,26 +604,27 @@ bool S2Polygon::Contains(const S2Cell& target) const {
   return MakeS2ShapeIndexRegion(&index_).Contains(target);
 }
 
-bool S2Polygon::ApproxContains(const S2Polygon* b, S1Angle tolerance) const {
+bool S2Polygon::ApproxContains(const S2Polygon& b, S1Angle tolerance) const {
   S2Polygon difference;
-  difference.InitToApproxDifference(b, this, tolerance);
+  difference.InitToDifference(b, *this, IdentitySnapFunction(tolerance));
   return difference.is_empty();
 }
 
-bool S2Polygon::ApproxDisjoint(const S2Polygon* b, S1Angle tolerance) const {
+bool S2Polygon::ApproxDisjoint(const S2Polygon& b, S1Angle tolerance) const {
   S2Polygon intersection;
-  intersection.InitToApproxIntersection(b, this, tolerance);
+  intersection.InitToIntersection(b, *this, IdentitySnapFunction(tolerance));
   return intersection.is_empty();
 }
 
-bool S2Polygon::ApproxEquals(const S2Polygon* b, S1Angle tolerance) const {
+bool S2Polygon::ApproxEquals(const S2Polygon& b, S1Angle tolerance) const {
   // TODO(ericv): This can be implemented more cheaply with S2Builder, by
   // simply adding all the edges from one polygon, adding the reversed edge
   // from the other polygon, and turning on the options to split edges and
   // discard sibling pairs.  Then the polygons are approximately equal if the
   // output graph has no edges.
   S2Polygon symmetric_difference;
-  symmetric_difference.InitToApproxSymmetricDifference(b, this, tolerance);
+  symmetric_difference.InitToSymmetricDifference(
+      b, *this, IdentitySnapFunction(tolerance));
   return symmetric_difference.is_empty();
 }
 
@@ -781,17 +782,17 @@ bool S2Polygon::DecodeUncompressed(Decoder* const decoder, bool within_scope) {
 // TODO(ericv): Consider adding this to the S2Loop API.  (May also want an
 // undirected version (CompareDirected vs CompareUndirected); should they
 // return a sign, or have separate "<" and "==" methods?)
-int S2Polygon::CompareLoops(const S2Loop* a, const S2Loop* b) {
-  if (a->num_vertices() != b->num_vertices()) {
-    return a->num_vertices() - b->num_vertices();
+int S2Polygon::CompareLoops(const S2Loop& a, const S2Loop& b) {
+  if (a.num_vertices() != b.num_vertices()) {
+    return a.num_vertices() - b.num_vertices();
   }
-  S2::LoopOrder ao = a->GetCanonicalLoopOrder();
-  S2::LoopOrder bo = b->GetCanonicalLoopOrder();
+  S2::LoopOrder ao = a.GetCanonicalLoopOrder();
+  S2::LoopOrder bo = b.GetCanonicalLoopOrder();
   if (ao.dir != bo.dir) return ao.dir - bo.dir;
-  for (int n = a->num_vertices(), ai = ao.first, bi = bo.first;
-       --n >= 0; ai += ao.dir, bi += bo.dir) {
-    if (a->vertex(ai) < b->vertex(bi)) return -1;
-    if (a->vertex(ai) > b->vertex(bi)) return 1;
+  for (int n = a.num_vertices(), ai = ao.first, bi = bo.first; --n >= 0;
+       ai += ao.dir, bi += bo.dir) {
+    if (a.vertex(ai) < b.vertex(bi)) return -1;
+    if (a.vertex(ai) > b.vertex(bi)) return 1;
   }
   return 0;
 }
@@ -858,7 +859,7 @@ void S2Polygon::Invert() {
   InitLoopProperties();
 }
 
-void S2Polygon::InitToComplement(const S2Polygon* a) {
+void S2Polygon::InitToComplement(const S2Polygon& a) {
   Copy(a);
   Invert();
 }
@@ -884,13 +885,8 @@ void S2Polygon::InitToOperation(S2BooleanOperation::OpType op_type,
   }
 }
 
-void S2Polygon::InitToIntersection(const S2Polygon* a, const S2Polygon* b) {
-  InitToApproxIntersection(a, b, S2::kIntersectionMergeRadius);
-}
-
-void S2Polygon::InitToApproxIntersection(const S2Polygon* a, const S2Polygon* b,
-                                         S1Angle snap_radius) {
-  InitToIntersection(*a, *b, IdentitySnapFunction(snap_radius));
+void S2Polygon::InitToIntersection(const S2Polygon& a, const S2Polygon& b) {
+  InitToIntersection(a, b, IdentitySnapFunction(S2::kIntersectionMergeRadius));
 }
 
 void S2Polygon::InitToIntersection(
@@ -915,13 +911,8 @@ bool S2Polygon::InitToIntersection(
                          snap_function, a, b, error);
 }
 
-void S2Polygon::InitToUnion(const S2Polygon* a, const S2Polygon* b) {
-  InitToApproxUnion(a, b, S2::kIntersectionMergeRadius);
-}
-
-void S2Polygon::InitToApproxUnion(const S2Polygon* a, const S2Polygon* b,
-                                  S1Angle snap_radius) {
-  InitToUnion(*a, *b, IdentitySnapFunction(snap_radius));
+void S2Polygon::InitToUnion(const S2Polygon& a, const S2Polygon& b) {
+  InitToUnion(a, b, IdentitySnapFunction(S2::kIntersectionMergeRadius));
 }
 
 void S2Polygon::InitToUnion(
@@ -937,13 +928,8 @@ bool S2Polygon::InitToUnion(
                          snap_function, a, b, error);
 }
 
-void S2Polygon::InitToDifference(const S2Polygon* a, const S2Polygon* b) {
-  InitToApproxDifference(a, b, S2::kIntersectionMergeRadius);
-}
-
-void S2Polygon::InitToApproxDifference(const S2Polygon* a, const S2Polygon* b,
-                                       S1Angle snap_radius) {
-  InitToDifference(*a, *b, IdentitySnapFunction(snap_radius));
+void S2Polygon::InitToDifference(const S2Polygon& a, const S2Polygon& b) {
+  InitToDifference(a, b, IdentitySnapFunction(S2::kIntersectionMergeRadius));
 }
 
 void S2Polygon::InitToDifference(
@@ -959,15 +945,10 @@ bool S2Polygon::InitToDifference(
                          snap_function, a, b, error);
 }
 
-void S2Polygon::InitToSymmetricDifference(const S2Polygon* a,
-                                          const S2Polygon* b) {
-  InitToApproxSymmetricDifference(a, b, S2::kIntersectionMergeRadius);
-}
-
-void S2Polygon::InitToApproxSymmetricDifference(const S2Polygon* a,
-                                                const S2Polygon* b,
-                                                S1Angle snap_radius) {
-  InitToSymmetricDifference(*a, *b, IdentitySnapFunction(snap_radius));
+void S2Polygon::InitToSymmetricDifference(const S2Polygon& a,
+                                          const S2Polygon& b) {
+  InitToSymmetricDifference(a, b,
+                            IdentitySnapFunction(S2::kIntersectionMergeRadius));
 }
 
 void S2Polygon::InitToSymmetricDifference(
@@ -992,7 +973,7 @@ void S2Polygon::InitFromBuilder(const S2Polygon& a, S2Builder* builder) {
     S2_LOG(DFATAL) << "Could not build polygon: " << error;
   }
   // If there are no loops, check whether the result should be the full
-  // polygon rather than the empty one.  (See InitToApproxIntersection.)
+  // polygon rather than the empty one.  (See InitToIntersection.)
   if (num_loops() == 0) {
     if (a.bound_.Area() > 2 * M_PI && a.GetArea() > 2 * M_PI) Invert();
   }
@@ -1004,8 +985,8 @@ void S2Polygon::InitToSnapped(const S2Polygon& polygon,
   InitFromBuilder(polygon, &builder);
 }
 
-void S2Polygon::InitToSnapped(const S2Polygon* a, int snap_level) {
-  InitToSnapped(*a, S2CellIdSnapFunction(snap_level));
+void S2Polygon::InitToSnapped(const S2Polygon& polygon, int snap_level) {
+  InitToSnapped(polygon, S2CellIdSnapFunction(snap_level));
 }
 
 void S2Polygon::InitToSimplified(const S2Polygon& a,
@@ -1037,9 +1018,9 @@ uint8 GetCellEdgeIncidenceMask(const S2Cell& cell, const S2Point& p,
   return mask;
 }
 
-void S2Polygon::InitToSimplifiedInCell(
-    const S2Polygon* a, const S2Cell& cell,
-    S1Angle snap_radius, S1Angle boundary_tolerance) {
+void S2Polygon::InitToSimplifiedInCell(const S2Polygon& a, const S2Cell& cell,
+                                       S1Angle snap_radius,
+                                       S1Angle boundary_tolerance) {
   // The polygon to be simplified consists of "boundary edges" that follow the
   // cell boundary and "interior edges" that do not.  We want to simplify the
   // interior edges while leaving the boundary edges unchanged.  It's not
@@ -1089,8 +1070,8 @@ void S2Polygon::InitToSimplifiedInCell(
 
   // The first pass yields a collection of simplified polylines that preserve
   // the original cyclic vertex order.
-  auto polylines = SimplifyEdgesInCell(*a, cell, boundary_tolerance_uv,
-                                       snap_radius);
+  auto polylines =
+      SimplifyEdgesInCell(a, cell, boundary_tolerance_uv, snap_radius);
 
   // The second pass eliminates any intersections between interior edges and
   // boundary edges, and then assembles the edges into a polygon.
@@ -1108,9 +1089,9 @@ void S2Polygon::InitToSimplifiedInCell(
     return;
   }
   // If there are no loops, check whether the result should be the full
-  // polygon rather than the empty one.  (See InitToApproxIntersection.)
+  // polygon rather than the empty one.  (See InitToIntersection.)
   if (num_loops() == 0) {
-    if (a->bound_.Area() > 2 * M_PI && a->GetArea() > 2 * M_PI) Invert();
+    if (a.bound_.Area() > 2 * M_PI && a.GetArea() > 2 * M_PI) Invert();
   }
 }
 
@@ -1350,11 +1331,11 @@ bool S2Polygon::IsNormalized() const {
   return true;
 }
 
-bool S2Polygon::Equals(const S2Polygon* b) const {
-  if (num_loops() != b->num_loops()) return false;
+bool S2Polygon::Equals(const S2Polygon& b) const {
+  if (num_loops() != b.num_loops()) return false;
   for (int i = 0; i < num_loops(); ++i) {
     const S2Loop* a_loop = loop(i);
-    const S2Loop* b_loop = b->loop(i);
+    const S2Loop* b_loop = b.loop(i);
     if ((b_loop->depth() != a_loop->depth()) || !b_loop->Equals(a_loop)) {
       return false;
     }
@@ -1362,14 +1343,14 @@ bool S2Polygon::Equals(const S2Polygon* b) const {
   return true;
 }
 
-bool S2Polygon::BoundaryEquals(const S2Polygon* b) const {
-  if (num_loops() != b->num_loops()) return false;
+bool S2Polygon::BoundaryEquals(const S2Polygon& b) const {
+  if (num_loops() != b.num_loops()) return false;
 
   for (int i = 0; i < num_loops(); ++i) {
     const S2Loop* a_loop = loop(i);
     bool success = false;
     for (int j = 0; j < num_loops(); ++j) {
-      const S2Loop* b_loop = b->loop(j);
+      const S2Loop* b_loop = b.loop(j);
       if ((b_loop->depth() == a_loop->depth()) &&
           b_loop->BoundaryEquals(a_loop)) {
         success = true;

--- a/src/s2/s2polygon.h
+++ b/src/s2/s2polygon.h
@@ -190,7 +190,11 @@ class S2Polygon final : public S2Region {
 
   // Makes a deep copy of the given source polygon.  The destination polygon
   // will be cleared if necessary.
-  void Copy(const S2Polygon* src);
+  void Copy(const S2Polygon& src);
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  void Copy(const S2Polygon* src) { Copy(*src); }
+#endif
 
   // Destroys the polygon and frees its loops.
   ~S2Polygon() override;
@@ -290,8 +294,15 @@ class S2Polygon final : public S2Region {
 
   // Return the overlap fractions between two polygons, i.e. the ratios of the
   // area of intersection to the area of each polygon.
+  static std::pair<double, double> GetOverlapFractions(const S2Polygon& a,
+                                                       const S2Polygon& b);
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
   static std::pair<double, double> GetOverlapFractions(const S2Polygon* a,
-                                                       const S2Polygon* b);
+                                                       const S2Polygon* b) {
+    return GetOverlapFractions(*a, *b);
+  }
+#endif
 
   // If the given point is contained by the polygon, return it.  Otherwise
   // return the closest point on the polygon boundary.  If the polygon is
@@ -306,7 +317,7 @@ class S2Polygon final : public S2Region {
 
   // Return true if this polygon contains the given other polygon, i.e.
   // if polygon A contains all points contained by polygon B.
-  bool Contains(const S2Polygon* b) const;
+  bool Contains(const S2Polygon& b) const;
 
   // Returns true if this polgyon (A) approximately contains the given other
   // polygon (B). This is true if it is possible to move the vertices of B
@@ -314,11 +325,11 @@ class S2Polygon final : public S2Region {
   //
   // For example, the empty polygon will contain any polygon whose maximum
   // width is no more than "tolerance".
-  bool ApproxContains(const S2Polygon* b, S1Angle tolerance) const;
+  bool ApproxContains(const S2Polygon& b, S1Angle tolerance) const;
 
   // Return true if this polygon intersects the given other polygon, i.e.
   // if there is a point that is contained by both polygons.
-  bool Intersects(const S2Polygon* b) const;
+  bool Intersects(const S2Polygon& b) const;
 
   // Returns true if this polgyon (A) and the given polygon (B) are
   // approximately disjoint.  This is true if it is possible to ensure that A
@@ -328,7 +339,7 @@ class S2Polygon final : public S2Region {
   //
   // For example, any polygon is approximately disjoint from a polygon whose
   // maximum width is no more than "tolerance".
-  bool ApproxDisjoint(const S2Polygon* b, S1Angle tolerance) const;
+  bool ApproxDisjoint(const S2Polygon& b, S1Angle tolerance) const;
 
   // Initialize this polygon to the intersection, union, difference (A - B),
   // or symmetric difference (XOR) of the given two polygons.
@@ -374,45 +385,64 @@ class S2Polygon final : public S2Region {
   // success and set "error" appropriately otherwise.  However note that these
   // functions should never return an error provided that both input polygons
   // are valid (i.e., IsValid() returns true).
-  void InitToIntersection(const S2Polygon* a, const S2Polygon* b);
+  void InitToIntersection(const S2Polygon& a, const S2Polygon& b);
   void InitToIntersection(const S2Polygon& a, const S2Polygon& b,
                           const S2Builder::SnapFunction& snap_function);
   bool InitToIntersection(const S2Polygon& a, const S2Polygon& b,
                           const S2Builder::SnapFunction& snap_function,
                           S2Error *error);
 
-  void InitToUnion(const S2Polygon* a, const S2Polygon* b);
+  void InitToUnion(const S2Polygon& a, const S2Polygon& b);
   void InitToUnion(const S2Polygon& a, const S2Polygon& b,
                    const S2Builder::SnapFunction& snap_function);
   bool InitToUnion(const S2Polygon& a, const S2Polygon& b,
                    const S2Builder::SnapFunction& snap_function,
                    S2Error *error);
 
-  void InitToDifference(const S2Polygon* a, const S2Polygon* b);
+  void InitToDifference(const S2Polygon& a, const S2Polygon& b);
   void InitToDifference(const S2Polygon& a, const S2Polygon& b,
                         const S2Builder::SnapFunction& snap_function);
   bool InitToDifference(const S2Polygon& a, const S2Polygon& b,
                         const S2Builder::SnapFunction& snap_function,
                         S2Error *error);
 
-  void InitToSymmetricDifference(const S2Polygon* a, const S2Polygon* b);
+  void InitToSymmetricDifference(const S2Polygon& a, const S2Polygon& b);
   void InitToSymmetricDifference(const S2Polygon& a, const S2Polygon& b,
                                  const S2Builder::SnapFunction& snap_function);
   bool InitToSymmetricDifference(const S2Polygon& a, const S2Polygon& b,
                                  const S2Builder::SnapFunction& snap_function,
                                  S2Error *error);
 
-  // Convenience functions that use the IdentitySnapFunction with the given
-  // snap radius.  TODO(ericv): Consider deprecating these and require the
-  // snap function to be specified explcitly?
-  void InitToApproxIntersection(const S2Polygon* a, const S2Polygon* b,
-                                S1Angle snap_radius);
-  void InitToApproxUnion(const S2Polygon* a, const S2Polygon* b,
-                         S1Angle snap_radius);
-  void InitToApproxDifference(const S2Polygon* a, const S2Polygon* b,
-                              S1Angle snap_radius);
-  void InitToApproxSymmetricDifference(const S2Polygon* a, const S2Polygon* b,
-                                       S1Angle snap_radius);
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Contains(const S2Polygon* b) const { return Contains(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool ApproxContains(const S2Polygon* b, S1Angle tolerance) const {
+    return ApproxContains(*b, tolerance);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Intersects(const S2Polygon* b) const { return Intersects(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool ApproxDisjoint(const S2Polygon* b, S1Angle tolerance) const {
+    return ApproxDisjoint(*b, tolerance);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToIntersection(const S2Polygon* a, const S2Polygon* b) {
+    return InitToIntersection(*a, *b);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToUnion(const S2Polygon* a, const S2Polygon* b) {
+    return InitToUnion(*a, *b);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToDifference(const S2Polygon* a, const S2Polygon* b) {
+    return InitToDifference(*a, *b);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToSymmetricDifference(const S2Polygon* a, const S2Polygon* b) {
+    return InitToSymmetricDifference(*a, *b);
+  }
+#endif
 
   // Snaps the vertices of the given polygon using the given SnapFunction
   // (e.g., s2builderutil::IntLatLngSnapFunction(6) snaps to E6 coordinates).
@@ -431,7 +461,7 @@ class S2Polygon final : public S2Region {
   // given level (default level 30, which has S2CellId centers spaced about 1
   // centimeter apart).  Polygons can be efficiently encoded by Encode() after
   // they have been snapped.
-  void InitToSnapped(const S2Polygon* polygon,
+  void InitToSnapped(const S2Polygon& polygon,
                      int snap_level = S2CellId::kMaxLevel);
 
   // Snaps the input polygon according to the given "snap_function" and
@@ -482,11 +512,27 @@ class S2Polygon final : public S2Region {
   //
   // REQUIRES: all vertices of "a" are within "boundary_tolerance" of "cell".
   void InitToSimplifiedInCell(
-      const S2Polygon* a, const S2Cell& cell, S1Angle snap_radius,
+      const S2Polygon& a, const S2Cell& cell, S1Angle snap_radius,
       S1Angle boundary_tolerance = S1Angle::Radians(1e-15));
 
   // Initialize this polygon to the complement of the given polygon.
-  void InitToComplement(const S2Polygon* a);
+  void InitToComplement(const S2Polygon& a);
+
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToSnapped(const S2Polygon* polygon,
+                     int snap_level = S2CellId::kMaxLevel) {
+    return InitToSnapped(*polygon, snap_level);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToSimplifiedInCell(
+      const S2Polygon* a, const S2Cell& cell, S1Angle snap_radius,
+      S1Angle boundary_tolerance = S1Angle::Radians(1e-15)) {
+    return InitToSimplifiedInCell(*a, cell, snap_radius, boundary_tolerance);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  void InitToComplement(const S2Polygon* a) { return InitToComplement(*a); }
+#endif
 
   // Invert the polygon (replace it by its complement).
   void Invert();
@@ -609,7 +655,7 @@ class S2Polygon final : public S2Region {
   // Return true if two polygons have exactly the same loops.  The loops must
   // appear in the same order, and corresponding loops must have the same
   // linear vertex ordering (i.e., cyclic rotations are not allowed).
-  bool Equals(const S2Polygon* b) const;
+  bool Equals(const S2Polygon& b) const;
 
   // Return true if two polygons are approximately equal to within the given
   // tolerance.  This is true if it is possible to move the vertices of the
@@ -624,7 +670,7 @@ class S2Polygon final : public S2Region {
   // a good choice for comparing polygons that have been snapped, simplified,
   // unioned, etc, since these operations use a model similar to this one
   // (i.e., degenerate loops or portions of loops are automatically removed).
-  bool ApproxEquals(const S2Polygon* b, S1Angle tolerance) const;
+  bool ApproxEquals(const S2Polygon& b, S1Angle tolerance) const;
 
   // Returns true if two polygons have the same boundary.  More precisely,
   // this method requires that both polygons have loops with the same cyclic
@@ -632,7 +678,18 @@ class S2Polygon final : public S2Region {
   // may be cyclically rotated between corresponding loops, and the loop
   // ordering may be different between the two polygons as long as the nesting
   // hierarchy is the same.)
-  bool BoundaryEquals(const S2Polygon* b) const;
+  bool BoundaryEquals(const S2Polygon& b) const;
+
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Equals(const S2Polygon* b) const { return Equals(*b); }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool ApproxEquals(const S2Polygon* b, S1Angle tolerance) const {
+    return ApproxEquals(*b, tolerance);
+  }
+  ABSL_DEPRECATED("Inline the implementation")
+  bool BoundaryEquals(const S2Polygon* b) const { return BoundaryEquals(*b); }
+#endif
 
   // Return true if two polygons have the same boundary except for vertex
   // perturbations.  Both polygons must have loops with the same cyclic vertex
@@ -895,7 +952,13 @@ class S2Polygon final : public S2Region {
   // Defines a total ordering on S2Loops that does not depend on the cyclic
   // order of loop vertices.  This function is used to choose which loop to
   // invert in the case where several loops have exactly the same area.
-  static int CompareLoops(const S2Loop* a, const S2Loop* b);
+  static int CompareLoops(const S2Loop& a, const S2Loop& b);
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  static int CompareLoops(const S2Loop* a, const S2Loop* b) {
+    return CompareLoops(*a, *b);
+  }
+#endif
 
   std::vector<std::unique_ptr<S2Loop> > loops_;
 

--- a/src/s2/s2polyline.cc
+++ b/src/s2/s2polyline.cc
@@ -20,12 +20,14 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <memory>
 #include <set>
 #include <utility>
 #include <vector>
 
 #include "absl/container/fixed_array.h"
 #include "absl/flags/flag.h"
+#include "absl/memory/memory.h"
 #include "absl/utility/utility.h"
 
 #include "s2/base/commandlineflags.h"
@@ -49,6 +51,7 @@
 #include "s2/util/coding/coder.h"
 #include "s2/util/math/matrix3x3.h"
 
+using absl::make_unique;
 using absl::Span;
 using s2builderutil::S2CellIdSnapFunction;
 using s2builderutil::S2PolylineLayer;
@@ -106,7 +109,7 @@ S2Debug S2Polyline::s2debug_override() const {
 
 void S2Polyline::Init(Span<const S2Point> vertices) {
   num_vertices_ = vertices.size();
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   std::copy(vertices.begin(), vertices.end(), &vertices_[0]);
   if (absl::GetFlag(FLAGS_s2debug) && s2debug_override_ == S2Debug::ALLOW) {
     S2_CHECK(IsValid());
@@ -115,7 +118,7 @@ void S2Polyline::Init(Span<const S2Point> vertices) {
 
 void S2Polyline::Init(Span<const S2LatLng> vertices) {
   num_vertices_ = vertices.size();
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   for (int i = 0; i < num_vertices_; ++i) {
     vertices_[i] = vertices[i].ToPoint();
   }
@@ -195,11 +198,11 @@ S2Polyline* S2Polyline::Clone() const {
 }
 
 S1Angle S2Polyline::GetLength() const {
-  return S2::GetLength(S2PointSpan(vertices_.get(), num_vertices_));
+  return S2::GetLength(vertices_span());
 }
 
 S2Point S2Polyline::GetCentroid() const {
-  return S2::GetCentroid(S2PointSpan(vertices_.get(), num_vertices_));
+  return S2::GetCentroid(vertices_span());
 }
 
 int S2Polyline::GetSnapLevel() const {
@@ -239,7 +242,7 @@ S2Point S2Polyline::GetSuffix(double fraction, int* next_vertex) const {
     if (target < length) {
       // This interpolates with respect to arc length rather than
       // straight-line distance, and produces a unit-length result.
-      S2Point result = S2::GetPointOnLine(vertex(i-1), vertex(i), target);
+      S2Point result = S2::GetPointOnLine(vertex(i - 1), vertex(i), target);
       // It is possible that (result == vertex(i)) due to rounding errors.
       *next_vertex = (result == vertex(i)) ? (i + 1) : i;
       return result;
@@ -333,21 +336,20 @@ bool S2Polyline::IsOnRight(const S2Point& point) const {
   return s2pred::Sign(point, vertex(next_vertex), vertex(next_vertex - 1)) > 0;
 }
 
-bool S2Polyline::Intersects(const S2Polyline* line) const {
-  if (num_vertices() <= 0 || line->num_vertices() <= 0) {
+bool S2Polyline::Intersects(const S2Polyline& line) const {
+  if (num_vertices() <= 0 || line.num_vertices() <= 0) {
     return false;
   }
 
-  if (!GetRectBound().Intersects(line->GetRectBound())) {
+  if (!GetRectBound().Intersects(line.GetRectBound())) {
     return false;
   }
 
   // TODO(ericv): Use S2ShapeIndex here.
   for (int i = 1; i < num_vertices(); ++i) {
-    S2EdgeCrosser crosser(
-        &vertex(i - 1), &vertex(i), &line->vertex(0));
-    for (int j = 1; j < line->num_vertices(); ++j) {
-      if (crosser.CrossingSign(&line->vertex(j)) >= 0) {
+    S2EdgeCrosser crosser(&vertex(i - 1), &vertex(i), &line.vertex(0));
+    for (int j = 1; j < line.num_vertices(); ++j) {
+      if (crosser.CrossingSign(&line.vertex(j)) >= 0) {
         return true;
       }
     }
@@ -436,7 +438,7 @@ bool S2Polyline::DecodeUncompressed(Decoder* const decoder) {
   // Check the bytes available before allocating memory in case of
   // corrupt/malicious input.
   if (decoder->avail() < num_vertices_ * sizeof(S2Point)) return false;
-  vertices_.reset(new S2Point[num_vertices_]);
+  vertices_ = make_unique<S2Point[]>(num_vertices_);
   decoder->getn(&vertices_[0], num_vertices_ * sizeof(vertices_[0]));
 
   if (absl::GetFlag(FLAGS_s2debug) && s2debug_override_ == S2Debug::ALLOW) {
@@ -630,10 +632,10 @@ void S2Polyline::SubsampleVertices(S1Angle tolerance,
   }
 }
 
-bool S2Polyline::Equals(const S2Polyline* b) const {
-  if (num_vertices() != b->num_vertices()) return false;
+bool S2Polyline::Equals(const S2Polyline& b) const {
+  if (num_vertices() != b.num_vertices()) return false;
   for (int offset = 0; offset < num_vertices(); ++offset) {
-    if (vertex(offset) != b->vertex(offset)) return false;
+    if (vertex(offset) != b.vertex(offset)) return false;
   }
   return true;
 }

--- a/src/s2/s2polyline.h
+++ b/src/s2/s2polyline.h
@@ -219,7 +219,11 @@ class S2Polyline final : public S2Region {
   // The running time is quadratic in the number of vertices.  (To intersect
   // polylines more efficiently, or compute the actual intersection geometry,
   // use S2BooleanOperation.)
-  bool Intersects(const S2Polyline* line) const;
+  bool Intersects(const S2Polyline& line) const;
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Intersects(const S2Polyline* line) const { return Intersects(*line); }
+#endif
 
   // Reverse the order of the polyline vertices.
   void Reverse();
@@ -254,7 +258,11 @@ class S2Polyline final : public S2Region {
   void SubsampleVertices(S1Angle tolerance, std::vector<int>* indices) const;
 
   // Return true if two polylines are exactly the same.
-  bool Equals(const S2Polyline* b) const;
+  bool Equals(const S2Polyline& b) const;
+#ifndef SWIG
+  ABSL_DEPRECATED("Inline the implementation")
+  bool Equals(const S2Polyline* b) const { return Equals(*b); }
+#endif
 
   // Return true if two polylines have the same number of vertices, and
   // corresponding vertex pairs are separated by no more than "max_error".

--- a/src/s2/s2polyline_alignment.cc
+++ b/src/s2/s2polyline_alignment.cc
@@ -15,7 +15,6 @@
 
 
 #include "s2/s2polyline_alignment.h"
-#include "s2/s2polyline_alignment_internal.h"
 
 #include <algorithm>
 #include <numeric>
@@ -26,6 +25,7 @@
 
 #include "s2/base/logging.h"
 #include "absl/memory/memory.h"
+#include "s2/s2polyline_alignment_internal.h"
 #include "s2/util/math/mathutil.h"
 
 using std::string;

--- a/src/s2/s2polyline_alignment_internal.h
+++ b/src/s2/s2polyline_alignment_internal.h
@@ -17,12 +17,11 @@
 #ifndef S2_S2POLYLINE_ALIGNMENT_INTERNAL_H_
 #define S2_S2POLYLINE_ALIGNMENT_INTERNAL_H_
 
-#include "s2/s2polyline_alignment.h"
-
 #include <limits>
 #include <vector>
 
 #include "s2/s2polyline.h"
+#include "s2/s2polyline_alignment.h"
 
 namespace s2polyline_alignment {
 

--- a/src/s2/s2polyline_measures.cc
+++ b/src/s2/s2polyline_measures.cc
@@ -18,6 +18,7 @@
 #include "s2/s2polyline_measures.h"
 
 #include <cmath>
+
 #include "s2/base/logging.h"
 #include "s2/s2centroids.h"
 

--- a/src/s2/s2polyline_test.cc
+++ b/src/s2/s2polyline_test.cc
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -52,7 +53,7 @@ using std::vector;
 
 namespace {
 
-// Wraps s2textformat::MakePolyline in order to test Encode/Decode.
+// Wraps s2textformat::MakePolylineOrDie in order to test Encode/Decode.
 unique_ptr<S2Polyline> MakePolyline(absl::string_view str,
                                     S2Debug debug_override = S2Debug::ALLOW) {
   unique_ptr<S2Polyline> polyline =

--- a/src/s2/s2predicates.cc
+++ b/src/s2/s2predicates.cc
@@ -16,14 +16,15 @@
 // Author: ericv@google.com (Eric Veach)
 
 #include "s2/s2predicates.h"
-#include "s2/s2predicates_internal.h"
 
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <ostream>
+
 #include "s2/s1chord_angle.h"
 #include "s2/s2edge_crossings.h"
+#include "s2/s2predicates_internal.h"
 #include "s2/util/math/exactfloat/exactfloat.h"
 #include "s2/util/math/vector.h"
 

--- a/src/s2/s2predicates.h
+++ b/src/s2/s2predicates.h
@@ -49,6 +49,7 @@
 
 #include <cfloat>
 #include <iosfwd>
+#include <ostream>
 
 #include "absl/flags/flag.h"
 #include "s2/_fp_contract_off.h"

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -703,8 +703,8 @@ TEST(CompareDistances, Consistency) {
     S1Angle r = S1Angle::Radians(M_PI_2 * pow(1e-30, rnd.RandDouble()));
     if (rnd.OneIn(2)) r = S1Angle::Radians(M_PI_2) - r;
     if (rnd.OneIn(2)) r = S1Angle::Radians(M_PI_2) + r;
-    S2Point a = S2::InterpolateAtDistance(r, x, dir);
-    S2Point b = S2::InterpolateAtDistance(r, x, -dir);
+    S2Point a = S2::GetPointOnLine(x, dir, r);
+    S2Point b = S2::GetPointOnLine(x, -dir, r);
     Precision prec = TestCompareDistancesConsistency<CosDistances>(x, a, b);
     if (r.degrees() >= 45 && r.degrees() <= 135) cos_stats.Tally(prec);
     // The Sin2 method is only valid if both distances are less than 90
@@ -854,7 +854,7 @@ TEST(CompareDistance, Consistency) {
     S1Angle r = S1Angle::Radians(M_PI_2 * pow(1e-30, rnd.RandDouble()));
     if (rnd.OneIn(2)) r = S1Angle::Radians(M_PI_2) - r;
     if (rnd.OneIn(5)) r = S1Angle::Radians(M_PI_2) + r;
-    S2Point y = S2::InterpolateAtDistance(r, x, dir);
+    S2Point y = S2::GetPointOnLine(x, dir, r);
     Precision prec = TestCompareDistanceConsistency<CosDistance>(
         x, y, S1ChordAngle(r));
     if (r.degrees() >= 45) cos_stats.Tally(prec);
@@ -986,7 +986,7 @@ TEST(CompareEdgeDistance, Consistency) {
     rnd.Reset(iter + 1);  // Easier to reproduce a specific case.
     S2Point a0 = ChoosePoint();
     S1Angle len = S1Angle::Radians(M_PI * pow(1e-20, rnd.RandDouble()));
-    S2Point a1 = S2::InterpolateAtDistance(len, a0, ChoosePoint());
+    S2Point a1 = S2::GetPointOnLine(a0, ChoosePoint(), len);
     if (rnd.OneIn(2)) a1 = -a1;
     if (a0 == -a1) continue;  // Not allowed by API.
     S2Point n = S2::RobustCrossProd(a0, a1).Normalize();
@@ -994,7 +994,7 @@ TEST(CompareEdgeDistance, Consistency) {
     S2Point a = ((1 - f) * a0 + f * a1).Normalize();
     S1Angle r = S1Angle::Radians(M_PI_2 * pow(1e-20, rnd.RandDouble()));
     if (rnd.OneIn(2)) r = S1Angle::Radians(M_PI_2) - r;
-    S2Point x = S2::InterpolateAtDistance(r, a, n);
+    S2Point x = S2::GetPointOnLine(a, n, r);
     if (rnd.OneIn(5)) {
       // Replace "x" with a random point that is closest to an edge endpoint.
       do {
@@ -1138,11 +1138,11 @@ TEST(CompareEdgeDirections, Consistency) {
     rnd.Reset(iter + 1);  // Easier to reproduce a specific case.
     S2Point a0 = ChoosePoint();
     S1Angle a_len = S1Angle::Radians(M_PI * pow(1e-20, rnd.RandDouble()));
-    S2Point a1 = S2::InterpolateAtDistance(a_len, a0, ChoosePoint());
+    S2Point a1 = S2::GetPointOnLine(a0, ChoosePoint(), a_len);
     S2Point a_norm = S2::RobustCrossProd(a0, a1).Normalize();
     S2Point b0 = ChoosePoint();
     S1Angle b_len = S1Angle::Radians(M_PI * pow(1e-20, rnd.RandDouble()));
-    S2Point b1 = S2::InterpolateAtDistance(b_len, b0, a_norm);
+    S2Point b1 = S2::GetPointOnLine(b0, a_norm, b_len);
     if (a0 == -a1 || b0 == -b1) continue;  // Not allowed by API.
     Precision prec = TestCompareEdgeDirectionsConsistency(a0, a1, b0, b1);
     // Don't skew the statistics by recording degenerate inputs.
@@ -1289,9 +1289,9 @@ TEST(EdgeCircumcenterSign, Consistency) {
     double c1 = (rnd.OneIn(2) ? -1 : 1) * pow(1e-20, rnd.RandDouble());
     S2Point z = (c0 * x0 + c1 * x1).Normalize();
     S1Angle r = S1Angle::Radians(M_PI * pow(1e-30, rnd.RandDouble()));
-    S2Point a = S2::InterpolateAtDistance(r, z, ChoosePoint());
-    S2Point b = S2::InterpolateAtDistance(r, z, ChoosePoint());
-    S2Point c = S2::InterpolateAtDistance(r, z, ChoosePoint());
+    S2Point a = S2::GetPointOnLine(z, ChoosePoint(), r);
+    S2Point b = S2::GetPointOnLine(z, ChoosePoint(), r);
+    S2Point c = S2::GetPointOnLine(z, ChoosePoint(), r);
     Precision prec = TestEdgeCircumcenterSignConsistency(x0, x1, a, b, c);
     // Don't skew the statistics by recording degenerate inputs.
     if (x0 == x1) {
@@ -1537,8 +1537,8 @@ TEST(VoronoiSiteExclusion, Consistency) {
     double f = pow(1e-20, rnd.RandDouble());
     S2Point p = ((1 - f) * x0 + f * x1).Normalize();
     S1Angle r1 = S1Angle::Radians(M_PI_2 * pow(1e-20, rnd.RandDouble()));
-    S2Point a = S2::InterpolateAtDistance(r1, p, ChoosePoint());
-    S2Point b = S2::InterpolateAtDistance(r1, p, ChoosePoint());
+    S2Point a = S2::GetPointOnLine(p, ChoosePoint(), r1);
+    S2Point b = S2::GetPointOnLine(p, ChoosePoint(), r1);
     // Check that the other API requirements are met.
     S1ChordAngle r(r1);
     if (s2pred::CompareEdgeDistance(a, x0, x1, r) > 0) continue;

--- a/src/s2/s2projections.cc
+++ b/src/s2/s2projections.cc
@@ -18,6 +18,7 @@
 #include "s2/s2projections.h"
 
 #include <cmath>
+
 #include "s2/s2latlng.h"
 
 using std::fabs;

--- a/src/s2/s2projections_test.cc
+++ b/src/s2/s2projections_test.cc
@@ -18,6 +18,7 @@
 #include "s2/s2projections.h"
 
 #include <limits>
+
 #include <gtest/gtest.h>
 #include "s2/s2latlng.h"
 #include "s2/s2pointutil.h"

--- a/src/s2/s2region_coverer.cc
+++ b/src/s2/s2region_coverer.cc
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <functional>
 #include <queue>
+#include <utility>
 #include <vector>
 
 #include "absl/base/casts.h"

--- a/src/s2/s2region_coverer.h
+++ b/src/s2/s2region_coverer.h
@@ -18,6 +18,7 @@
 #ifndef S2_S2REGION_COVERER_H_
 #define S2_S2REGION_COVERER_H_
 
+#include <algorithm>
 #include <cstddef>
 #include <new>
 #include <queue>

--- a/src/s2/s2region_coverer_test.cc
+++ b/src/s2/s2region_coverer_test.cc
@@ -65,9 +65,8 @@ S2_DEFINE_int32(iters, google::DEBUG_MODE ? 1000 : 100000,
 
 namespace {
 
-using absl::SimpleAtoi;
-using absl::StrCat;
 using absl::flat_hash_map;
+using absl::StrCat;
 using std::max;
 using std::min;
 using std::priority_queue;

--- a/src/s2/s2region_intersection.cc
+++ b/src/s2/s2region_intersection.cc
@@ -16,6 +16,8 @@
 
 #include "s2/s2region_intersection.h"
 
+#include <utility>
+
 #include "s2/s2cap.h"
 #include "s2/s2latlng_rect.h"
 

--- a/src/s2/s2region_test.cc
+++ b/src/s2/s2region_test.cc
@@ -61,20 +61,6 @@ const char kEncodedCapFromPoint[] =
 const char kEncodedCapFromCenterHeight[] =
     "00000000000000000000000000000000000000000000F03F0000000000001040";
 
-// S2CellId.
-// S2CellId from Face 0.
-const char kEncodedCellIDFace0[] = "0000000000000010";
-// S2CellId from Face 5.
-const char kEncodedCellIDFace5[] = "00000000000000B0";
-// S2CellId from Face 0 in the last S2Cell at kMaxLevel.
-const char kEncodedCellIDFace0MaxLevel[] = "0100000000000020";
-// S2CellId from Face 5 in the last S2Cell at kMaxLevel.
-const char kEncodedCellIDFace5MaxLevel[] = "01000000000000C0";
-// S2CellId FromFacePosLevel(3, 0x12345678, S2CellId::kMaxLevel - 4)
-const char kEncodedCellIDFacePosLevel[] = "0057341200000060";
-// S2CellId from the 0 value.
-const char kEncodedCellIDInvalid[] = "0000000000000000";
-
 // S2Cell.
 // S2Cell from S2Point(1, 2, 3)
 const char kEncodedCellFromPoint[] = "F51392E0F35DCC43";
@@ -119,20 +105,6 @@ const char kEncodedLoopCross[] =
     "3FB4825F3C81FDEF3F27DCF7C958DE91BF1EDD892B0BDF91BFD44A8442C3F9EF3F7EDA2AB3"
     "41DC91BF27DCF7C958DEA1BF0000000000013EFC10E8F8DFA1BF3EFC10E8F8DFA13F389D52"
     "A246DF91BF389D52A246DF913F";
-// S2Loop encoded using EncodeCompressed from snapped points.
-// vector<S2Point> snapped_loop_a_vertices = {
-//       S2CellId(s2textformat::MakePoint("0:178")).ToPoint(),
-//       S2CellId(s2textformat::MakePoint("-1:180")).ToPoint(),
-//       S2CellId(s2textformat::MakePoint("0:-179")).ToPoint(),
-//       S2CellId(s2textformat::MakePoint("1:-180")).ToPoint()};
-// snapped_loop = make_unique<S2Loop>(snapped_loop_a_vertices));
-// absl::FixedArray<S2XYZFaceSiTi> points(loop.num_vertices());
-// loop.GetXYZFaceSiTiVertices(points.data());
-// loop.EncodeCompressed(encoder, points.data(), level);
-//
-const char kEncodedLoopCompressed[] =
-    "041B02222082A222A806A0C7A991DE86D905D7C3A691F2DEE40383908880A095880500000"
-    "3";
 
 // S2PointRegion
 // The difference between an S2PointRegion and an S2Point being encoded is the
@@ -147,10 +119,10 @@ const char kEncodedPointTesting[] =
     "0109AD578332DBCA3FBC9FDB9BB4E4EE3FE67E7C2CA7CEC33F";
 
 // S2Polygon
-// S2Polygon from s2textformat::MakePolygon("").
+// S2Polygon from s2textformat::MakePolygonOrDie("").
 // This is encoded in compressed format v4.
 const char kEncodedPolygonEmpty[] = "041E00";
-// S2Polygon from s2textformat::MakePolygon("full").
+// S2Polygon from s2textformat::MakePolygonOrDie("full").
 // This is encoded in compressed format v4.
 const char kEncodedPolygonFull[] = "040001010B000100";
 // S2Polygon from the unit test value kCross1. Encoded in lossless format.
@@ -334,12 +306,12 @@ TEST_F(S2RegionEncodeDecodeTest, S2Polygon) {
   const string kCrossCenterHole = "-0.5:0.5, 0.5:0.5, 0.5:-0.5, -0.5:-0.5;";
 
   S2Polygon polygon;
-  unique_ptr<S2Polygon> polygon_empty = s2textformat::MakePolygon("");
+  unique_ptr<S2Polygon> polygon_empty = s2textformat::MakePolygonOrDie("");
   unique_ptr<S2Polygon> polygon_full =
-      s2textformat::MakeVerbatimPolygon("full");
-  unique_ptr<S2Polygon> polygon_cross = s2textformat::MakePolygon(kCross1);
+      s2textformat::MakeVerbatimPolygonOrDie("full");
+  unique_ptr<S2Polygon> polygon_cross = s2textformat::MakePolygonOrDie(kCross1);
   unique_ptr<S2Polygon> polygon_cross_hole =
-      s2textformat::MakePolygon(kCross1 + ";" + kCrossCenterHole);
+      s2textformat::MakePolygonOrDie(kCross1 + ";" + kCrossCenterHole);
 
   TestEncodeDecode(kEncodedPolygonEmpty, *polygon_empty, &polygon);
   EXPECT_TRUE(polygon_empty->Equals(&polygon));

--- a/src/s2/s2region_union_test.cc
+++ b/src/s2/s2region_union_test.cc
@@ -59,7 +59,7 @@ TEST(S2RegionUnionTest, Basic) {
   two_points_orig.reset();
   // The bounds below may not be exactly equal because the S2PointRegion
   // version converts each S2LatLng value to an S2Point and back.
-  EXPECT_TRUE(s2textformat::MakeLatLngRect("-35:-40,35:40").ApproxEquals(
+  EXPECT_TRUE(s2textformat::MakeLatLngRectOrDie("-35:-40,35:40").ApproxEquals(
       two_points->GetRectBound()))
       << two_points->GetRectBound();
 

--- a/src/s2/s2shape.h
+++ b/src/s2/s2shape.h
@@ -147,11 +147,14 @@ class S2Shape {
   S2Shape() : id_(-1) {}
   virtual ~S2Shape() {}
 
-  // Returns the number of edges in this shape.  Edges have ids ranging from 0
-  // to num_edges() - 1.
+  // Returns the number of edges in this shape, or points, if the shape's
+  // dimension is 0.  Edges or points have ids ranging from 0 to
+  // num_edges() - 1.
   virtual int num_edges() const = 0;
 
-  // Returns the endpoints of the given edge id.
+  // Returns the edge or point for the given edge id.  Points are represented as
+  // degenerate edges, with equal endpoints, but not all degenerate edges are
+  // points.
   //
   // REQUIRES: 0 <= id < num_edges()
   virtual Edge edge(int edge_id) const = 0;

--- a/src/s2/s2shape_index_buffered_region.cc
+++ b/src/s2/s2shape_index_buffered_region.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <vector>
+
 #include "s2/s2metrics.h"
 #include "s2/s2shape_index_region.h"
 

--- a/src/s2/s2shape_index_measures.cc
+++ b/src/s2/s2shape_index_measures.cc
@@ -17,6 +17,8 @@
 
 #include "s2/s2shape_index_measures.h"
 
+#include <algorithm>
+
 #include "s2/s2shape_measures.h"
 
 namespace S2 {

--- a/src/s2/s2shape_index_region.h
+++ b/src/s2/s2shape_index_region.h
@@ -18,6 +18,7 @@
 #define S2_S2SHAPE_INDEX_REGION_H_
 
 #include <vector>
+
 #include "absl/container/flat_hash_map.h"
 #include "s2/s2cap.h"
 #include "s2/s2cell.h"

--- a/src/s2/s2shape_index_region_test.cc
+++ b/src/s2/s2shape_index_region_test.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 

--- a/src/s2/s2shape_measures.cc
+++ b/src/s2/s2shape_measures.cc
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <vector>
+
 #include "s2/base/log_severity.h"
 #include "s2/s2loop_measures.h"
 #include "s2/s2polyline_measures.h"

--- a/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
+++ b/src/s2/s2shapeutil_build_polygon_boundaries_test.cc
@@ -17,6 +17,7 @@
 
 #include "s2/s2shapeutil_build_polygon_boundaries.h"
 
+#include <algorithm>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -32,7 +33,7 @@ namespace s2shapeutil {
 class TestLaxLoop : public S2LaxLoopShape {
  public:
   explicit TestLaxLoop(absl::string_view vertex_str) {
-    vector<S2Point> vertices = s2textformat::ParsePoints(vertex_str);
+    vector<S2Point> vertices = s2textformat::ParsePointsOrDie(vertex_str);
     Init(vertices);
   }
 };

--- a/src/s2/s2shapeutil_coding.cc
+++ b/src/s2/s2shapeutil_coding.cc
@@ -18,6 +18,7 @@
 #include "s2/s2shapeutil_coding.h"
 
 #include <memory>
+#include <utility>
 
 #include "absl/memory/memory.h"
 #include "s2/encoded_s2point_vector.h"

--- a/src/s2/s2shapeutil_coding.h
+++ b/src/s2/s2shapeutil_coding.h
@@ -35,6 +35,7 @@
 
 #include <functional>
 #include <memory>
+
 #include "s2/util/coding/coder.h"
 #include "s2/encoded_string_vector.h"
 #include "s2/s2shape.h"

--- a/src/s2/s2shapeutil_coding_test.cc
+++ b/src/s2/s2shapeutil_coding_test.cc
@@ -17,6 +17,8 @@
 
 #include "s2/s2shapeutil_coding.h"
 
+#include <string>
+
 #include <gtest/gtest.h>
 #include "absl/strings/escaping.h"
 #include "s2/util/coding/coder.h"

--- a/src/s2/s2shapeutil_contains_brute_force.cc
+++ b/src/s2/s2shapeutil_contains_brute_force.cc
@@ -18,6 +18,7 @@
 #include "s2/s2shapeutil_contains_brute_force.h"
 
 #include <utility>
+
 #include "s2/s2edge_crosser.h"
 
 namespace s2shapeutil {

--- a/src/s2/s2shapeutil_contains_brute_force_test.cc
+++ b/src/s2/s2shapeutil_contains_brute_force_test.cc
@@ -22,28 +22,28 @@
 #include "s2/s2lax_polyline_shape.h"
 #include "s2/s2text_format.h"
 
-using s2textformat::MakeLaxPolygon;
-using s2textformat::MakeLaxPolyline;
-using s2textformat::MakePoint;
+using s2textformat::MakeLaxPolygonOrDie;
+using s2textformat::MakeLaxPolylineOrDie;
+using s2textformat::MakePointOrDie;
 
 namespace s2shapeutil {
 
 TEST(ContainsBruteForce, NoInterior) {
   // Defines a polyline that almost entirely encloses the point 0:0.
-  auto polyline = MakeLaxPolyline("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
-  EXPECT_FALSE(ContainsBruteForce(*polyline, MakePoint("0:0")));
+  auto polyline = MakeLaxPolylineOrDie("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
+  EXPECT_FALSE(ContainsBruteForce(*polyline, MakePointOrDie("0:0")));
 }
 
 TEST(ContainsBruteForce, ContainsReferencePoint) {
   // Checks that ContainsBruteForce agrees with GetReferencePoint.
-  auto polygon = MakeLaxPolygon("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
+  auto polygon = MakeLaxPolygonOrDie("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
   auto ref = polygon->GetReferencePoint();
   EXPECT_EQ(ref.contained, ContainsBruteForce(*polygon, ref.point));
 }
 
 TEST(ContainsBruteForce, ConsistentWithS2Loop) {
   // Checks that ContainsBruteForce agrees with S2Loop::Contains().
-  auto loop = S2Loop::MakeRegularLoop(MakePoint("89:-179"),
+  auto loop = S2Loop::MakeRegularLoop(MakePointOrDie("89:-179"),
                                       S1Angle::Degrees(10), 100);
   S2Loop::Shape shape(loop.get());
   for (int i = 0; i < loop->num_vertices(); ++i) {

--- a/src/s2/s2shapeutil_conversion.cc
+++ b/src/s2/s2shapeutil_conversion.cc
@@ -17,6 +17,8 @@
 
 #include "s2/s2shapeutil_conversion.h"
 
+#include <utility>
+
 #include "s2/s2shape_measures.h"
 
 namespace s2shapeutil {

--- a/src/s2/s2shapeutil_count_edges.h
+++ b/src/s2/s2shapeutil_count_edges.h
@@ -22,19 +22,18 @@
 
 namespace s2shapeutil {
 
-// Returns the total number of edges in all indexed shapes.  This method takes
-// time linear in the number of shapes.
+// Returns the total number of edges and points in all indexed shapes in the
+// given index.  This method takes time linear in the number of shapes.
 template <class S2ShapeIndexType>
 int CountEdges(const S2ShapeIndexType& index);
 
-// Like CountEdges(), but stops once "max_edges" edges have been found (in
-// which case the current running total is returned).
+// Like CountEdges(), but stops once "max_edges" edges and / or points have been
+// found, in which case the current running total is returned.
 template <class S2ShapeIndexType>
 int CountEdgesUpTo(const S2ShapeIndexType& index, int max_edges);
 
 
 //////////////////   Implementation details follow   ////////////////////
-
 
 template <class S2ShapeIndexType>
 inline int CountEdges(const S2ShapeIndexType& index) {

--- a/src/s2/s2shapeutil_count_edges_test.cc
+++ b/src/s2/s2shapeutil_count_edges_test.cc
@@ -24,7 +24,7 @@
 namespace {
 
 TEST(CountEdgesUpTo, StopsEarly) {
-  auto index = s2textformat::MakeIndex(
+  auto index = s2textformat::MakeIndexOrDie(
       "0:0 | 0:1 | 0:2 | 0:3 | 0:4 # 1:0, 1:1 | 1:2, 1:3 | 1:4, 1:5, 1:6 #");
   // Verify the test parameters.
   ASSERT_EQ(index->num_shape_ids(), 4);

--- a/src/s2/s2shapeutil_edge_iterator_test.cc
+++ b/src/s2/s2shapeutil_edge_iterator_test.cc
@@ -52,35 +52,35 @@ void Verify(const S2ShapeIndex* index) {
 }  // namespace
 
 TEST(S2ShapeutilEdgeIteratorTest, Empty) {
-  auto index = s2textformat::MakeIndex("##");
+  auto index = s2textformat::MakeIndexOrDie("##");
   Verify(index.get());
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, Points) {
-  auto index = s2textformat::MakeIndex("0:0|1:1##");
+  auto index = s2textformat::MakeIndexOrDie("0:0|1:1##");
   Verify(index.get());
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, Lines) {
-  auto index = s2textformat::MakeIndex("#0:0,10:10|5:5,5:10|1:2,2:1#");
+  auto index = s2textformat::MakeIndexOrDie("#0:0,10:10|5:5,5:10|1:2,2:1#");
   Verify(index.get());
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, Polygons) {
   auto index =
-      s2textformat::MakeIndex("##10:10,10:0,0:0|-10:-10,-10:0,0:0,0:-10");
+      s2textformat::MakeIndexOrDie("##10:10,10:0,0:0|-10:-10,-10:0,0:0,0:-10");
   Verify(index.get());
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, Collection) {
-  auto index = s2textformat::MakeIndex(
+  auto index = s2textformat::MakeIndexOrDie(
       "1:1|7:2#1:1,2:2,3:3|2:2,1:7#"
       "10:10,10:0,0:0;20:20,20:10,10:10|15:15,15:0,0:0");
   Verify(index.get());
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, Remove) {
-  auto index = s2textformat::MakeIndex(
+  auto index = s2textformat::MakeIndexOrDie(
       "1:1|7:2#1:1,2:2,3:3|2:2,1:7#"
       "10:10,10:0,0:0;20:20,20:10,10:10|15:15,15:0,0:0");
   index->Release(0);
@@ -89,11 +89,11 @@ TEST(S2ShapeutilEdgeIteratorTest, Remove) {
 }
 
 TEST(S2ShapeutilEdgeIteratorTest, AssignmentAndEquality) {
-  auto index1 = s2textformat::MakeIndex(
+  auto index1 = s2textformat::MakeIndexOrDie(
       "1:1|7:2#1:1,2:2,3:3|2:2,1:7#"
       "10:10,10:0,0:0;20:20,20:10,10:10|15:15,15:0,0:0");
 
-  auto index2 = s2textformat::MakeIndex(
+  auto index2 = s2textformat::MakeIndexOrDie(
       "1:1|7:2#1:1,2:2,3:3|2:2,1:7#"
       "10:10,10:0,0:0;20:20,20:10,10:10|15:15,15:0,0:0");
 

--- a/src/s2/s2shapeutil_get_reference_point_test.cc
+++ b/src/s2/s2shapeutil_get_reference_point_test.cc
@@ -42,19 +42,17 @@ TEST(GetReferencePoint, FullPolygon) {
 
 TEST(GetReferencePoint, DegenerateLoops) {
   vector<S2LaxPolygonShape::Loop> loops = {
-    s2textformat::ParsePoints("1:1, 1:2, 2:2, 1:2, 1:3, 1:2, 1:1"),
-    s2textformat::ParsePoints("0:0, 0:3, 0:6, 0:9, 0:6, 0:3, 0:0"),
-    s2textformat::ParsePoints("5:5, 6:6")
-  };
+      s2textformat::ParsePointsOrDie("1:1, 1:2, 2:2, 1:2, 1:3, 1:2, 1:1"),
+      s2textformat::ParsePointsOrDie("0:0, 0:3, 0:6, 0:9, 0:6, 0:3, 0:0"),
+      s2textformat::ParsePointsOrDie("5:5, 6:6")};
   S2LaxPolygonShape shape(loops);
   EXPECT_FALSE(shape.GetReferencePoint().contained);
 }
 
 TEST(GetReferencePoint, InvertedLoops) {
   vector<S2LaxPolygonShape::Loop> loops = {
-    s2textformat::ParsePoints("1:2, 1:1, 2:2"),
-    s2textformat::ParsePoints("3:4, 3:3, 4:4")
-  };
+      s2textformat::ParsePointsOrDie("1:2, 1:1, 2:2"),
+      s2textformat::ParsePointsOrDie("3:4, 3:3, 4:4")};
   S2LaxPolygonShape shape(loops);
   EXPECT_TRUE(s2shapeutil::ContainsBruteForce(shape, S2::Origin()));
 }

--- a/src/s2/s2shapeutil_range_iterator_test.cc
+++ b/src/s2/s2shapeutil_range_iterator_test.cc
@@ -25,7 +25,7 @@ namespace s2shapeutil {
 
 TEST(RangeIterator, Next) {
   // Create an index with one point each on S2CellId faces 0, 1, and 2.
-  auto index = s2textformat::MakeIndex("0:0 | 0:90 | 90:0 # #");
+  auto index = s2textformat::MakeIndexOrDie("0:0 | 0:90 | 90:0 # #");
   RangeIterator it(*index);
   EXPECT_EQ(0, it.id().face());
   it.Next();
@@ -38,8 +38,8 @@ TEST(RangeIterator, Next) {
 }
 
 TEST(RangeIterator, EmptyIndex) {
-  auto empty = s2textformat::MakeIndex("# #");
-  auto non_empty = s2textformat::MakeIndex("0:0 # #");
+  auto empty = s2textformat::MakeIndexOrDie("# #");
+  auto non_empty = s2textformat::MakeIndexOrDie("0:0 # #");
   RangeIterator empty_it(*empty);
   RangeIterator non_empty_it(*non_empty);
   EXPECT_FALSE(non_empty_it.done());

--- a/src/s2/s2text_format.h
+++ b/src/s2/s2text_format.h
@@ -91,11 +91,6 @@ std::vector<S2Point> ParsePointsOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool ParsePoints(absl::string_view str,
                                       std::vector<S2Point>* vertices);
 
-ABSL_DEPRECATED("Inline the implementation")
-inline std::vector<S2Point> ParsePoints(absl::string_view str) {
-  return ParsePointsOrDie(str);
-}
-
 // Given a string in the same format as ParseLatLngs, returns a single S2LatLng.
 S2LatLng MakeLatLngOrDie(absl::string_view str);
 
@@ -167,12 +162,6 @@ ABSL_MUST_USE_RESULT bool MakePolyline(absl::string_view str,
                                        std::unique_ptr<S2Polyline>* polyline,
                                        S2Debug debug_override = S2Debug::ALLOW);
 
-ABSL_DEPRECATED("Inline the implementation")
-inline std::unique_ptr<S2Polyline> MakePolyline(
-    absl::string_view str, S2Debug debug_override = S2Debug::ALLOW) {
-  return MakePolylineOrDie(str, debug_override);
-}
-
 // Like MakePolyline, but returns an S2LaxPolylineShape instead.
 std::unique_ptr<S2LaxPolylineShape> MakeLaxPolylineOrDie(absl::string_view str);
 
@@ -180,12 +169,6 @@ std::unique_ptr<S2LaxPolylineShape> MakeLaxPolylineOrDie(absl::string_view str);
 // conversion is successful.
 ABSL_MUST_USE_RESULT bool MakeLaxPolyline(
     absl::string_view str, std::unique_ptr<S2LaxPolylineShape>* lax_polyline);
-
-ABSL_DEPRECATED("Inline the implementation")
-inline std::unique_ptr<S2LaxPolylineShape> MakeLaxPolyline(
-    absl::string_view str) {
-  return MakeLaxPolylineOrDie(str);
-}
 
 // Given a sequence of loops separated by semicolons, returns a newly
 // allocated polygon.  Loops are automatically normalized by inverting them
@@ -225,11 +208,6 @@ std::unique_ptr<S2Polygon> MakeVerbatimPolygonOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeVerbatimPolygon(
     absl::string_view str, std::unique_ptr<S2Polygon>* polygon);
 
-ABSL_DEPRECATED("Inline the implementation")
-inline std::unique_ptr<S2Polygon> MakeVerbatimPolygon(absl::string_view str) {
-  return MakeVerbatimPolygonOrDie(str);
-}
-
 // Parses a string in the same format as MakePolygon, except that loops must
 // be oriented so that the interior of the loop is always on the left, and
 // polygons with degeneracies are supported.  As with MakePolygon, "full" and
@@ -241,24 +219,24 @@ std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygonOrDie(absl::string_view str);
 ABSL_MUST_USE_RESULT bool MakeLaxPolygon(
     absl::string_view str, std::unique_ptr<S2LaxPolygonShape>* lax_polygon);
 
-ABSL_DEPRECATED("Inline the implementation")
-inline std::unique_ptr<S2LaxPolygonShape> MakeLaxPolygon(
-    absl::string_view str) {
-  return MakeLaxPolygonOrDie(str);
-}
-
 // Returns a MutableS2ShapeIndex containing the points, polylines, and loops
-// (in the form of a single polygon) described by the following format:
+// (in the form of one polygon for each group of loops) described by the
+// following format:
 //
 //   point1|point2|... # line1|line2|... # polygon1|polygon2|...
 //
 // Examples:
-//   1:2 | 2:3 # #                     // Two points
+//   1:2 | 2:3 # #                     // Two points (one S2PointVectorShape)
 //   # 0:0, 1:1, 2:2 | 3:3, 4:4 #      // Two polylines
 //   # # 0:0, 0:3, 3:0; 1:1, 2:1, 1:2  // Two nested loops (one polygon)
-//   5:5 # 6:6, 7:7 # 0:0, 0:1, 1:0    // One of each
+//   5:5 # 6:6, 7:7 # 0:0, 0:1, 1:0    // One of each point, line, and polygon
 //   # # empty                         // One empty polygon
 //   # # empty | full                  // One empty polygon, one full polygon
+//
+// All the points, if any, are stored as a single S2PointVectorShape in the
+// index.  Polylines are stored as individual S2LaxPolylineShapes.  Polygons
+// are separated by '|', with distinct loops for a polygon separated by ';'.
+// Each group of loops is stored as an individual S2LaxPolygonShape.
 //
 // Loops should be directed so that the region's interior is on the left.
 // Loops can be degenerate (they do not need to meet S2Loop requirements).
@@ -271,11 +249,6 @@ std::unique_ptr<MutableS2ShapeIndex> MakeIndexOrDie(absl::string_view str);
 // conversion is successful.
 ABSL_MUST_USE_RESULT bool MakeIndex(
     absl::string_view str, std::unique_ptr<MutableS2ShapeIndex>* index);
-
-ABSL_DEPRECATED("Inline the implementation")
-inline std::unique_ptr<MutableS2ShapeIndex> MakeIndex(absl::string_view str) {
-  return MakeIndexOrDie(str);
-}
 
 // Convert an S2Point, S2LatLng, S2LatLngRect, S2CellId, S2CellUnion, loop,
 // polyline, or polygon to the string format above.

--- a/src/s2/s2text_format_test.cc
+++ b/src/s2/s2text_format_test.cc
@@ -15,6 +15,7 @@
 
 #include "s2/s2text_format.h"
 
+#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/src/s2/s2winding_operation.cc
+++ b/src/s2/s2winding_operation.cc
@@ -18,6 +18,8 @@
 
 #include "s2/s2winding_operation.h"
 
+#include <utility>
+
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"

--- a/src/s2/s2winding_operation_test.cc
+++ b/src/s2/s2winding_operation_test.cc
@@ -18,6 +18,7 @@
 #include "s2/s2winding_operation.h"
 
 #include <memory>
+#include <string>
 
 #include <gtest/gtest.h>
 #include "absl/flags/flag.h"

--- a/src/s2/sequence_lexicon_test.cc
+++ b/src/s2/sequence_lexicon_test.cc
@@ -17,8 +17,10 @@
 
 #include "s2/sequence_lexicon.h"
 
+#include <algorithm>
 #include <array>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "s2/base/logging.h"

--- a/src/s2/util/bits/bits.cc
+++ b/src/s2/util/bits/bits.cc
@@ -42,8 +42,8 @@ int Bits::Difference(const void *m1, const void *m2, int num_bytes) {
   return nbits;
 }
 
-int Bits::CappedDifference(const void *m1, const void *m2,
-                           int num_bytes, int cap) {
+int Bits::CappedDifference(const void *m1, const void *m2, int num_bytes,
+                           int cap) {
   int nbits = 0;
   const uint8 *s1 = (const uint8 *)m1;
   const uint8 *s2 = (const uint8 *)m2;
@@ -54,7 +54,7 @@ int Bits::CappedDifference(const void *m1, const void *m2,
 
 int Bits::Log2Ceiling(uint32 n) {
   int floor = (absl::bit_width(n) - 1);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;
@@ -62,7 +62,7 @@ int Bits::Log2Ceiling(uint32 n) {
 
 int Bits::Log2Ceiling64(uint64 n) {
   int floor = (absl::bit_width(n) - 1);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;
@@ -70,7 +70,7 @@ int Bits::Log2Ceiling64(uint64 n) {
 
 int Bits::Log2Ceiling128(absl::uint128 n) {
   int floor = Log2Floor128(n);
-  if ((n & (n - 1)) == 0)              // zero or a power of two
+  if ((n & (n - 1)) == 0)  // zero or a power of two
     return floor;
   else
     return floor + 1;

--- a/src/s2/util/coding/varint.h
+++ b/src/s2/util/coding/varint.h
@@ -294,7 +294,7 @@ inline const char* Varint::Parse32WithLimit(const char* p, const char* l,
    auto ptr = reinterpret_cast<const int8*>(p);
    int64 byte = *ptr;
    if (byte >= 0) {
-     *OUTPUT = byte;
+     *OUTPUT = static_cast<uint64>(byte);
      return reinterpret_cast<const char*>(ptr) + 1;
   } else {
     auto tmp = Parse64FallbackPair(p, byte);
@@ -395,7 +395,7 @@ inline int Varint::Length32(uint32 v) {
   // Use an explicit multiplication to implement the divide of
   // a number in the 1..31 range.
   // Explicit OR 0x1 to handle v == 0.
-  uint32 log2value = Bits::Log2FloorNonZero(v | 0x1);
+  uint32 log2value = static_cast<uint32>(Bits::Log2FloorNonZero(v | 0x1));
   return static_cast<int>((log2value * 9 + 73) / 64);
 }
 
@@ -404,7 +404,7 @@ inline int Varint::Length64(uint64 v) {
   // Use an explicit multiplication to implement the divide of
   // a number in the 1..63 range.
   // Explicit OR 0x1 to handle v == 0.
-  uint32 log2value = Bits::Log2FloorNonZero64(v | 0x1);
+  uint32 log2value = static_cast<uint32>(Bits::Log2FloorNonZero64(v | 0x1));
   return static_cast<int>((log2value * 9 + 73) / 64);
 }
 

--- a/src/s2/util/math/matrix3x3.h
+++ b/src/s2/util/math/matrix3x3.h
@@ -77,22 +77,21 @@ class Matrix3x3 {
   // Casting constructor
   template <class VType2>
   static Matrix3x3 Cast(const Matrix3x3<VType2> &mb) {
-    return Matrix3x3(static_cast<VType>(mb(0, 0)),
-                     static_cast<VType>(mb(0, 1)),
-                     static_cast<VType>(mb(0, 2)),
-                     static_cast<VType>(mb(1, 0)),
-                     static_cast<VType>(mb(1, 1)),
-                     static_cast<VType>(mb(1, 2)),
-                     static_cast<VType>(mb(2, 0)),
-                     static_cast<VType>(mb(2, 1)),
+    return Matrix3x3(static_cast<VType>(mb(0, 0)),  //
+                     static_cast<VType>(mb(0, 1)),  //
+                     static_cast<VType>(mb(0, 2)),  //
+                     static_cast<VType>(mb(1, 0)),  //
+                     static_cast<VType>(mb(1, 1)),  //
+                     static_cast<VType>(mb(1, 2)),  //
+                     static_cast<VType>(mb(2, 0)),  //
+                     static_cast<VType>(mb(2, 1)),  //
                      static_cast<VType>(mb(2, 2)));
   }
 
   // Change the value of all the coefficients of the matrix
-  inline Matrix3x3 &
-    Set(const VType &m00, const VType &m01, const VType &m02,
-        const VType &m10, const VType &m11, const VType &m12,
-        const VType &m20, const VType &m21, const VType &m22) {
+  inline Matrix3x3 &Set(const VType &m00, const VType &m01, const VType &m02,
+                        const VType &m10, const VType &m11, const VType &m12,
+                        const VType &m20, const VType &m21, const VType &m22) {
     m_[0][0] = m00;
     m_[0][1] = m01;
     m_[0][2] = m02;
@@ -108,7 +107,7 @@ class Matrix3x3 {
   }
 
   // Matrix addition
-  inline Matrix3x3& operator+=(const Matrix3x3 &mb) {
+  inline Matrix3x3 &operator+=(const Matrix3x3 &mb) {
     m_[0][0] += mb.m_[0][0];
     m_[0][1] += mb.m_[0][1];
     m_[0][2] += mb.m_[0][2];
@@ -124,7 +123,7 @@ class Matrix3x3 {
   }
 
   // Matrix subtration
-  inline Matrix3x3& operator-=(const Matrix3x3 &mb) {
+  inline Matrix3x3 &operator-=(const Matrix3x3 &mb) {
     m_[0][0] -= mb.m_[0][0];
     m_[0][1] -= mb.m_[0][1];
     m_[0][2] -= mb.m_[0][2];
@@ -140,7 +139,7 @@ class Matrix3x3 {
   }
 
   // Matrix multiplication by a scalar
-  inline Matrix3x3& operator*=(const VType &k) {
+  inline Matrix3x3 &operator*=(const VType &k) {
     m_[0][0] *= k;
     m_[0][1] *= k;
     m_[0][2] *= k;
@@ -167,8 +166,8 @@ class Matrix3x3 {
 
   // Change the sign of all the coefficients in the matrix
   friend inline Matrix3x3 operator-(const Matrix3x3 &vb) {
-    return Matrix3x3(-vb.m_[0][0], -vb.m_[0][1], -vb.m_[0][2],
-                     -vb.m_[1][0], -vb.m_[1][1], -vb.m_[1][2],
+    return Matrix3x3(-vb.m_[0][0], -vb.m_[0][1], -vb.m_[0][2],  //
+                     -vb.m_[1][0], -vb.m_[1][1], -vb.m_[1][2],  //
                      -vb.m_[2][0], -vb.m_[2][1], -vb.m_[2][2]);
   }
 
@@ -178,11 +177,12 @@ class Matrix3x3 {
   }
 
   friend inline Matrix3x3 operator*(const VType &k, const Matrix3x3 &mb) {
-    return Matrix3x3(mb)*k;
+    return Matrix3x3(mb) * k;
   }
 
   // Matrix multiplication
   inline Matrix3x3 operator*(const Matrix3x3 &mb) const {
+    // clang-format off
     return Matrix3x3(
       m_[0][0] * mb.m_[0][0] + m_[0][1] * mb.m_[1][0] + m_[0][2] * mb.m_[2][0],
       m_[0][0] * mb.m_[0][1] + m_[0][1] * mb.m_[1][1] + m_[0][2] * mb.m_[2][1],
@@ -195,24 +195,21 @@ class Matrix3x3 {
       m_[2][0] * mb.m_[0][0] + m_[2][1] * mb.m_[1][0] + m_[2][2] * mb.m_[2][0],
       m_[2][0] * mb.m_[0][1] + m_[2][1] * mb.m_[1][1] + m_[2][2] * mb.m_[2][1],
       m_[2][0] * mb.m_[0][2] + m_[2][1] * mb.m_[1][2] + m_[2][2] * mb.m_[2][2]);
+    // clang-format on
   }
 
   // Multiplication of a matrix by a vector
   inline MVector operator*(const MVector &v) const {
-    return MVector(
-      m_[0][0] * v[0] + m_[0][1] * v[1] + m_[0][2] * v[2],
-      m_[1][0] * v[0] + m_[1][1] * v[1] + m_[1][2] * v[2],
-      m_[2][0] * v[0] + m_[2][1] * v[1] + m_[2][2] * v[2]);
+    return MVector(m_[0][0] * v[0] + m_[0][1] * v[1] + m_[0][2] * v[2],
+                   m_[1][0] * v[0] + m_[1][1] * v[1] + m_[1][2] * v[2],
+                   m_[2][0] * v[0] + m_[2][1] * v[1] + m_[2][2] * v[2]);
   }
 
   // Return the determinant of the matrix
   inline VType Det() const {
-    return m_[0][0] * m_[1][1] * m_[2][2]
-         + m_[0][1] * m_[1][2] * m_[2][0]
-         + m_[0][2] * m_[1][0] * m_[2][1]
-         - m_[2][0] * m_[1][1] * m_[0][2]
-         - m_[2][1] * m_[1][2] * m_[0][0]
-         - m_[2][2] * m_[1][0] * m_[0][1];
+    return m_[0][0] * m_[1][1] * m_[2][2] + m_[0][1] * m_[1][2] * m_[2][0] +
+           m_[0][2] * m_[1][0] * m_[2][1] - m_[2][0] * m_[1][1] * m_[0][2] -
+           m_[2][1] * m_[1][2] * m_[0][0] - m_[2][2] * m_[1][0] * m_[0][1];
   }
 
   // Return the trace of the matrix
@@ -220,12 +217,8 @@ class Matrix3x3 {
 
   // Return a pointer to the data array for interface with other libraries
   // like opencv
-  VType* Data() {
-    return reinterpret_cast<VType*>(m_);
-  }
-  const VType* Data() const {
-    return reinterpret_cast<const VType*>(m_);
-  }
+  VType *Data() { return reinterpret_cast<VType *>(m_); }
+  const VType *Data() const { return reinterpret_cast<const VType *>(m_); }
 
   // Return matrix element (i,j) with 0<=i<=2 0<=j<=2
   inline VType &operator()(const int i, const int j) {
@@ -247,36 +240,35 @@ class Matrix3x3 {
   inline VType &operator[](const int i) {
     S2_DCHECK_GE(i, 0);
     S2_DCHECK_LT(i, 9);
-    return reinterpret_cast<VType*>(m_)[i];
+    return reinterpret_cast<VType *>(m_)[i];
   }
   inline VType operator[](const int i) const {
     S2_DCHECK_GE(i, 0);
     S2_DCHECK_LT(i, 9);
-    return reinterpret_cast<const VType*>(m_)[i];
+    return reinterpret_cast<const VType *>(m_)[i];
   }
 
   // Return the transposed matrix
   inline Matrix3x3 Transpose() const {
-    return Matrix3x3(m_[0][0], m_[1][0], m_[2][0],
-                     m_[0][1], m_[1][1], m_[2][1],
+    return Matrix3x3(m_[0][0], m_[1][0], m_[2][0],  //
+                     m_[0][1], m_[1][1], m_[2][1],  //
                      m_[0][2], m_[1][2], m_[2][2]);
   }
 
   // Return the transposed of the matrix of the cofactors
   // (Useful for inversion for example)
   inline Matrix3x3 ComatrixTransposed() const {
-    return Matrix3x3(
-      m_[1][1] * m_[2][2] - m_[2][1] * m_[1][2],
-      m_[2][1] * m_[0][2] - m_[0][1] * m_[2][2],
-      m_[0][1] * m_[1][2] - m_[1][1] * m_[0][2],
+    return Matrix3x3(m_[1][1] * m_[2][2] - m_[2][1] * m_[1][2],
+                     m_[2][1] * m_[0][2] - m_[0][1] * m_[2][2],
+                     m_[0][1] * m_[1][2] - m_[1][1] * m_[0][2],
 
-      m_[1][2] * m_[2][0] - m_[2][2] * m_[1][0],
-      m_[2][2] * m_[0][0] - m_[0][2] * m_[2][0],
-      m_[0][2] * m_[1][0] - m_[1][2] * m_[0][0],
+                     m_[1][2] * m_[2][0] - m_[2][2] * m_[1][0],
+                     m_[2][2] * m_[0][0] - m_[0][2] * m_[2][0],
+                     m_[0][2] * m_[1][0] - m_[1][2] * m_[0][0],
 
-      m_[1][0] * m_[2][1] - m_[2][0] * m_[1][1],
-      m_[2][0] * m_[0][1] - m_[0][0] * m_[2][1],
-      m_[0][0] * m_[1][1] - m_[1][0] * m_[0][1]);
+                     m_[1][0] * m_[2][1] - m_[2][0] * m_[1][1],
+                     m_[2][0] * m_[0][1] - m_[0][0] * m_[2][1],
+                     m_[0][0] * m_[1][1] - m_[1][0] * m_[0][1]);
   }
   // Matrix inversion
   inline Matrix3x3 Inverse() const {
@@ -300,23 +292,21 @@ class Matrix3x3 {
   }
 
   // Create a matrix from 3 row vectors
-  static inline Matrix3x3 FromRows(const MVector &v1,
-                              const MVector &v2,
-                              const MVector &v3) {
+  static inline Matrix3x3 FromRows(const MVector &v1, const MVector &v2,
+                                   const MVector &v3) {
     Matrix3x3 temp;
-    temp.Set(v1[0], v1[1], v1[2],
-             v2[0], v2[1], v2[2],
+    temp.Set(v1[0], v1[1], v1[2],  //
+             v2[0], v2[1], v2[2],  //
              v3[0], v3[1], v3[2]);
     return temp;
   }
 
   // Create a matrix from 3 column vectors
-  static inline Matrix3x3 FromCols(const MVector &v1,
-                              const MVector &v2,
-                              const MVector &v3) {
+  static inline Matrix3x3 FromCols(const MVector &v1, const MVector &v2,
+                                   const MVector &v3) {
     Matrix3x3 temp;
-    temp.Set(v1[0], v2[0], v3[0],
-             v1[1], v2[1], v3[1],
+    temp.Set(v1[0], v2[0], v3[0],  //
+             v1[1], v2[1], v3[1],  //
              v1[2], v2[2], v3[2]);
     return temp;
   }
@@ -363,24 +353,23 @@ class Matrix3x3 {
 
   // Return a diagonal matrix with the coefficients in v
   static inline Matrix3x3 Diagonal(const MVector &v) {
-    return Matrix3x3(v[0], VType(), VType(),
-                     VType(), v[1], VType(),
+    return Matrix3x3(v[0], VType(), VType(),  //
+                     VType(), v[1], VType(),  //
                      VType(), VType(), v[2]);
   }
 
   // Return the matrix vvT
   static Matrix3x3 Sym3(const MVector &v) {
-    return Matrix3x3(
-      v[0]*v[0], v[0]*v[1], v[0]*v[2],
-      v[1]*v[0], v[1]*v[1], v[1]*v[2],
-      v[2]*v[0], v[2]*v[1], v[2]*v[2]);
+    return Matrix3x3(v[0] * v[0], v[0] * v[1], v[0] * v[2],  //
+                     v[1] * v[0], v[1] * v[1], v[1] * v[2],  //
+                     v[2] * v[0], v[2] * v[1], v[2] * v[2]);
   }
   // Return a matrix M such that:
   // for each u,  M * u = v.CrossProd(u)
   static Matrix3x3 AntiSym3(const MVector &v) {
-    return Matrix3x3(VType(),    -v[2],     v[1],
-                     v[2],     VType(),    -v[0],
-                     -v[1],       v[0],   VType());
+    return Matrix3x3(VType(), -v[2], v[1],  //
+                     v[2], VType(), -v[0],  //
+                     -v[1], v[0], VType());
   }
 
   // Returns matrix that rotates |rot| radians around axis rot.
@@ -427,8 +416,8 @@ class Matrix3x3 {
     // characteristic polynomial
     // x^3 + a*x^2 + b*x + c
     VType a = -Trace();
-    VType b = m_[0][0]*m_[1][1] + m_[1][1]*m_[2][2] + m_[2][2]*m_[0][0]
-            - m_[1][0]*m_[0][1] - m_[2][1]*m_[1][2] - m_[0][2]*m_[2][0];
+    VType b = m_[0][0] * m_[1][1] + m_[1][1] * m_[2][2] + m_[2][2] * m_[0][0] -
+              m_[1][0] * m_[0][1] - m_[2][1] * m_[1][2] - m_[0][2] * m_[2][0];
     VType c = -Det();
     bool res = MathUtil::RealRootsForCubic(a, b, c, &r1, &r2, &r3);
     (*eig_val)[0] = r1;
@@ -453,9 +442,9 @@ class Matrix3x3 {
                             Matrix3x3 *eig_vec /*nullable*/) const {
     // Compute characteristic polynomial coefficients.
     double c2 = -Trace();
-    double c1 = -(m_[1][0] * m_[1][0] - m_[0][0] * m_[1][1]
-                  - m_[0][0] * m_[2][2] - m_[1][1] * m_[2][2]
-                  + m_[2][0] * m_[2][0] + m_[2][1] * m_[2][1]);
+    double c1 =
+        -(m_[1][0] * m_[1][0] - m_[0][0] * m_[1][1] - m_[0][0] * m_[2][2] -
+          m_[1][1] * m_[2][2] + m_[2][0] * m_[2][0] + m_[2][1] * m_[2][1]);
     double c0 = -(m_[0][0] * m_[1][1] * m_[2][2]    //
                   - m_[2][0] * m_[2][0] * m_[1][1]  //
                   - m_[1][0] * m_[1][0] * m_[2][2]  //
@@ -466,8 +455,8 @@ class Matrix3x3 {
     // NOTE: Cannot reuse general cubic solver MathUtil::RealRootsForCubic()
     // because it doesn't guarantee finding 3 real roots, e.g. it won't always
     // return roots {2, 2, 0} for the cubic x^3 - 4*x^2 + 4*x + epsilon = 0.
-    double q = (c2*c2-3*c1)/9.0;
-    double r = (2*c2*c2*c2-9*c2*c1+27*c0)/54.0;
+    double q = (c2 * c2 - 3 * c1) / 9.0;
+    double r = (2 * c2 * c2 * c2 - 9 * c2 * c1 + 27 * c0) / 54.0;
     // Assume R^2 <= Q^3 so there are three real roots.
     // Avoid sqrt of negative q, which can only happen due to numerical error.
     if (q < 0) q = 0;
@@ -478,19 +467,18 @@ class Matrix3x3 {
     double theta = atan2(q3_r2 <= 0 ? 0 : sqrt(q3_r2), r);
     double c2_3 = c2 / 3;
     (*eig_val)[0] = sqrt_q * cos(theta / 3.0) - c2_3;
-    (*eig_val)[1] = sqrt_q * cos((theta + 2.0 * M_PI)/3.0) - c2_3;
-    (*eig_val)[2] = sqrt_q * cos((theta - 2.0 * M_PI)/3.0) - c2_3;
+    (*eig_val)[1] = sqrt_q * cos((theta + 2.0 * M_PI) / 3.0) - c2_3;
+    (*eig_val)[2] = sqrt_q * cos((theta - 2.0 * M_PI) / 3.0) - c2_3;
 
     // Sort eigen value in decreasing order
     Vector3<int> d_order = eig_val->ComponentOrder();
-    (*eig_val) = MVector((*eig_val)[d_order[2]],
-                         (*eig_val)[d_order[1]],
+    (*eig_val) = MVector((*eig_val)[d_order[2]], (*eig_val)[d_order[1]],
                          (*eig_val)[d_order[0]]);
 
     // Compute eigenvectors
     if (!eig_vec) return;
     for (int i = 0; i < 3; ++i) {
-      MVector r1 , r2 , r3 , e1 , e2 , e3;
+      MVector r1, r2, r3, e1, e2, e3;
       r1[0] = m_[0][0] - (*eig_val)[i];
       r2[0] = m_[1][0];
       r3[0] = m_[2][0];
@@ -515,9 +503,9 @@ class Matrix3x3 {
 
   // Return true is one of the elements of the matrix is NaN
   bool IsNaN() const {
-    for ( int i = 0; i < 3; ++i ) {
-      for ( int j = 0; j < 3; ++j ) {
-        if ( isnan(m_[i][j]) ) {
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        if (isnan(m_[i][j])) {
           return true;
         }
       }
@@ -526,14 +514,10 @@ class Matrix3x3 {
   }
 
   friend bool operator==(const Matrix3x3 &a, const Matrix3x3 &b) {
-    return a.m_[0][0] == b.m_[0][0] &&
-           a.m_[0][1] == b.m_[0][1] &&
-           a.m_[0][2] == b.m_[0][2] &&
-           a.m_[1][0] == b.m_[1][0] &&
-           a.m_[1][1] == b.m_[1][1] &&
-           a.m_[1][2] == b.m_[1][2] &&
-           a.m_[2][0] == b.m_[2][0] &&
-           a.m_[2][1] == b.m_[2][1] &&
+    return a.m_[0][0] == b.m_[0][0] && a.m_[0][1] == b.m_[0][1] &&
+           a.m_[0][2] == b.m_[0][2] && a.m_[1][0] == b.m_[1][0] &&
+           a.m_[1][1] == b.m_[1][1] && a.m_[1][2] == b.m_[1][2] &&
+           a.m_[2][0] == b.m_[2][0] && a.m_[2][1] == b.m_[2][1] &&
            a.m_[2][2] == b.m_[2][2];
   }
 
@@ -541,10 +525,10 @@ class Matrix3x3 {
     return !(a == b);
   }
 
-  friend std::ostream &operator <<(std::ostream &out, const Matrix3x3 &mb) {
+  friend std::ostream &operator<<(std::ostream &out, const Matrix3x3 &mb) {
     int i, j;
     for (i = 0; i < 3; i++) {
-      if (i ==0) {
+      if (i == 0) {
         out << "[";
       } else {
         out << " ";
@@ -562,13 +546,13 @@ class Matrix3x3 {
   }
 
   template <typename H>
-  friend H AbslHashValue(H h, const Matrix3x3& m) {
+  friend H AbslHashValue(H h, const Matrix3x3 &m) {
     return H::combine_contiguous(std::move(h), m.Data(), 3 * 3);
   }
 };
 
-typedef Matrix3x3<int>    Matrix3x3_i;
-typedef Matrix3x3<float>  Matrix3x3_f;
+typedef Matrix3x3<int> Matrix3x3_i;
+typedef Matrix3x3<float> Matrix3x3_f;
 typedef Matrix3x3<double> Matrix3x3_d;
 
 


### PR DESCRIPTION
    * Remove deprecated s2textformat functions (where ...OrDie should be
      used instead)
    * Use absl::make_unique instead of raw new in some places
    * Add missing includes
    * Deprecate many functions taking const pointers; change to const
      references
    * Deprecate InterpolateAtDistance (use GetPointOnLine instead)