### PR TITLE
Allow already have abseil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,9 @@ if (WITH_GFLAGS)
     add_definitions(-DS2_USE_GFLAGS)
 endif()
 
-find_package(absl REQUIRED)
+if (NOT TARGET absl::base)
+    find_package(absl REQUIRED)
+endif()
 find_package(OpenSSL REQUIRED)
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)


### PR DESCRIPTION
We don't install abseil, we use add_subdirectory. so for us I needs patch like this.

Is it ok for you? The main idea if we already have abseil targets we don't need to find them