### PR TITLE
Update CMakeLists.txt for python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.18)
 
 project(s2-geometry
         VERSION 0.12.0)
@@ -67,7 +67,7 @@ if (WITH_PYTHON)
     find_package(SWIG 4.0)
     # Use Python3_ROOT_DIR to help find python3, if the correct location is not
     # being found by default.
-    find_package(Python3 COMPONENTS Interpreter Development)
+    find_package(Python3 COMPONENTS Interpreter Development.Module)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
The "Development" component of  Python3 needs more files than we care about (e.g. `libpython3.xx.so`). 

However when compiling a module, we only need part of the development files, (e.g. the headers).

To support this distinction, [cmake added `Development.Modules` in 3.18](https://cmake.org/cmake/help/latest/module/FindPython3.html) so that this will work in more environments (e.g. docker image `quay.io/pypa/manylinux_2_28_x86_64`)