### PR TITLE
Remove trailing null from Python strings

### DIFF
--- a/src/python/pywraps2_test.py
+++ b/src/python/pywraps2_test.py
@@ -826,6 +826,14 @@ class PyWrapS2TestCase(unittest.TestCase):
     self.assertFalse(s2.UpdateMinDistance(pC, p1, p2, md))
     self.assertAlmostEqual(0.1478883, md.degrees())
 
+  def testS1AngleToString(self):
+    a = s2.S1Angle.Degrees(123)
+    self.assertEqual("123.0000000", str(a))
+
+  def testS2CellIdToString(self):
+    a = s2.S2CellId(12345)
+    self.assertEqual("0/000000000000000000000001200130", str(a))
+
 class RegionTermIndexerTest(unittest.TestCase):
   def _randomCaps(self, query_type, **indexer_options):
     # This function creates an index consisting either of points (if

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -922,7 +922,7 @@ public:
   %extend type {
     std::string __str__() {
       std::ostringstream output;
-      output << *$self << std::ends;
+      output << *$self;
       return output.str();
     }
   }


### PR DESCRIPTION
Python strings have an explicit length, not a terminating zero byte.

Before:

$ python
Python 3.10.8 (main, Oct 11 2022, 11:35:05) [GCC 11.3.0] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> import pywraps2 as s2
>>> str(s2.S1Angle.Degrees(123))
'123.0000000\x00'
>>> str(s2.S2CellId(12345))
'0/000000000000000000000001200130\x00'

After:

$ python
Python 3.10.8 (main, Oct 11 2022, 11:35:05) [GCC 11.3.0] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> import pywraps2 as s2
>>> str(s2.S1Angle.Degrees(123))
'123.0000000'
>>> str(s2.S2CellId(12345))
'0/000000000000000000000001200130'