### PR TITLE
Add a CMake option BUILD_TESTS to decide whether to build S2 unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_feature_info(SHARED_LIBS BUILD_SHARED_LIBS
                  "builds shared libraries instead of static.")
 
 option(BUILD_EXAMPLES "Build s2 documentation examples." ON)
-option(BUILD_TESTS "Build s2 unittests." OFF)
+option(BUILD_TESTS "Build s2 unittests." ON)
 
 option(WITH_PYTHON "Add python interface" OFF)
 add_feature_info(PYTHON WITH_PYTHON "provides python interface to S2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,8 +432,12 @@ install(TARGETS ${S2_TARGETS}
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-message("GOOGLETEST_ROOT: ${GOOGLETEST_ROOT}")
-if (GOOGLETEST_ROOT AND BUILD_TESTS)
+if (BUILD_TESTS)
+  if (NOT GOOGLETEST_ROOT)
+    message(FATAL_ERROR "BUILD_TESTS requires GOOGLETEST_ROOT")
+  endif()
+  message("GOOGLETEST_ROOT: ${GOOGLETEST_ROOT}")
+
   add_subdirectory(${GOOGLETEST_ROOT}/googlemock build_gmock)
   include_directories(${GOOGLETEST_ROOT}/googlemock/include)
   include_directories(${GOOGLETEST_ROOT}/googletest/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_feature_info(SHARED_LIBS BUILD_SHARED_LIBS
                  "builds shared libraries instead of static.")
 
 option(BUILD_EXAMPLES "Build s2 documentation examples." ON)
+option(BUILD_TESTS "Build s2 unittests." OFF)
 
 option(WITH_PYTHON "Add python interface" OFF)
 add_feature_info(PYTHON WITH_PYTHON "provides python interface to S2")
@@ -432,7 +433,7 @@ install(TARGETS ${S2_TARGETS}
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
 message("GOOGLETEST_ROOT: ${GOOGLETEST_ROOT}")
-if (GOOGLETEST_ROOT)
+if (GOOGLETEST_ROOT AND BUILD_TESTS)
   add_subdirectory(${GOOGLETEST_ROOT}/googlemock build_gmock)
   include_directories(${GOOGLETEST_ROOT}/googlemock/include)
   include_directories(${GOOGLETEST_ROOT}/googletest/include)


### PR DESCRIPTION
In the use case of using s2geometry as a thirdparty library of a project, it's not needed to build S2 unit tests, but it's possible to use test utilities in src/s2/s2testing.
In this case, `s2testing` has to be exported, but unit tests are not necessary to build.
This patch adds an option `BUILD_TESTS` to decide whether to build S2 unit tests.
