### PR TITLE
Add modern cmake config targets to s2geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,10 @@ install(TARGETS ${S2_TARGETS}
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
+# create an export type "s2Targets" detailing the targetable artifacts created by this project
 install(TARGETS s2 EXPORT s2Targets)
+# install the export targets as a CMake config file in the share/s2 folder so that they can referenced 
+# by downstream projects as `s2::s2` after a successful `find_package` call
 install(EXPORT s2Targets
         NAMESPACE s2
         FILE s2Targets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,10 +434,12 @@ install(TARGETS ${S2_TARGETS}
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-# create an export type "s2Targets" detailing the targetable artifacts created by this project
+# Create an export type "s2Targets" detailing the targetable artifacts created
+# by this project.
 install(TARGETS s2 EXPORT s2Targets)
-# install the export targets as a CMake config file in the share/s2 folder so that they can referenced 
-# by downstream projects as `s2::s2` after a successful `find_package` call
+# Install the export targets as a CMake config file in the share/s2 folder so
+# that they can referenced  by downstream projects as `s2::s2` after a
+# successful `find_package` call.
 install(EXPORT s2Targets
         NAMESPACE s2
         FILE s2Targets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,10 @@ endif()
 if (S2_USE_SYSTEM_INCLUDES)
     target_include_directories(s2 SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 else ()
-    target_include_directories(s2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_include_directories(s2 PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+      $<INSTALL_INTERFACE:include>
+    )
 endif ()
 
 # Add version information to the target
@@ -432,6 +435,13 @@ install(TARGETS ${S2_TARGETS}
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
+install(TARGETS s2 EXPORT s2Targets)
+install(EXPORT s2Targets
+  NAMESPACE s2
+  FILE s2Targets.cmake
+  DESTINATION share/s2/
+)
+
 if (BUILD_TESTS)
   if (NOT GOOGLETEST_ROOT)
     message(FATAL_ERROR "BUILD_TESTS requires GOOGLETEST_ROOT")
@@ -586,3 +596,14 @@ endif()
 if (${SWIG_FOUND} AND ${Python3_FOUND})
   add_subdirectory("src/python" python)
 endif()
+
+include(CMakePackageConfigHelpers)
+
+# generate the config file that is includes the exports
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/s2Config.cmake"
+  INSTALL_DESTINATION "share/s2/"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/s2Config.cmake DESTINATION "share/s2/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,7 @@ if (S2_USE_SYSTEM_INCLUDES)
 else ()
     target_include_directories(s2 PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-      $<INSTALL_INTERFACE:include>
-    )
+      $<INSTALL_INTERFACE:include>)
 endif ()
 
 # Add version information to the target
@@ -437,10 +436,9 @@ install(TARGETS ${S2_TARGETS}
 
 install(TARGETS s2 EXPORT s2Targets)
 install(EXPORT s2Targets
-  NAMESPACE s2
-  FILE s2Targets.cmake
-  DESTINATION share/s2/
-)
+        NAMESPACE s2
+        FILE s2Targets.cmake
+        DESTINATION share/s2/)
 
 if (BUILD_TESTS)
   if (NOT GOOGLETEST_ROOT)
@@ -599,11 +597,10 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-# generate the config file that is includes the exports
+# Generate the config file that includes the exports.
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/s2Config.cmake"
   INSTALL_DESTINATION "share/s2/"
   NO_SET_AND_CHECK_MACRO
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO
-)
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/s2Config.cmake DESTINATION "share/s2/")

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
 
-include ( "${CMAKE_CURRENT_LIST_DIR}/s2Targets.cmake" )
+include("${CMAKE_CURRENT_LIST_DIR}/s2Targets.cmake")

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/s2Targets.cmake" )


### PR DESCRIPTION
The current vcpkg [version](https://github.com/microsoft/vcpkg/tree/master/ports/s2geometry) of s2geometry has to patch the [CMakeLists.txt](https://github.com/microsoft/vcpkg/blob/master/ports/s2geometry/CMakeLists.txt.patch) and generate a [Config.cmake.in](https://github.com/microsoft/vcpkg/blob/master/ports/s2geometry/Config.cmake.in.patch) file in order to create a modern CMake target file that can then be found by other packages via `find_package`.

Because this is a vcpkg addition, they mandate that this be placed in the `unofficial` namespace, in order to prevent any potential conflict with an eventual upstream config that might be introduced.  This PR introduces the upstream config so that it can be used by anyone who builds the package and so that the vcpkg version no longer requires any patching at all.

The changes here are essentially duplicating what the vcpkg patch does, except that they drop the `unofficial` prefix to everything, since the config would now be coming from the primary source.