### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Prefix it with `sudo` if needed:
 sudo make install
 ```
 
-_NOTE_: There is not `uninstall` target but `install_manifest.txt` may be helpfull.
+_NOTE_: There is not `uninstall` target but `install_manifest.txt` may be helpful.
 
 All files will be installed at location specified in `CMAKE_INSTALL_PREFIX` variable.
 

--- a/src/s2/base/port.h
+++ b/src/s2/base/port.h
@@ -17,7 +17,7 @@
 #define S2_BASE_PORT_H_
 
 // This file contains things that are not used in third_party/absl but needed by
-// s2geometry. It is structed into the following high-level categories:
+// s2geometry. It is structured into the following high-level categories:
 // - Endianness
 // - Performance optimization (alignment)
 

--- a/src/s2/s2boolean_operation.h
+++ b/src/s2/s2boolean_operation.h
@@ -70,7 +70,7 @@
 // lakes and rivers are merged and/or reduced to degenerate point or sibling
 // edge pair holes).  Mathematically speaking, degeneracy support allows
 // geometry to be simplified while guaranteeing that the Hausdorff distance
-// betweeen the boundaries of the original and simplified geometries is at
+// between the boundaries of the original and simplified geometries is at
 // most the simplification tolerance.  It also allows geometry to be
 // simplified without changing its dimension, thus preserving boundary
 // semantics.  (Note that the boundary of a polyline ABCD is {A,D}, whereas

--- a/src/s2/s2builder_graph_test.cc
+++ b/src/s2/s2builder_graph_test.cc
@@ -310,7 +310,7 @@ TEST(ProcessEdges, MergeConvertedUndirectedDuplicateDegenerateEdges) {
 TEST(ProcessEdges, DiscardExcessConnectedDegenerateEdges) {
   GraphOptions options(EdgeType::DIRECTED, DegenerateEdges::DISCARD_EXCESS,
                        DuplicateEdges::KEEP, SiblingPairs::KEEP);
-  // Test that degenerate edges are discarded if they are connnected to any
+  // Test that degenerate edges are discarded if they are connected to any
   // non-degenerate edges (whether they are incoming or outgoing, and whether
   // they are lexicographically before or after the degenerate edge).
   TestProcessEdges({{0, 0}, {0, 1}}, {{0, 1}}, &options);

--- a/src/s2/s2builder_test.cc
+++ b/src/s2/s2builder_test.cc
@@ -225,7 +225,7 @@ TEST(S2Builder, VerticesMoveLessThanSnapRadius) {
 }
 
 TEST(S2Builder, MinEdgeVertexSeparation) {
-  // Check that edges are separted from non-incident vertices by at least
+  // Check that edges are separated from non-incident vertices by at least
   // min_edge_vertex_separation().  This requires adding new vertices (not
   // present in the input) in some cases.
 
@@ -1014,7 +1014,7 @@ TEST(S2Builder, SimplifyLimitsEdgeDeviation) {
 }
 
 TEST(S2Builder, SimplifyPreservesTopology) {
-  // Crate several nested concentric loops, and verify that the loops are
+  // Create several nested concentric loops, and verify that the loops are
   // still nested after simplification.
 
   constexpr int kNumLoops = 20;
@@ -1332,7 +1332,7 @@ TEST(S2Builder, HighPrecisionPredicates) {
 }
 
 // Chooses a random S2Point that is often near the intersection of one of the
-// coodinates planes or coordinate axes with the unit sphere.  (It is possible
+// coordinates planes or coordinate axes with the unit sphere.  (It is possible
 // to represent very small perturbations near such points.)
 S2Point ChoosePoint(absl::BitGenRef bitgen) {
   S2Point x = s2random::Point(bitgen);

--- a/src/s2/s2builderutil_get_snapped_winding_delta_test.cc
+++ b/src/s2/s2builderutil_get_snapped_winding_delta_test.cc
@@ -215,7 +215,7 @@ TEST(GetSnappedWindingDelta, ExternalLoopDoubleHoleToSingleShell) {
                      "0:0", 10.0, 0, +3);
 }
 
-// This and the following tests vertify that the partial loops formed by the
+// This and the following tests verify that the partial loops formed by the
 // local input and output edges are closed consistently with each other (such
 // that the hypothetical connecting edges can deform from one to the other
 // without passing through the reference vertex).

--- a/src/s2/s2builderutil_snap_functions.cc
+++ b/src/s2/s2builderutil_snap_functions.cc
@@ -121,7 +121,7 @@ S1Angle S2CellIdSnapFunction::MinSnapRadiusForLevel(int level) {
 }
 
 int S2CellIdSnapFunction::LevelForMaxSnapRadius(S1Angle snap_radius) {
-  // When choosing a level, we need to acount for the error bound of
+  // When choosing a level, we need to account for the error bound of
   // 4 * DBL_EPSILON that is added by MinSnapRadiusForLevel().
   return S2::kMaxDiag.GetLevelForMaxValue(
       2 * (snap_radius.radians() - 4 * DBL_EPSILON));
@@ -170,7 +170,7 @@ S1Angle S2CellIdSnapFunction::min_edge_vertex_separation() const {
   //    (b) Otherwise, for arbitrary snap radii the worst-case configuration
   //    in the plane has an edge-vertex separation of sqrt(3/19) *
   //    kMinDiag(level), where sqrt(3/19) is about 0.3973597071.  The unit
-  //    test verifies that the bound is slighty better on the sphere:
+  //    test verifies that the bound is slightly better on the sphere:
   //    0.3973595687 * kMinDiag(level).
   //
   // 2. Proportional bound: In the plane, the worst-case configuration has an
@@ -277,7 +277,7 @@ S1Angle IntLatLngSnapFunction::MinSnapRadiusForExponent(int exponent) {
 }
 
 int IntLatLngSnapFunction::ExponentForMaxSnapRadius(S1Angle snap_radius) {
-  // When choosing an exponent, we need to acount for the error bound of
+  // When choosing an exponent, we need to account for the error bound of
   // (9 * sqrt(2) + 1.5) * DBL_EPSILON added by MinSnapRadiusForExponent().
   snap_radius -= S1Angle::Radians((9 * M_SQRT2 + 1.5) * DBL_EPSILON);
   snap_radius = max(snap_radius, S1Angle::Radians(1e-30));

--- a/src/s2/s2closest_edge_query_base.h
+++ b/src/s2/s2closest_edge_query_base.h
@@ -350,7 +350,7 @@ class S2ClosestEdgeQueryBase {
   // return faster results, and 0 < max_error() < distance_limit_.
   bool use_conservative_cell_distance_;
 
-  // For the optimized algorihm we precompute the top-level S2CellIds that
+  // For the optimized algorithm we precompute the top-level S2CellIds that
   // will be added to the priority queue.  There can be at most 6 of these
   // cells.  Essentially this is just a covering of the indexed edges, except
   // that we also store pointers to the corresponding S2ShapeIndexCells to

--- a/src/s2/s2closest_point_query.h
+++ b/src/s2/s2closest_point_query.h
@@ -257,7 +257,7 @@ class S2ClosestPointQuery {
   // Returns a reference to the underlying S2PointIndex.
   const Index& index() const;
 
-  // Returns the query options.  Options can be modifed between queries.
+  // Returns the query options.  Options can be modified between queries.
   const Options& options() const;
   Options* mutable_options();
 

--- a/src/s2/s2closest_point_query_base.h
+++ b/src/s2/s2closest_point_query_base.h
@@ -274,7 +274,7 @@ class S2ClosestPointQueryBase {
   // return faster results, and 0 < max_error() < distance_limit_.
   bool use_conservative_cell_distance_;
 
-  // For the optimized algorihm we precompute the top-level S2CellIds that
+  // For the optimized algorithm we precompute the top-level S2CellIds that
   // will be added to the priority queue.  There can be at most 6 of these
   // cells.  Essentially this is just a covering of the indexed points.
   std::vector<S2CellId> index_covering_;

--- a/src/s2/s2crossing_edge_query_test.cc
+++ b/src/s2/s2crossing_edge_query_test.cc
@@ -364,7 +364,7 @@ TEST(GetCrossings, ShapeIdsAreCorrect) {
 // visited.  (At one point this was not always true, because when the query edge
 // is clipped to the index cell boundary without using any padding then the
 // result is sometimes empty, i.e., the query edge appears not to intersect the
-// specifed root cell.  The code now uses an appropriate amount of padding,
+// specified root cell.  The code now uses an appropriate amount of padding,
 // i.e. S2::kFaceClipErrorUVCoord.)
 TEST(VisitCells, QueryEdgeOnFaceBoundary) {
   absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(

--- a/src/s2/s2edge_crossings_test.cc
+++ b/src/s2/s2edge_crossings_test.cc
@@ -276,7 +276,7 @@ TEST(S2, RobustCrossProdMagnitude) {
 }
 
 // Chooses a random S2Point that is often near the intersection of one of the
-// coodinates planes or coordinate axes with the unit sphere.  (It is possible
+// coordinates planes or coordinate axes with the unit sphere.  (It is possible
 // to represent very small perturbations near such points.)
 S2Point ChoosePoint(absl::BitGenRef bitgen) {
   S2Point x = s2random::Point(bitgen);

--- a/src/s2/s2edge_distances_test.cc
+++ b/src/s2/s2edge_distances_test.cc
@@ -266,7 +266,7 @@ TEST(S2, MaxDistance) {
 }
 
 // Chooses a random S2Point that is often near the intersection of one of the
-// coodinates planes or coordinate axes with the unit sphere.  (It is possible
+// coordinates planes or coordinate axes with the unit sphere.  (It is possible
 // to represent very small perturbations near such points.)
 S2Point ChoosePoint(absl::BitGenRef bitgen) {
   S2Point x = s2random::Point(bitgen);

--- a/src/s2/s2edge_tessellator_test.cc
+++ b/src/s2/s2edge_tessellator_test.cc
@@ -198,7 +198,7 @@ TEST(S2EdgeTessellator, IsAssignable) {
   S2::PlateCarreeProjection proj(180);
   S2EdgeTessellator tess(&proj, S1Angle::Degrees(0.01));
 
-  // Assigning a tesselator with a new tolerance should work.
+  // Assigning a tessellator with a new tolerance should work.
   tess = S2EdgeTessellator(&proj, S1Angle::Degrees(1));
 }
 
@@ -504,7 +504,7 @@ TEST(S2EdgeTessellator, RandomEdgesMercator) {
   TestRandomEdges(bitgen, proj, tolerance);
 }
 
-// TODO(ericv): Superceded by random edge tests above, remove?
+// TODO(ericv): Superseded by random edge tests above, remove?
 TEST(S2EdgeTessellator, UnprojectedAccuracyRandomCheck) {
   absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
       "UNPROJECTED_ACCURACY_RANDOM_CHECK",
@@ -523,7 +523,7 @@ TEST(S2EdgeTessellator, UnprojectedAccuracyRandomCheck) {
   }
 }
 
-// XXX(ericv): Superceded by random edge tests above, remove?
+// XXX(ericv): Superseded by random edge tests above, remove?
 TEST(S2EdgeTessellator, ProjectedAccuracyRandomCheck) {
   absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
       "PROJECTED_ACCURACY_RANDOM_CHECK",

--- a/src/s2/s2fractal.h
+++ b/src/s2/s2fractal.h
@@ -70,7 +70,7 @@ class S2Fractal {
   void SetLevelForApproxMaxEdges(int max_edges);
 
   // Set the fractal dimension.  The default value of approximately 1.26
-  // corresponds to the stardard Koch curve.  The value must lie in the range
+  // corresponds to the standard Koch curve.  The value must lie in the range
   // [1.0, 2.0).
   //
   // DEFAULT: log(4) / log(3) ~= 1.26

--- a/src/s2/s2latlng_rect.cc
+++ b/src/s2/s2latlng_rect.cc
@@ -411,7 +411,7 @@ bool S2LatLngRect::IntersectsLatEdge(const S2Point& a, const S2Point& b,
   if (z[2] < 0) z = -z;
 
   // Extend this to an orthonormal frame (x,y,z) where x is the direction
-  // where the great circle through AB achieves its maximium latitude.
+  // where the great circle through AB achieves its maximum latitude.
   Vector3_d y = S2::RobustCrossProd(z, S2Point(0, 0, 1)).Normalize();
   Vector3_d x = y.CrossProd(z);
   ABSL_DCHECK(S2::IsUnitLength(x));
@@ -710,7 +710,7 @@ S1Angle S2LatLngRect::GetInteriorMaxDistance(const R1Interval& a_lat,
   if (a_lat.is_empty() || b.x() >= 0) return S1Angle::Radians(-1);
 
   // Project b to the y=0 plane. The antipodal of the normalized projection is
-  // the point at which the maxium distance from b occurs, if it is contained
+  // the point at which the maximum distance from b occurs, if it is contained
   // in a_lat.
   S2Point intersection_point = S2Point(-b.x(), 0, -b.z()).Normalize();
   if (a_lat.InteriorContains(

--- a/src/s2/s2latlng_rect_bounder.cc
+++ b/src/s2/s2latlng_rect_bounder.cc
@@ -200,7 +200,7 @@ S2LatLngRect S2LatLngRectBounder::GetBound() const {
   // is simply the maximum rounding error for results in the range [-Pi, Pi].
   // This is true because the Gnu implementation of atan2() comes from the IBM
   // Accurate Mathematical Library, which implements correct rounding for this
-  // instrinsic (i.e., it returns the infinite precision result rounded to the
+  // intrinsic (i.e., it returns the infinite precision result rounded to the
   // nearest representable value, with ties rounded to even values).  This
   // implies that we don't need to expand the longitude bounds at all, since
   // we only guarantee that the bound contains the *rounded* latitudes of

--- a/src/s2/s2point.h
+++ b/src/s2/s2point.h
@@ -43,7 +43,7 @@ class S2Point : public Vector3_d {
   using Base = Vector3_d;
   using Base::Base;
 
-  // Due to an ambiguity in original C++11 specificiation, it was unclear
+  // Due to an ambiguity in original C++11 specification, it was unclear
   // whether imported base class default constructors should be considered
   // when deciding to delete the default constructor of a class.  GCC and
   // Clang both accept the base class default ctor, while MSVC 2017 and

--- a/src/s2/s2polyline_alignment.h
+++ b/src/s2/s2polyline_alignment.h
@@ -136,7 +136,7 @@ VertexAlignment GetExactVertexAlignment(const S2Polyline& a,
 double GetExactVertexAlignmentCost(const S2Polyline& a, const S2Polyline& b);
 
 // GetApproxVertexAlignment takes two non-empty polylines `a` and `b` as input,
-// and a `radius` paramater GetApproxVertexAlignment (quickly) computes an
+// and a `radius` parameter GetApproxVertexAlignment (quickly) computes an
 // approximately optimal vertex alignment of points between polylines `a` and
 // `b` by implementing the algorithm described in `FastDTW: Toward Accurate
 // Dynamic Time Warping in Linear Time and Space` by Stan Salvador and Philip
@@ -152,7 +152,7 @@ double GetExactVertexAlignmentCost(const S2Polyline& a, const S2Polyline& b);
 VertexAlignment GetApproxVertexAlignment(const S2Polyline& a,
                                          const S2Polyline& b, const int radius);
 
-// A convience overload for GetApproxVertexAlignment which computes and uses
+// A convenience overload for GetApproxVertexAlignment which computes and uses
 // suggested default parameter of radius = max(a.size(), b.size())^0.25
 VertexAlignment GetApproxVertexAlignment(const S2Polyline& a,
                                          const S2Polyline& b);

--- a/src/s2/s2polyline_simplifier.h
+++ b/src/s2/s2polyline_simplifier.h
@@ -100,7 +100,7 @@ class S2PolylineSimplifier {
   //
   // If your input is a polyline, you can compute "disc_on_left" as follows.
   // Let the polyline be ABCDE and assume that it already avoids a set of
-  // points X_i.  Suppose that you have aleady added ABC to the simplifier, and
+  // points X_i.  Suppose that you have already added ABC to the simplifier, and
   // now want to extend the edge chain to D.  First find the X_i that are near
   // the edge CD, then discard the ones such that AX_i <= AC or AX_i >= AD
   // (since these points have either already been considered or aren't

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -341,7 +341,7 @@ class SignTest : public testing::Test {
     while (points.size() < n) {
       AddDegeneracy(bitgen, &points);
     }
-    // Remove any (0, 0, 0) points that were accidentically created, then sort
+    // Remove any (0, 0, 0) points that were accidentally created, then sort
     // the points and remove duplicates.
     points.erase(std::remove(points.begin(), points.end(), S2Point(0, 0, 0)),
                  points.end());
@@ -558,7 +558,7 @@ string PrecisionStats::ToString() {
 }
 
 // Chooses a random S2Point that is often near the intersection of one of the
-// coodinates planes or coordinate axes with the unit sphere.  (It is possible
+// coordinates planes or coordinate axes with the unit sphere.  (It is possible
 // to represent very small perturbations near such points.)
 static S2Point ChoosePoint(absl::BitGenRef bitgen) {
   S2Point x = s2random::Point(bitgen);

--- a/src/s2/s2region_coverer.h
+++ b/src/s2/s2region_coverer.h
@@ -174,7 +174,7 @@ class S2RegionCoverer {
   S2RegionCoverer();
   ~S2RegionCoverer();
 
-  // Returns the current options.  Options can be modifed between calls.
+  // Returns the current options.  Options can be modified between calls.
   const Options& options() const { return options_; }
   Options* mutable_options() { return &options_; }
 

--- a/src/s2/s2region_term_indexer.h
+++ b/src/s2/s2region_term_indexer.h
@@ -241,7 +241,7 @@ class S2RegionTermIndexer {
   S2RegionTermIndexer(S2RegionTermIndexer&&) noexcept;
   S2RegionTermIndexer& operator=(S2RegionTermIndexer&&) noexcept;
 
-  // Returns the current options.  Options can be modifed between calls.
+  // Returns the current options.  Options can be modified between calls.
   const Options& options() const { return options_; }
   Options* mutable_options() { return &options_; }
 

--- a/src/s2/s2shape_index_buffered_region.h
+++ b/src/s2/s2shape_index_buffered_region.h
@@ -109,7 +109,7 @@ class S2ShapeIndexBufferedRegion final : public S2Region {
  private:
   S1ChordAngle radius_;
 
-  // In order to handle (radius_ == 0) corectly, we need to test whether
+  // In order to handle (radius_ == 0) correctly, we need to test whether
   // distances are less than or equal to "radius_".  This is done by testing
   // whether distances are less than radius_.Successor().
   S1ChordAngle radius_successor_;

--- a/src/s2/s2shapeutil_get_reference_point.cc
+++ b/src/s2/s2shapeutil_get_reference_point.cc
@@ -33,7 +33,7 @@ namespace s2shapeutil {
 // This is a helper function for GetReferencePoint() below.
 //
 // If the given vertex "vtest" is unbalanced (see definition below), sets
-// "result" to a ReferencePoint indicating whther "vtest" is contained and
+// "result" to a ReferencePoint indicating whether "vtest" is contained and
 // returns true.  Otherwise returns false.
 static bool GetReferencePointAtVertex(
     const S2Shape& shape, const S2Point& vtest, ReferencePoint* result) {

--- a/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
+++ b/src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
@@ -74,7 +74,7 @@ EdgePairVector GetCrossings(const S2ShapeIndex& index, CrossingType type) {
   return edge_pairs;
 }
 
-// Get crossings betweeen two indexes.
+// Get crossings between two indexes.
 EdgePairVector GetCrossings(const S2ShapeIndex& indexA,
                             const S2ShapeIndex& indexB, CrossingType type) {
   EdgePairVector edge_pairs;

--- a/src/s2/s2text_format_test.cc
+++ b/src/s2/s2text_format_test.cc
@@ -485,7 +485,7 @@ TEST(SafeMakeLaxPolygon, ValidInput) {
   EXPECT_TRUE(
       s2textformat::MakeLaxPolygon("-20:150, -20:151, -19:150", &lax_polygon));
 
-  // One loop of three verticies & three edges, in one chain starting at edge 0
+  // One loop of three vertices & three edges, in one chain starting at edge 0
   // and three edges long.
   ASSERT_EQ(1, lax_polygon->num_loops());
   ASSERT_EQ(3, lax_polygon->num_vertices());

--- a/src/s2/s2winding_operation.cc
+++ b/src/s2/s2winding_operation.cc
@@ -263,7 +263,7 @@ void WindingLayer::Build(const Graph& g, S2Error* error) {
     new_input_edge_ids.push_back(g.input_edge_id_set_id(e));
   }
 
-  // Our goal is to assemble the given edges into loops that parition the
+  // Our goal is to assemble the given edges into loops that partition the
   // sphere.  In order to do this we merge duplicate edges and create sibling
   // edges so that every region can have its own directed boundary loop.
   //

--- a/src/s2/s2winding_operation.h
+++ b/src/s2/s2winding_operation.h
@@ -209,7 +209,7 @@ class S2WindingOperation {
   // The boundary edges are sent to the S2Builder result layer specified in the
   // constructor, along with an appropriate IsFullPolygonPredicate that can be
   // used to distinguish whether the result is empty or full (even when
-  // degeneracies are present).  Note that distingishing empty from full
+  // degeneracies are present).  Note that distinguishing empty from full
   // results is a problem unique to spherical geometry.
   //
   // REQUIRES: error->ok() [an existing error will not be overwritten]

--- a/src/s2/util/bitmap/bitmap.h
+++ b/src/s2/util/bitmap/bitmap.h
@@ -226,7 +226,7 @@ class BasicBitmap {
 
   // A static version of FindNextSetBitBeforeLimit that can be called
   // by other clients that have an array of words in their hands,
-  // layed out in the same way as BitMap.  Scans bits in "*words"
+  // laid out in the same way as BitMap.  Scans bits in "*words"
   // starting at bit "*bit_index", looking for a set bit.  If it finds
   // a set bit before reaching bit index "bit_limit", sets
   // "*bit_index" to the bit index and returns true.  Otherwise
@@ -269,7 +269,7 @@ class BasicBitmap {
 
   // A static version of FindNextUnsetBitBeforeLimit that can be called
   // by other clients that have an array of words in their hands,
-  // layed out in the same way as BitMap.  Scans bits in "*words"
+  // laid out in the same way as BitMap.  Scans bits in "*words"
   // starting at bit "*bit_index", looking for an unset bit.  If it finds
   // an unset bit before reaching bit index "bit_limit", sets
   // "*bit_index" to the bit index and returns true.  Otherwise

--- a/src/s2/util/bits/bit-interleave.cc
+++ b/src/s2/util/bits/bit-interleave.cc
@@ -30,7 +30,7 @@
 //     Xeon E5 2690 V3, while DeinterleaveUint16 has 6% performance regression
 //     with table-free implementations.
 //     Some client of this lib like util/geometry/s2point_compression.cc even
-//     see up to 28% performance improvment by adopting the table-free
+//     see up to 28% performance improvement by adopting the table-free
 //     DeinterleaveUint32 implementation.
 //     TODO(user): As of 2022, Xeon E5 2690 V3 is also an ancient
 //     architecture(Haswell). We need to consider benchmarking it on more

--- a/src/s2/util/coding/varint.cc
+++ b/src/s2/util/coding/varint.cc
@@ -150,7 +150,7 @@ done2:
 const char* Varint::Parse64Fallback(const char* p, uint64_t* OUTPUT) {
   const unsigned char* ptr = reinterpret_cast<const unsigned char*>(p);
   assert(*ptr >= 128);
-  // Fast path: need to accumulate data in upto three result fragments
+  // Fast path: need to accumulate data in up to three result fragments
   //    res1    bits 0..27
   //    res2    bits 28..55
   //    res3    bits 56..63

--- a/src/s2/util/gtl/compact_array.h
+++ b/src/s2/util/gtl/compact_array.h
@@ -219,7 +219,7 @@ class compact_array_base {
 
   // Safe against self-swapping.
   // copying/destruction of compact_array_base is fairly trivial as the type
-  // was designed to be useable in a C++98 union.
+  // was designed to be usable in a C++98 union.
   void swap(compact_array_base& v) noexcept {
     compact_array_base tmp = *this;
     *this = v;

--- a/src/s2/util/gtl/densehashtable.h
+++ b/src/s2/util/gtl/densehashtable.h
@@ -666,7 +666,7 @@ class dense_hashtable {
       const size_type target =
           static_cast<size_type>(settings.shrink_size(resize_to * 2));
       if (num_elements - num_deleted + delta >= target) {
-        // Good, we won't be below the shrink threshhold even if we double.
+        // Good, we won't be below the shrink threshold even if we double.
         resize_to *= 2;
       }
     }
@@ -984,7 +984,7 @@ class dense_hashtable {
   }
 
   // Clear the table without resizing it.
-  // Mimicks the stl_hashtable's behaviour when clear()-ing in that it
+  // Mimics the stl_hashtable's behaviour when clear()-ing in that it
   // does not modify the bucket count
   void clear_no_resize() {
     if (num_elements > 0) {

--- a/src/s2/util/gtl/hashtable_common.h
+++ b/src/s2/util/gtl/hashtable_common.h
@@ -138,7 +138,7 @@ class sh_hashtable_settings : public HashFunc {
     set_consider_shrink(false);
   }
 
-  // Caller is resposible for calling reset_threshold right after
+  // Caller is responsible for calling reset_threshold right after
   // set_resizing_parameters.
   void set_resizing_parameters(float shrink, float grow) {
     assert(shrink >= 0.0);

--- a/src/s2/util/math/exactfloat/exactfloat.h
+++ b/src/s2/util/math/exactfloat/exactfloat.h
@@ -93,7 +93,7 @@
 //      y = Vector3_d(x[0].ToDouble(), x[1].ToDouble(), x[2].ToDouble()); // OK
 //
 //  - IsNaN() is not supported because it calls isnan(), which is defined as a
-//    macro in <math.h> and therefore can't easily be overrided.
+//    macro in <math.h> and therefore can't easily be overridden.
 //
 // Precision Semantics
 // -------------------
@@ -299,7 +299,7 @@ class ExactFloat {
   //
   // Note that if two values have different precisions, they may have the same
   // ToString() value even though their values are slightly different.  If you
-  // need to distinguish such values, use ToUniqueString() intead.
+  // need to distinguish such values, use ToUniqueString() instead.
   std::string ToString() const;
 
   // Return a string formatted according to printf("%Ng") where N is the given

--- a/src/s2/util/math/matrix3x3.h
+++ b/src/s2/util/math/matrix3x3.h
@@ -22,7 +22,7 @@
 // (Reading a = a + b*2 - c is much easier to read than
 // a = Sub(Add(a, Mul(b,2)),c)   )
 //
-// Please be careful about overflows when using those matrices wth integer types
+// Please be careful about overflows when using those matrices with integer types
 // The calculations are carried with VType. eg : if you are using uint8 as the
 // base type, all values will be modulo 256.
 // This feature is necessary to use the class in a more general framework with


### PR DESCRIPTION
Typos were quickly identified and corrected using [codespell](https://github.com/codespell-project/codespell).