### PR TITLE
Support building in -std=c++20 mode.

### DIFF
--- a/src/s2/util/math/vector.h
+++ b/src/s2/util/math/vector.h
@@ -98,20 +98,25 @@ class BasicVector {
   }
 
   // TODO(user): Relationals should be nonmembers.
-  bool operator==(const D& b) const {
-    const T* ap = static_cast<const D&>(*this).Data();
-    return std::equal(ap, ap + this->Size(), b.Data());
+  bool operator==(const BasicVector<VecTemplate, T, N>& b) const {
+    const T* ap = AsD().Data();
+    return std::equal(ap, ap + this->Size(), b.AsD().Data());
   }
-  bool operator!=(const D& b) const { return !(AsD() == b); }
-  bool operator<(const D& b) const {
-    const T* ap = static_cast<const D&>(*this).Data();
-    const T* bp = b.Data();
+  bool operator<(const BasicVector<VecTemplate, T, N>& b) const {
+    const T* ap = AsD().Data();
+    const T* bp = b.AsD().Data();
     return std::lexicographical_compare(ap, ap + this->Size(), bp,
                                         bp + b.Size());
   }
-  bool operator>(const D& b) const { return b < AsD(); }
-  bool operator<=(const D& b) const { return !(AsD() > b); }
-  bool operator>=(const D& b) const { return !(AsD() < b); }
+  bool operator>(const BasicVector<VecTemplate, T, N>& b) const {
+    return b < *this;
+  }
+  bool operator<=(const BasicVector<VecTemplate, T, N>& b) const {
+    return !(*this > b);
+  }
+  bool operator>=(const BasicVector<VecTemplate, T, N>& b) const {
+    return !(*this < b);
+  }
 
   D& operator+=(const D& b) {
     PlusEq(static_cast<D&>(*this).Data(), b.Data(), IdxSeqN{});


### PR DESCRIPTION
Types on both sides of comparison operators must be the same.

Bug: chromium:1284275