### PR TITLE
Fix several MSVC build issues

### DIFF
--- a/src/s2/s1angle.cc
+++ b/src/s2/s1angle.cc
@@ -50,7 +50,7 @@ std::ostream& operator<<(std::ostream& os, S1Angle a) {
   char buffer[13];
   int sz = snprintf(buffer, sizeof(buffer), "%.7f", degrees);
   // Fix sign/unsign comparison for client that use `-Wextra` (e.g. Chrome).
-  if (sz >= 0 && static_cast<uint>(sz) < sizeof(buffer)) {
+  if (sz >= 0 && static_cast<uint32_t>(sz) < sizeof(buffer)) {
     return os << buffer;
   } else {
     return os << degrees;

--- a/src/s2/s2lax_polygon_shape.h
+++ b/src/s2/s2lax_polygon_shape.h
@@ -259,19 +259,19 @@ inline S2Shape::ChainPosition S2LaxPolygonShape::chain_position(int e) const {
   // Test if this edge belongs to the loop returned by the previous call.
   const uint32* start = &loop_starts_[0] +
                         prev_loop_.load(std::memory_order_relaxed);
-  if (static_cast<uint>(e) >= start[0] && static_cast<uint>(e) < start[1]) {
+  if (static_cast<uint32_t>(e) >= start[0] && static_cast<uint32_t>(e) < start[1]) {
     // This edge belongs to the same loop as the previous call.
   } else {
-    if (static_cast<uint>(e) == start[1]) {
+    if (static_cast<uint32_t>(e) == start[1]) {
       // This is the edge immediately following the previous loop.
       do {
         ++start;
-      } while (static_cast<uint>(e) == start[1]);
+      } while (static_cast<uint32_t>(e) == start[1]);
     } else {
       start = &loop_starts_[0];
       constexpr int kMaxLinearSearchLoops = 12;  // From benchmarks.
       if (num_loops() <= kMaxLinearSearchLoops) {
-        while (start[1] <= static_cast<uint>(e)) ++start;
+        while (start[1] <= static_cast<uint32_t>(e)) ++start;
       } else {
         start = std::upper_bound(start + 1, start + num_loops(), e) - 1;
       }
@@ -304,20 +304,20 @@ inline S2Shape::ChainPosition EncodedS2LaxPolygonShape::chain_position(int e)
   }
   constexpr int kMaxLinearSearchLoops = 12;  // From benchmarks.
   int i = prev_loop_.load(std::memory_order_relaxed);
-  if (i == 0 && static_cast<uint>(e) < loop_starts_[1]) {
+  if (i == 0 && static_cast<uint32_t>(e) < loop_starts_[1]) {
     return ChainPosition(0, e);  // Optimization for first loop.
   }
-  if (static_cast<uint>(e) >= loop_starts_[i] &&
-      static_cast<uint>(e) < loop_starts_[i + 1]) {
+  if (static_cast<uint32_t>(e) >= loop_starts_[i] &&
+      static_cast<uint32_t>(e) < loop_starts_[i + 1]) {
     // This edge belongs to the same loop as the previous call.
   } else {
-    if (static_cast<uint>(e) == loop_starts_[i + 1]) {
+    if (static_cast<uint32_t>(e) == loop_starts_[i + 1]) {
       // This is the edge immediately following the previous loop.
       do {
         ++i;
-      } while (static_cast<uint>(e) == loop_starts_[i + 1]);
+      } while (static_cast<uint32_t>(e) == loop_starts_[i + 1]);
     } else if (num_loops() <= kMaxLinearSearchLoops) {
-      for (i = 0; loop_starts_[i + 1] <= static_cast<uint>(e); ++i) {
+      for (i = 0; loop_starts_[i + 1] <= static_cast<uint32_t>(e); ++i) {
       }
     } else {
       i = loop_starts_.lower_bound(e + 1) - 1;

--- a/src/s2/s2point.h
+++ b/src/s2/s2point.h
@@ -43,6 +43,25 @@ class S2Point : public Vector3_d {
   using Base = Vector3_d;
   using Base::Base;
 
+  // Due to an ambiguity in original C++11 specificiation, it was unclear
+  // whether imported base class default constructors should be considered
+  // when deciding to delete the default constructor of a class.  GCC and
+  // Clang both accept the base class default ctor, while MSVC 2017 and
+  // later do not.
+  // The ambiguity was resolved in
+  // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html
+  // and accepted as part of the C++17 approval process, with the intent of
+  // being retroactively applied to C++11.
+  // However, while MSVC accepted the change for C++17 and forward, it did
+  // not implement the change for prior versions. See their conformance page:
+  // https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170
+  // (search for P0136R1).
+  // The explicit declaration here of a default ctor is a workaround until
+  // this codebase is targeted at C++17 and above, at which point MSVC, GCC
+  // and Clang will all have identical behavior and won't require this
+  // explicit declaration of a default ctor.
+  S2Point() = default;
+
   // When S2Point was defined as a Vector3_d we could mix and match the two
   // names.  With inheritance upcasting to a Vector3_d is easy, but we need to
   // explicitly allow the other direction, even though there's no data to

--- a/src/s2/s2polygon.h
+++ b/src/s2/s2polygon.h
@@ -962,11 +962,11 @@ inline S2Shape::ChainPosition S2Polygon::Shape::chain_position(int e) const {
     }
   } else {
     i = prev_loop_.load(std::memory_order_relaxed);
-    if (static_cast<uint>(e) >= start[i] &&
-        static_cast<uint>(e) < start[i + 1]) {
+    if (static_cast<uint32_t>(e) >= start[i] &&
+        static_cast<uint32_t>(e) < start[i + 1]) {
       // This edge belongs to the same loop as the previous call.
     } else {
-      if (static_cast<uint>(e) == start[i + 1]) {
+      if (static_cast<uint32_t>(e) == start[i + 1]) {
         // This edge immediately follows the loop from the previous call.
         // Note that S2Polygon does not allow empty loops.
         ++i;


### PR DESCRIPTION
Attempting to fix some of the issues preventing compilation on Windows platforms, in order to then fix the vcpkg version to also support windows, and finally to fix a downstream consumer of s2geometry so it can use vcpkg for the dependency.


### Changes

The `using Base::Base` technique to import the base class ctors doesn't appear to import the base class default ctor if it would otherwise be implicitly deleted (be the declaration of a non-default ctor in this case), at least on MSVC 2022.  See https://godbolt.org/z/EPnsMEq8v  Clang and GCC both seem to handle this OK.

`uint` isn't a primitive type or a guaranteed typedef in C++.  While Clang and GCC both appear to thread it as `unsigned int`, MSVC treats it as un unknown symbol.  Replacing it with `uint32_t` seems to do the trick.

