### PR TITLE
s2loop_measures_test: Disable GetSignedArea on arm64 macOS

### DIFF
--- a/src/s2/s2loop_measures_test.cc
+++ b/src/s2/s2loop_measures_test.cc
@@ -255,6 +255,9 @@ TEST(GetSignedArea, Underflow) {
 }
 
 TEST(GetSignedArea, ErrorAccumulation) {
+#if defined(__APPLE__) && defined(__aarch64__)
+  GTEST_SKIP() << "https://github.com/google/s2geometry/issues/395";
+#endif
   // Loop encompassing half an octant of the sphere.
   vector<S2Point> loop{
       {1.0, 0.0, 0.0},


### PR DESCRIPTION
This fails and needs more investigation.

See #395.

Disable it so we can have clean presubmit checks.