### PR TITLE
Fix build on big-endian architectures

### DIFF
--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -142,7 +142,7 @@ inline static uint64 BN_ext_get_uint64(const BIGNUM* bn) {
 #ifdef IS_LITTLE_ENDIAN
   S2_CHECK_EQ(BN_bn2lebinpad(bn, reinterpret_cast<unsigned char*>(&r),
               sizeof(r)), sizeof(r));
-#elif IS_BIG_ENDIAN
+#elif defined(IS_BIG_ENDIAN)
   S2_CHECK_EQ(BN_bn2binpad(bn, reinterpret_cast<unsigned char*>(&r),
               sizeof(r)), sizeof(r));
 #else


### PR DESCRIPTION
```
/usr/bin/c++ -DS2_USE_GFLAGS -DS2_USE_GLOG -Ds2_EXPORTS -I/wrkdirs/usr/ports/graphics/s2/work/s2geometry-0.10.0/src -O2 -pipe  -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing   -mcpu=power7 -isystem /usr/local/include -std=c++11 -O2 -pipe  -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing   -mcpu=power7 -isystem /usr/local/include -std=c++11 -fPIC   -Wno-attributes -Wno-deprecated-declarations -pthread -std=c++11 -MD -MT CMakeFiles/s2.dir/src/s2/util/math/exactfloat/exactfloat.cc.o -MF CMakeFiles/s2.dir/src/s2/util/math/exactfloat/exactfloat.cc.o.d -o CMakeFiles/s2.dir/src/s2/util/math/exactfloat/exactfloat.cc.o -c /wrkdirs/usr/ports/graphics/s2/work/s2geometry-0.10.0/src/s2/util/math/exactfloat/exactfloat.cc
/wrkdirs/usr/ports/graphics/s2/work/s2geometry-0.10.0/src/s2/util/math/exactfloat/exactfloat.cc:144:20: error: expected value in expression
```