### PR TITLE
value_lexicon: Fix build with abseil LTS 2023-08-02

### DIFF
--- a/src/s2/value_lexicon.h
+++ b/src/s2/value_lexicon.h
@@ -28,14 +28,6 @@
 #include "s2/base/integral_types.h"
 #include "s2/util/gtl/dense_hash_set.h"
 
-class S2Point;
-namespace absl {
-namespace hash_internal {
-template <typename T>
-struct Hash;
-}  // namespace hash_internal
-}  // namespace absl
-
 // ValueLexicon is a class that maps distinct values to sequentially numbered
 // integer identifiers.  It automatically eliminates duplicates and uses a
 // compact representation.  See also SequenceLexicon.


### PR DESCRIPTION
Fix the build error like:
```
In file included from /usr/local/include/absl/hash/hash.h:85,
                 from /home/xxx/dev/s2geometry/src/s2/s2point.h:24,
                 from /home/xxx/dev/s2geometry/src/s2/value_lexicon_test.cc:28:
/usr/local/include/absl/hash/internal/hash.h:247:23: error: reference to 'hash_internal' is ambiguous
  247 |   using is_hashable = absl::hash_internal::is_hashable<T>;
      |                       ^~~~
In file included from /usr/local/include/absl/hash/internal/hash.h:49,
                 from /usr/local/include/absl/hash/hash.h:85,
                 from /home/xxx/dev/s2geometry/src/s2/s2point.h:24,
                 from /home/xxx/dev/s2geometry/src/s2/value_lexicon_test.cc:28:
/usr/local/include/absl/hash/internal/city.h:57:11: note: candidates are: 'namespace absl::lts_20230802::hash_internal { }'
   57 | namespace hash_internal {
      |           ^~~~~~~~~~~~~
In file included from /home/xxx/dev/s2geometry/src/s2/value_lexicon_test.cc:18:
/home/xxx/dev/s2geometry/src/s2/value_lexicon.h:33:11: note:                 'namespace absl::hash_internal { }'
   33 | namespace hash_internal {
      |           ^~~~~~~~~~~~~
```
Because absl::hash_internal::Hash is not used in this file, it's safe to remove it.