### PR TITLE
README.md: Add warning about API/ABI stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ introduction to the [basic types](http://s2geometry.io/devguide/basic_types).
 
 S2 documentation can be found on [s2geometry.io](http://s2geometry.io).
 
+## API/ABI Stability
+
+Note that all [releases](https://github.com/google/s2geometry/releases) are
+version 0.x, so there are
+[no API or ABI stability guarantees](https://semver.org/#spec-item-4).
+Starting with 1.0 we will adhere to [SemVer](https://semver.org/).
+
+The Python API is particularly unstable, and it is planned that the SWIGged
+API will be replaced by a pybind11 version with more Pythonic names and more
+complete functionality.
+
 ## Requirements for End Users
 
 * [CMake](http://www.cmake.org/)


### PR DESCRIPTION
#278 (ABI compatability and SOVERSION) asked questions about ABI stability.

Clarify that nothing is stable while we are on 0.x releases, but we will adhere to SemVer starting with 1.0.