### PR TITLE
Avoid deprecated `std::iterator`

### DIFF
--- a/src/s2/s2builder_graph.h
+++ b/src/s2/s2builder_graph.h
@@ -186,9 +186,14 @@ class S2Builder::Graph {
 
   // A helper class for VertexOutMap that represents the outgoing edge *ids*
   // from a given vertex.
-  class VertexOutEdgeIds
-      : public std::iterator<std::forward_iterator_tag, EdgeId> {
+  class VertexOutEdgeIds {
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = EdgeId;
+    using difference_type = std::ptrdiff_t;
+    using pointer = EdgeId*;
+    using reference = EdgeId&;
+
     // An iterator over a range of edge ids (like boost::counting_iterator).
     class Iterator {
      public:

--- a/src/s2/s2shape_index.h
+++ b/src/s2/s2shape_index.h
@@ -323,9 +323,14 @@ class S2ShapeIndex {
   //   for (S2Shape* shape : index) { ... }
   //
   // CAVEAT: Returns nullptr for shapes that have been removed from the index.
-  class ShapeIterator
-      : public std::iterator<std::forward_iterator_tag, S2Shape*> {
+  class ShapeIterator {
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = S2Shape*;
+    using difference_type = std::ptrdiff_t;
+    using pointer = S2Shape**;
+    using reference = S2Shape*&;
+
     ShapeIterator() = default;
     S2Shape* operator*() const;
     ShapeIterator& operator++();


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/iterator/iterator is deprecated in c++17 and forward