### PR TITLE
Fix macos build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,13 @@ if (WITH_PYTHON)
     find_package(SWIG 4.0)
     # Use Python3_ROOT_DIR to help find python3, if the correct location is not
     # being found by default.
-    find_package(Python3 COMPONENTS Interpreter Development.Module)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        # Workaround for issue https://github.com/google/s2geometry/issues/398
+        # Macos requires libpython3.13.dylib and does not get it with .Module
+        find_package(Python3 COMPONENTS Interpreter Development)
+    else()
+        find_package(Python3 COMPONENTS Interpreter Development.Module)
+    endif()
 endif()
 
 if (MSVC)


### PR DESCRIPTION
Closes #398

Mac seems to use dynamic linking more for making modules than Linux and Windows do. Thus the common python symbols were missing and it requires `libpython3.13.dylib` for these symbols. If this is a different in the mac "Framework" then cmake should probably include that for the `Development.Module` component. But this is a workaround in the meantime while we wait for any upstream fixes.