### PR TITLE
Fix build with libcxx16

### DIFF
--- a/src/s2/s2polyline.cc
+++ b/src/s2/s2polyline.cc
@@ -818,8 +818,6 @@ void S2Polyline::Shape::Init(const S2Polyline* polyline) {
   polyline_ = polyline;
 }
 
-S2Polyline::OwningShape::~OwningShape() = default;
-
 int S2Polyline::Shape::num_chains() const {
   return min(1, Shape::num_edges());  // Avoid virtual call.
 }
@@ -828,3 +826,5 @@ S2Shape::Chain S2Polyline::Shape::chain(int i) const {
   ABSL_DCHECK_EQ(i, 0);
   return Chain(0, Shape::num_edges());  // Avoid virtual call.
 }
+
+S2Polyline::OwningShape::~OwningShape() = default;

--- a/src/s2/s2polyline.cc
+++ b/src/s2/s2polyline.cc
@@ -818,6 +818,8 @@ void S2Polyline::Shape::Init(const S2Polyline* polyline) {
   polyline_ = polyline;
 }
 
+S2Polyline::OwningShape::~OwningShape() = default;
+
 int S2Polyline::Shape::num_chains() const {
   return min(1, Shape::num_edges());  // Avoid virtual call.
 }

--- a/src/s2/s2polyline.h
+++ b/src/s2/s2polyline.h
@@ -397,6 +397,8 @@ class S2Polyline final : public S2Region {
     explicit OwningShape(std::unique_ptr<const S2Polyline> polyline)
         : Shape(polyline.get()), owned_polyline_(std::move(polyline)) {}
 
+    ~OwningShape() override;
+
     void Init(std::unique_ptr<const S2Polyline> polyline) {
       Shape::Init(polyline.get());
       owned_polyline_ = std::move(polyline);

--- a/src/s2/s2polyline.h
+++ b/src/s2/s2polyline.h
@@ -397,6 +397,8 @@ class S2Polyline final : public S2Region {
     explicit OwningShape(std::unique_ptr<const S2Polyline> polyline)
         : Shape(polyline.get()), owned_polyline_(std::move(polyline)) {}
 
+    // S2Polyline is an incomplete type here. Due to unique_ptr, ~OwningShape
+    // must be defined after S2Polyline is complete, so it cannot be implicit.
     ~OwningShape() override;
 
     void Init(std::unique_ptr<const S2Polyline> polyline) {


### PR DESCRIPTION
The code is structured like this:

```
class S2Polyline {

  class OwningShape {
      std::unique_ptr<S2Polyline> owned_polyline_;
  };
};
```

libcxx 16 complains that S2Polyline is not defined at the point where
the dtor of the unique_ptr is called (which is OwningShape's implicitly
declared default destructor in the same header file) (also see [0]).

As a remedy, declare OwningShape's destructor in the source file where
the full declaration of S2Polyline is visible.

[0] https://stackoverflow.com/a/34073093/22422288)