### PR TITLE
Fix vs2019 & namespace for install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,7 @@ install(TARGETS s2 EXPORT s2Targets)
 # that they can referenced  by downstream projects as `s2::s2` after a
 # successful `find_package` call.
 install(EXPORT s2Targets
-        NAMESPACE s2
+        NAMESPACE s2::
         FILE s2Targets.cmake
         DESTINATION share/s2/)
 

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,3 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(absl CONFIG)
+
 include("${CMAKE_CURRENT_LIST_DIR}/s2Targets.cmake")

--- a/src/s2/s2lax_polygon_shape.cc
+++ b/src/s2/s2lax_polygon_shape.cc
@@ -50,7 +50,7 @@ namespace {
 template <typename T>
 unique_ptr<T> make_unique_for_overwrite(size_t n) {
   // We only need to support this one variant.
-  static_assert(std::is_array<T>::value);
+  static_assert(std::is_array<T>::value, "T must be an array type");
   return unique_ptr<T>(new typename absl::remove_extent_t<T>[n]);
 }
 }  // namespace


### PR DESCRIPTION
Three minor changes related to my recent fixes for vcpkg and Windows builds

First, the namespace for the export target should be `s2::`, not `s2`.  Otherwise the downstream imported target becomes `s2s2` instead of `s2::s2`, which is the actual convention.  Sorry, this was a result of my inexperience with the details of building these configs as opposed to consuming them.

Second, I failed to include put the absl dependency into the exported exported CMake config for downstream projects.  This is necessary because absl is part of the public interface for s2, and thus will be a dependency of any downstream project.  The VCPKG dependency mechanism already ensures that absl will be built and installed if s2geometry is requested, but this change is requires to avoid downstream packages having to explicitly call `find_dependency(absl CONFIG)` before using the s2 package.

Lastly, the file `src/s2/s2lax_polygon_shape.cc` uses the "terse" form of [static_assert](https://en.cppreference.com/w/cpp/language/static_assert), which is technically a part of the C++17 standard, while the project is marked as C++14 compliant.  It appears that almost every compiler, including MSVC 2022, supports the terse form even without a C++17 flag _except_ MSVC 2019.  MSVC 2019 generates an error causing S2 to fail to build on that platform, which unfortunately is one of the CI targets for the downstream project I'm working on.

Also, if we could push a v0.11.1 tag for these fixes, that would enable me to fix the vcpkg version without creating new patches there.  I'd really appreciate it.

Cheers.