### PR TITLE
Check for WIN32 rather than MSVC when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (WITH_PYTHON)
     find_package(Python3 COMPONENTS Interpreter Development)
 endif()
 
-if (MSVC)
+if (WIN32)
     # Use unsigned characters
     add_definitions(-J)
     # Make sure cmath header defines things like M_PI


### PR DESCRIPTION
This constraint is more general and occurs on all Windows platforms, where `MSVC` may not.  

xref https://github.com/JuliaPackaging/Yggdrasil/pull/9448, where we encountered this issue - the MSVC condition was not satisfied, but the build is on windows.  