### PR TITLE
Fix possible warning in header

### DIFF
--- a/src/s2/base/logging.h
+++ b/src/s2/base/logging.h
@@ -62,7 +62,7 @@ class S2LogMessage {
     : severity_(severity), stream_(stream) {
     if (enabled()) {
       stream_ << file << ":" << line << " "
-              << absl::LogSeverityName(severity) << " ";
+              << absl::LogSeverityName(severity_) << " ";
     }
   }
   ~S2LogMessage() { if (enabled()) stream_ << std::endl; }


### PR DESCRIPTION
if no defined ABSL_MIN_LOG_LEVEL severity_ will be unused.

Because its header it's pretty inconvenient.

As an alternative solution will be make field under ifdef.
But in this case layout of class will be changed, so I don't know, is it valid for you, I decide to make more simple fix.
