### PR TITLE
Fix -DCMAKE_CXX_STANDARD ignored by CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ endif()
 # s2geometry needs to use the same C++ standard that absl used to avoid
 # undefined symbol errors since ABSL_HAVE_STD_STRING_VIEW etc will
 # end up defined differently.  There is probably a better way to achieve
-# this than assuming what absl used.
-set(CMAKE_CXX_STANDARD 11)
+# this than assuming what absl used. 
+# Using CACHE allows the user to override the default.
+(CMAKE_CXX_STANDARD 11 CACHE)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # No compiler-specific extensions, i.e. -std=c++11, not -std=gnu++11.
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
The command line argument for setting the C++ standard to use is ignored. This change allows the default to remain 11 but allow for the user to override it.

Resolve #270 