### PR TITLE
Add ability to create Python wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,8 @@ python setup.py bdist_wheel
 
 The resulting wheel will be in the `dist` directory.
 
-> If OpenSSL is in a non-standard location (e.g., as installed by Homebrew on
-> macOS) make sure to set `OPENSSL_ROOT_DIR` when calling `setup.py`, for 
-> example: `OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.1.0 python setup.py bdist_wheel`.
+> If OpenSSL is in a non-standard location make sure to set `OPENSSL_ROOT_DIR` 
+> when calling `setup.py`, see above for more information.
 
 ## Other S2 implementations
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Disable building of shared libraries with `-DBUILD_SHARED_LIBS=OFF`.
 
 Enable the python interface with `-DWITH_PYTHON=ON`.
 
+If OpenSSL is installed in a non-standard location set `OPENSSL_ROOT_DIR`
+before running configure, for example on macOS:
+```
+OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.1.0 cmake -DCMAKE_PREFIX_PATH=/opt/homebrew -DCMAKE_CXX_STANDARD=17
+```
+
 ## Installing
 
 From `build` subdirectory:
@@ -179,6 +185,15 @@ Version 4.0 is required, but it should be easy to make it work 3.0 or probably
 even 2.0.
 
 Python 3 is required.
+
+### Creating wheels
+```
+python setup.py bdist_wheel
+```
+
+> If OpenSSL is in a non-standard location (e.g., as installed by Homebrew on
+> macOS) make sure to set `OPENSSL_ROOT_DIR` when calling `setup.py`, for 
+> example: `OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.1.0 python setup.py bdist_wheel`.
 
 ## Other S2 implementations
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,20 @@ even 2.0.
 Python 3 is required.
 
 ### Creating wheels
+First, make a virtual environment and install `cmake_build_extension` and `wheel`
+into it:
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install cmake_build_extension wheel
+```
+
+Then build the wheel:
 ```
 python setup.py bdist_wheel
 ```
+
+The resulting wheel will be in the `dist` directory.
 
 > If OpenSSL is in a non-standard location (e.g., as installed by Homebrew on
 > macOS) make sure to set `OPENSSL_ROOT_DIR` when calling `setup.py`, for 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "setuptools_scm[toml]",
+    "cmake_build_extension",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,13 @@ version = 0.10.0
 description = Python packaging of s2geometry
 author = Brian Miles
 author_email = selimnairb@gmail.com
-license= MIT
+license= Apache 2
 project_urls =
-    Source  = https://github.com/selimnairb/s2geometry
+    Source  = https://github.com/google/s2geometry
 classifiers =
+    Programming Language :: Python :: 3
+    Operating System :: POSIX
+    License :: OSI Approved :: Apache Software License
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = pywraps2
+version = 0.10.0
+description = Python packaging of s2geometry
+author = Brian Miles
+author_email = selimnairb@gmail.com
+license= MIT
+project_urls =
+    Source  = https://github.com/selimnairb/s2geometry
+classifiers =
+
+[options]
+zip_safe = False
+packages = find:
+package_dir = =src
+python_requres = >=3.7
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = s2geometry
-version = 0.10.0
+version = 0.11.0.dev1
 description = Python packaging of s2geometry
 author = Brian Miles
 author_email = selimnairb@gmail.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = pywraps2
+name = s2geometry
 version = 0.10.0
 description = Python packaging of s2geometry
 author = Brian Miles

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setuptools.setup(
                                         f"-DPython3_ROOT_DIR={Path(sys.prefix)}",
                                         '-DCALL_FROM_SETUP_PY:BOOL=ON',
                                         '-DBUILD_SHARED_LIBS:BOOL=OFF',
-                                        '-DCMAKE_CXX_STANDARD=17',
                                         '-DWITH_PYTHON=ON'
                                     ]
         )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
             # This could be anything you like, it is used to create build folders
             name="SwigBindings",
             # Name of the resulting package name (import mymath_swig)
-            install_prefix="pywraps2",
+            install_prefix="s2geometry",
             # Selects the folder where the main CMakeLists.txt is stored
             # (it could be a subfolder)
             source_dir=str(Path(__file__).parent.absolute()),

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import cmake_build_extension
+import setuptools
+
+# This example is compliant with PEP517 and PEP518. It uses the setup.cfg file to store
+# most of the package metadata. However, build extensions are not supported and must be
+# configured in the setup.py.
+setuptools.setup(
+    # The resulting "mymath" archive contains two packages: mymath_swig and mymath_pybind.
+    # This approach separates the two bindings types, typically just one of them is used.
+    ext_modules=[
+        cmake_build_extension.CMakeExtension(
+            # This could be anything you like, it is used to create build folders
+            name="SwigBindings",
+            # Name of the resulting package name (import mymath_swig)
+            install_prefix="pywraps2",
+            # Selects the folder where the main CMakeLists.txt is stored
+            # (it could be a subfolder)
+            source_dir=str(Path(__file__).parent.absolute()),
+            cmake_configure_options=[
+                                        # This option points CMake to the right Python interpreter, and helps
+                                        # the logic of FindPython3.cmake to find the active version
+                                        f"-DPython3_ROOT_DIR={Path(sys.prefix)}",
+                                        '-DCALL_FROM_SETUP_PY:BOOL=ON',
+                                        '-DBUILD_SHARED_LIBS:BOOL=OFF',
+                                        '-DCMAKE_CXX_STANDARD=17',
+                                        '-DWITH_PYTHON=ON'
+                                    ]
+        )
+    ],
+    cmdclass=dict(
+        # Enable the CMakeExtension entries defined above
+        build_ext=cmake_build_extension.BuildExtension,
+    ),
+)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
                                         f"-DPython3_ROOT_DIR={Path(sys.prefix)}",
                                         '-DCALL_FROM_SETUP_PY:BOOL=ON',
                                         '-DBUILD_SHARED_LIBS:BOOL=OFF',
+                                        '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
                                         '-DWITH_PYTHON=ON'
                                     ]
         )

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,13 @@ from pathlib import Path
 import cmake_build_extension
 import setuptools
 
-# This example is compliant with PEP517 and PEP518. It uses the setup.cfg file to store
-# most of the package metadata. However, build extensions are not supported and must be
-# configured in the setup.py.
+
 setuptools.setup(
-    # The resulting "mymath" archive contains two packages: mymath_swig and mymath_pybind.
-    # This approach separates the two bindings types, typically just one of them is used.
     ext_modules=[
         cmake_build_extension.CMakeExtension(
             # This could be anything you like, it is used to create build folders
             name="SwigBindings",
-            # Name of the resulting package name (import mymath_swig)
+            # Name of the resulting package name (import s2geometry)
             install_prefix="s2geometry",
             # Selects the folder where the main CMakeLists.txt is stored
             # (it could be a subfolder)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,42 +1,42 @@
 # Set SWIG policies
-#cmake_policy(SET CMP0078 NEW)
-#cmake_policy(SET CMP0086 NEW)
+cmake_policy(SET CMP0078 NEW)
+cmake_policy(SET CMP0086 NEW)
 
 # Handle where to install the resulting Python package
 if(CALL_FROM_SETUP_PY)
     # The CMakeExtension will set CMAKE_INSTALL_PREFIX to the root
     # of the resulting wheel archive
-    set(PYWRAPS2_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+    set(S2GEOMETRY_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 else()
     # The Python package is installed directly in the folder of the
     # detected interpreter (system, user, or virtualenv)
-    set(PYWRAPS2_INSTALL_PREFIX ${Python3_SITELIB})
+    set(S2GEOMETRY_INSTALL_PREFIX ${Python3_SITELIB})
 endif()
 
 include(${SWIG_USE_FILE})
 include_directories(${Python3_INCLUDE_DIRS})
 
 set(CMAKE_SWIG_FLAGS "")
-set_property(SOURCE s2.i PROPERTY SWIG_FLAGS "-module" "pywraps2")
+set_property(SOURCE s2.i PROPERTY SWIG_FLAGS "-module" "s2geometry")
 set_property(SOURCE s2.i PROPERTY CPLUSPLUS ON)
 
-swig_add_library(pywraps2 LANGUAGE python SOURCES s2.i)
+swig_add_library(s2geometry LANGUAGE python SOURCES s2.i)
 
-swig_link_libraries(pywraps2 ${Python3_LIBRARIES} s2)
+swig_link_libraries(s2geometry ${Python3_LIBRARIES} s2)
 enable_testing()
-add_test(NAME pywraps2_test COMMAND
+add_test(NAME s2geometry_test COMMAND
          ${Python3_EXECUTABLE}
-         "${PROJECT_SOURCE_DIR}/src/python/pywraps2_test.py")
-set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
+         "${PROJECT_SOURCE_DIR}/src/python/s2geometry_test.py")
+set_property(TEST s2geometry_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
 # Install the wrapper.
-install(TARGETS _pywraps2 DESTINATION ${PYWRAPS2_INSTALL_PREFIX})
+install(TARGETS s2geometry DESTINATION ${S2GEOMETRY_INSTALL_PREFIX})
 
 # Install swig-generated Python file (we rename it to __init__.py as it will
-# ultimately end up in a directory called pywraps2 in site-packages, which will
+# ultimately end up in a directory called s2geometry in site-packages, which will
 # serve as the module directory.
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pywraps2.py"
-        DESTINATION ${PYWRAPS2_INSTALL_PREFIX}
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/s2geometry.py"
+        DESTINATION ${S2GEOMETRY_INSTALL_PREFIX}
         RENAME __init__.py
-        COMPONENT pywraps2)
+        COMPONENT s2geometry)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,5 +1,6 @@
-# Set SWIG policies
+# Generate standard target names.
 cmake_policy(SET CMP0078 NEW)
+# Honor SWIG_MODULE_NAME via -module flag.
 cmake_policy(SET CMP0086 NEW)
 
 # Handle where to install the resulting Python package

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy(SET CMP0078 NEW)
 cmake_policy(SET CMP0086 NEW)
 
 # Handle where to install the resulting Python package
-if(CALL_FROM_SETUP_PY)
+if (CALL_FROM_SETUP_PY)
     # The CMakeExtension will set CMAKE_INSTALL_PREFIX to the root
     # of the resulting wheel archive
     set(S2GEOMETRY_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,3 +1,18 @@
+# Set SWIG policies
+#cmake_policy(SET CMP0078 NEW)
+#cmake_policy(SET CMP0086 NEW)
+
+# Handle where to install the resulting Python package
+if(CALL_FROM_SETUP_PY)
+    # The CMakeExtension will set CMAKE_INSTALL_PREFIX to the root
+    # of the resulting wheel archive
+    set(PYWRAPS2_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+else()
+    # The Python package is installed directly in the folder of the
+    # detected interpreter (system, user, or virtualenv)
+    set(PYWRAPS2_INSTALL_PREFIX ${Python3_SITELIB})
+endif()
+
 include(${SWIG_USE_FILE})
 include_directories(${Python3_INCLUDE_DIRS})
 
@@ -16,6 +31,12 @@ set_property(TEST pywraps2_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
 # Install the wrapper.
-install(TARGETS _pywraps2 DESTINATION ${Python3_SITELIB})
-install(FILES "${PROJECT_BINARY_DIR}/python/pywraps2.py"
-        DESTINATION ${Python3_SITELIB})
+install(TARGETS _pywraps2 DESTINATION ${PYWRAPS2_INSTALL_PREFIX})
+
+# Install swig-generated Python file (we rename it to __init__.py as it will
+# ultimately end up in a directory called pywraps2 in site-packages, which will
+# serve as the module directory.
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pywraps2.py"
+        DESTINATION ${PYWRAPS2_INSTALL_PREFIX}
+        RENAME __init__.py
+        COMPONENT pywraps2)

--- a/src/python/s2geometry_test.py
+++ b/src/python/s2geometry_test.py
@@ -17,7 +17,7 @@
 import unittest
 from collections import defaultdict
 
-import pywraps2 as s2
+import s2geometry as s2
 
 
 class PyWrapS2TestCase(unittest.TestCase):
@@ -1039,38 +1039,38 @@ class S2PolygonTestCase(unittest.TestCase):
 
 class S2ChordAngleTest(unittest.TestCase):
   def testBasic(self):
-    ca = s2.S1ChordAngle(s2.S1Angle_Degrees(100))
+    ca = s2.S1ChordAngle(s2.S1Angle.Degrees(100))
     self.assertAlmostEqual(100, ca.degrees())
 
   def testArithmetic(self):
-    ca1 = s2.S1ChordAngle(s2.S1Angle_Degrees(10))
-    ca2 = s2.S1ChordAngle(s2.S1Angle_Degrees(20))
+    ca1 = s2.S1ChordAngle(s2.S1Angle.Degrees(10))
+    ca2 = s2.S1ChordAngle(s2.S1Angle.Degrees(20))
     ca3 = ca1 + ca2
     self.assertAlmostEqual(30, ca3.degrees())
     ca4 = ca2 - ca1
     self.assertAlmostEqual(10, ca4.degrees())
 
   def testComparison(self):
-    ca1 = s2.S1ChordAngle(s2.S1Angle_Degrees(10))
-    ca2 = s2.S1ChordAngle(s2.S1Angle_Degrees(20))
+    ca1 = s2.S1ChordAngle(s2.S1Angle.Degrees(10))
+    ca2 = s2.S1ChordAngle(s2.S1Angle.Degrees(20))
     self.assertTrue(ca1 < ca2)
     self.assertTrue(ca2 > ca1)
     self.assertFalse(ca1 > ca2)
     self.assertFalse(ca2 < ca1)
 
-    ca3 = s2.S1ChordAngle(s2.S1Angle_Degrees(10))
+    ca3 = s2.S1ChordAngle(s2.S1Angle.Degrees(10))
     self.assertTrue(ca1 == ca3)
     self.assertFalse(ca1 == ca2)
     self.assertFalse(ca1 != ca3)
     self.assertTrue(ca1 != ca2)
 
   def testInfinity(self):
-    ca1 = s2.S1ChordAngle(s2.S1Angle_Degrees(179))
+    ca1 = s2.S1ChordAngle(s2.S1Angle.Degrees(179))
     ca2 = s2.S1ChordAngle.Infinity()
     self.assertTrue(ca2 > ca1)
 
   def testCopy(self):
-    ca1 = s2.S1ChordAngle(s2.S1Angle_Degrees(100))
+    ca1 = s2.S1ChordAngle(s2.S1Angle.Degrees(100))
     ca2 = s2.S1ChordAngle(ca1)
     self.assertAlmostEqual(100, ca2.degrees())
 
@@ -1092,7 +1092,7 @@ class S2BufferOperationTest(unittest.TestCase):
     self.assertEqual(4, loop.num_vertices())
 
   def testRadius(self):
-    self.opts.set_buffer_radius(s2.S1Angle_Degrees(0.001))
+    self.opts.set_buffer_radius(s2.S1Angle.Degrees(0.001))
     op = s2.S2BufferOperation(self.layer, self.opts)
 
     cell1 = s2.S2Cell(s2.S2CellId(s2.S2LatLng.FromDegrees(3.0, 4.0)).parent(8))
@@ -1104,7 +1104,7 @@ class S2BufferOperationTest(unittest.TestCase):
     self.assertEqual(20, loop.num_vertices())
 
   def testRadiusAndError(self):
-    self.opts.set_buffer_radius(s2.S1Angle_Degrees(0.001))
+    self.opts.set_buffer_radius(s2.S1Angle.Degrees(0.001))
     self.opts.set_error_fraction(0.1)
     op = s2.S2BufferOperation(self.layer, self.opts)
 
@@ -1117,7 +1117,7 @@ class S2BufferOperationTest(unittest.TestCase):
     self.assertEqual(12, loop.num_vertices())
 
   def testPoint(self):
-    self.opts.set_buffer_radius(s2.S1Angle_Degrees(0.001))
+    self.opts.set_buffer_radius(s2.S1Angle.Degrees(0.001))
     op = s2.S2BufferOperation(self.layer, self.opts)
 
     op.AddPoint(s2.S2LatLng.FromDegrees(14.0, 15.0).ToPoint())


### PR DESCRIPTION
This pull request enables the creation of Python wheels via integration with CMake. This also changes the name of the Python library from `pywraps2` to the more ergonomic `s2geometry`.