### PR TITLE
Missing include statement for abseil Hash

### DIFF
--- a/src/s2/s2cell_union.h
+++ b/src/s2/s2cell_union.h
@@ -25,6 +25,7 @@
 
 #include "absl/base/macros.h"
 #include "absl/flags/flag.h"
+#include "absl/hash/hash.h"
 
 #include "s2/base/commandlineflags.h"
 #include "s2/base/integral_types.h"


### PR DESCRIPTION
I ran into this error
`src/s2/s2cell_union.h:413:41: error: no member named 'HashOf' in namespace 'absl'`
This PR adds
`#include "absl/hash/hash.h`