### PR TITLE
python: Named component accessors for S2Point

### DIFF
--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -22,6 +22,15 @@ import pywraps2 as s2
 
 class PyWrapS2TestCase(unittest.TestCase):
 
+  def testS2PointFromRawToNamedCorrectly(self):
+      x = 1.0
+      y = 2.0
+      z = 3.0
+      point = s2.S2Point_FromRaw(x, y, z)
+      self.assertEqual(x, point.x())
+      self.assertEqual(y, point.y())
+      self.assertEqual(z, point.z())
+
   def testContainsIsWrappedCorrectly(self):
     london = s2.S2LatLngRect(s2.S2LatLng.FromDegrees(51.3368602, 0.4931979),
                              s2.S2LatLng.FromDegrees(51.7323965, 0.1495211))

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -163,6 +163,9 @@ std::vector<S2Polyline *> *out(std::vector<S2Polyline *> temp) {
 // difficult to wrap correctly.
 class S2Point {
  public:
+  double x();
+  double y();
+  double z();
   double Norm();
   S2Point Normalize();
   ~S2Point();


### PR DESCRIPTION
With this small change we can code something like this:

```python
import numpy as np
from pywraps2 import S2Cell, S2CellId
from matplotlib import pyplot as plt

def surf4face(f, l):
    m = 2**l; m1 = m + 1; m2 = m - 1
    k = range(0, 2**S2CellId.kMaxLevel, 2**(S2CellId.kMaxLevel - l))
    x = np.empty((m1,m1)); y = np.empty((m1,m1)); z = np.empty((m1,m1));
    for i in range(m):
        for j in range(m):
            c = S2Cell(S2CellId.FromFaceIJ(f, k[i], k[j]).parent(l))
            v = c.GetVertex(0)
            x[i][j] = v.x(); y[i][j] = v.y(); z[i][j] = v.z();
            if i == m2:
                v = c.GetVertex(1)
                x[m][j] = v.x(); y[m][j] = v.y(); z[m][j] = v.z();
            if j == m2:
                v = c.GetVertex(3)
                x[i][m] = v.x(); y[i][m] = v.y(); z[i][m] = v.z();
            if i == m2 and j == m2:
                v = c.GetVertex(2)
                x[m][m] = v.x(); y[m][m] = v.y(); z[m][m] = v.z();
    return (x, y, z)

fig = plt.figure()
ax = fig.add_subplot(projection='3d')

for f in range(6):
    s = surf4face(f, 2)
    ax.plot_surface(*s, color='blue')
    ax.plot_wireframe(*s, color='green')

fig.savefig('s2sphere.svg')
```

to render this:

![s2sphere](https://user-images.githubusercontent.com/8400779/185762982-eedd0ec4-82c7-4dc7-a300-3951d5ab2e67.svg)

and not only...