### PR TITLE
Update to latest google3 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,14 @@ endif()
 include_directories(src)
 
 add_library(s2
+            src/s2/base/malloc_extension.cc
             src/s2/encoded_s2cell_id_vector.cc
             src/s2/encoded_s2point_vector.cc
             src/s2/encoded_s2shape_index.cc
             src/s2/encoded_string_vector.cc
             src/s2/id_set_lexicon.cc
+            src/s2/internal/s2incident_edge_tracker.cc
+            src/s2/internal/s2index_cell_data.cc
             src/s2/mutable_s2shape_index.cc
             src/s2/r2rect.cc
             src/s2/s1angle.cc
@@ -154,7 +157,6 @@ add_library(s2
             src/s2/s2fractal.cc
             src/s2/s2furthest_edge_query.cc
             src/s2/s2hausdorff_distance_query.cc
-            src/s2/s2index_cell_data.cc
             src/s2/s2latlng.cc
             src/s2/s2latlng_rect.cc
             src/s2/s2latlng_rect_bounder.cc
@@ -334,6 +336,7 @@ install(FILES src/s2/_fp_contract_off.h
               src/s2/s2crossing_edge_query.h
               src/s2/s2debug.h
               src/s2/s2density_tree.h
+              src/s2/s2density_tree_internal.h
               src/s2/s2distance_target.h
               src/s2/s2earth.h
               src/s2/s2edge_clipping.h
@@ -347,7 +350,6 @@ install(FILES src/s2/_fp_contract_off.h
               src/s2/s2fractal.h
               src/s2/s2furthest_edge_query.h
               src/s2/s2hausdorff_distance_query.h
-              src/s2/s2index_cell_data.h
               src/s2/s2latlng.h
               src/s2/s2latlng_rect.h
               src/s2/s2latlng_rect_bounder.h
@@ -407,19 +409,24 @@ install(FILES src/s2/_fp_contract_off.h
               src/s2/s2shapeutil_visit_crossing_edge_pairs.h
               src/s2/s2testing.h
               src/s2/s2text_format.h
+              src/s2/s2validation_query.h
               src/s2/s2wedge_relations.h
               src/s2/s2winding_operation.h
               src/s2/s2wrapped_shape.h
               src/s2/sequence_lexicon.h
               src/s2/thread_testing.h
               src/s2/value_lexicon.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/s2")
-install(FILES src/s2/internal/s2meta.h
+        DESTINATION include/s2)
+install(FILES src/s2/internal/s2disjoint_set.h
+              src/s2/internal/s2incident_edge_tracker.h
+              src/s2/internal/s2index_cell_data.h
+              src/s2/internal/s2meta.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/s2/internal")
 install(FILES src/s2/base/casts.h
               src/s2/base/commandlineflags.h
               src/s2/base/commandlineflags_declare.h
               src/s2/base/log_severity.h
+              src/s2/base/malloc_extension.h
               src/s2/base/port.h
               src/s2/base/spinlock.h
               src/s2/base/types.h
@@ -493,6 +500,8 @@ if (BUILD_TESTS)
       src/s2/encoded_uint_vector_test.cc
       src/s2/gmock_matchers_test.cc
       src/s2/id_set_lexicon_test.cc
+      src/s2/internal/s2disjoint_set_test.cc
+      src/s2/internal/s2index_cell_data_test.cc
       src/s2/mutable_s2shape_index_test.cc
       src/s2/r1interval_test.cc
       src/s2/r2rect_test.cc
@@ -547,7 +556,6 @@ if (BUILD_TESTS)
       src/s2/s2fractal_test.cc
       src/s2/s2furthest_edge_query_test.cc
       src/s2/s2hausdorff_distance_query_test.cc
-      src/s2/s2index_cell_data_test.cc
       src/s2/s2latlng_rect_bounder_test.cc
       src/s2/s2latlng_rect_test.cc
       src/s2/s2latlng_test.cc
@@ -600,6 +608,7 @@ if (BUILD_TESTS)
       src/s2/s2shapeutil_shape_edge_id_test.cc
       src/s2/s2shapeutil_visit_crossing_edge_pairs_test.cc
       src/s2/s2text_format_test.cc
+      src/s2/s2validation_query_test.cc
       src/s2/s2wedge_relations_test.cc
       src/s2/s2winding_operation_test.cc
       src/s2/s2wrapped_shape_test.cc

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ This issue may require revision of boringssl or exactfloat.
 
 ## Requirements for End Users using CMake
 
-* [CMake](http://www.cmake.org/)
-* A C++ compiler with C++14 support, such as [g++ >= 5](https://gcc.gnu.org/)
-* [Abseil](https://github.com/abseil/abseil-cpp) >= LTS
-  [`20240116`](https://github.com/abseil/abseil-cpp/releases/tag/20240116.1)
-  (standard library extensions)
-* [OpenSSL](https://github.com/openssl/openssl) (for its bignum library)
-* [googletest testing framework >= 1.10](https://github.com/google/googletest)
-  (to build tests and example programs, optional)
+*   [CMake](http://www.cmake.org/) >= 3.5
+*   A C++ compiler with C++14 support, such as [g++ >= 5](https://gcc.gnu.org/)
+*   [Abseil](https://github.com/abseil/abseil-cpp) >= LTS
+    [`20240722`](https://github.com/abseil/abseil-cpp/releases/tag/20240722.0)
+    (standard library extensions)
+*   [OpenSSL](https://github.com/openssl/openssl) (for its bignum library)
+*   [googletest testing framework >= 1.10](https://github.com/google/googletest)
+    (to build tests and example programs, optional)
 
 On Ubuntu, all of these other than abseil can be installed via apt-get:
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -8,6 +8,8 @@ cc_library(
         "//s2:encoded_s2shape_index.cc",
         "//s2:encoded_string_vector.cc",
         "//s2:id_set_lexicon.cc",
+        "//s2:internal/s2index_cell_data.cc",
+        "//s2:internal/s2incident_edge_tracker.cc",
         "//s2:mutable_s2shape_index.cc",
         "//s2:r2rect.cc",
         "//s2:s1angle.cc",
@@ -90,6 +92,7 @@ cc_library(
         "//s2:s2shapeutil_contains_brute_force.cc",
         "//s2:s2shapeutil_conversion.cc",
         "//s2:s2shapeutil_edge_iterator.cc",
+        "//s2:s2shapeutil_edge_wrap.cc",
         "//s2:s2shapeutil_get_reference_point.cc",
         "//s2:s2shapeutil_visit_crossing_edge_pairs.cc",
         "//s2:s2text_format.cc",
@@ -104,6 +107,10 @@ cc_library(
         "//s2:encoded_string_vector.h",
         "//s2:encoded_uint_vector.h",
         "//s2:id_set_lexicon.h",
+        "//s2:internal/s2disjoint_set.h",
+        "//s2:internal/s2incident_edge_tracker.h",
+        "//s2:internal/s2index_cell_data.h",
+        "//s2:internal/s2meta.h",
         "//s2:mutable_s2shape_index.h",
         "//s2:r1interval.h",
         "//s2:r2.h",
@@ -213,12 +220,14 @@ cc_library(
         "//s2:s2shapeutil_conversion.h",
         "//s2:s2shapeutil_count_edges.h",
         "//s2:s2shapeutil_edge_iterator.h",
+        "//s2:s2shapeutil_edge_wrap.h",
         "//s2:s2shapeutil_get_reference_point.h",
         "//s2:s2shapeutil_shape_edge.h",
         "//s2:s2shapeutil_shape_edge_id.h",
         "//s2:s2shapeutil_testing.h",
         "//s2:s2shapeutil_visit_crossing_edge_pairs.h",
         "//s2:s2text_format.h",
+        "//s2:s2validation_query.h",
         "//s2:s2wedge_relations.h",
         "//s2:s2winding_operation.h",
         "//s2:s2wrapped_shape.h",
@@ -232,7 +241,6 @@ cc_library(
         "//s2/base:logging",
         "//s2/base:port",
         "//s2/base:spinlock",
-        "//s2/internal",
         "//s2/testing",
         "//s2/util/bitmap",
         "//s2/util/bits",
@@ -392,6 +400,16 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings:cord",
         "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "s2disjoint_set_test",
+    srcs = ["//s2:internal/s2disjoint_set_test.cc"],
+    deps = [
+        ":s2",
+        ":s2_testing_headers",
+        "@googletest//:gtest_main",
     ],
 )
 
@@ -976,6 +994,16 @@ cc_test(
 )
 
 cc_test(
+    name = "s2index_cell_data_test",
+    srcs = ["//s2:internal/s2index_cell_data_test.cc"],
+    deps = [
+        ":s2",
+        ":s2_testing_headers",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "s2latlng_test",
     srcs = ["//s2:s2latlng_test.cc"],
     deps = [
@@ -1416,6 +1444,16 @@ cc_test(
 )
 
 cc_test(
+    name = "s2shapeutil_edge_wrap_test",
+    srcs = ["//s2:s2shapeutil_edge_wrap_test.cc"],
+    deps = [
+        ":s2",
+        ":s2_testing_headers",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "s2shapeutil_get_reference_point_test",
     srcs = ["//s2:s2shapeutil_get_reference_point_test.cc"],
     deps = [
@@ -1448,6 +1486,16 @@ cc_test(
 cc_test(
     name = "s2text_format_test",
     srcs = ["//s2:s2text_format_test.cc"],
+    deps = [
+        ":s2",
+        ":s2_testing_headers",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "s2validation_query_test",
+    srcs = ["//s2:s2validation_query_test.cc"],
     deps = [
         ":s2",
         ":s2_testing_headers",
@@ -1504,5 +1552,3 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
-
-

--- a/src/s2/BUILD
+++ b/src/s2/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 exports_files(glob(
   include = [
+    "internal/*.h", "internal/*.cc",
     "r1*.h","r1*.cc",
     "r2*.h","r2*.cc",
     "s1*.h","s1*.cc",

--- a/src/s2/base/BUILD
+++ b/src/s2/base/BUILD
@@ -13,6 +13,15 @@ cc_library(
 )
 
 cc_library(
+    name = "malloc_extension",
+    hdrs = ["malloc_extension.h"],
+    srcs = ["malloc_extension.cc"],
+    deps = [
+        "@abseil-cpp//absl/base:core_headers",
+    ],
+)
+
+cc_library(
     name = "types",
     hdrs = ["types.h"],
 )

--- a/src/s2/base/malloc_extension.cc
+++ b/src/s2/base/malloc_extension.cc
@@ -1,0 +1,31 @@
+// Copyright Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "s2/base/malloc_extension.h"
+
+#include <cstddef>
+#include <new>
+
+#include "absl/base/attributes.h"
+
+ABSL_ATTRIBUTE_WEAK ABSL_ATTRIBUTE_NOINLINE size_t nallocx(size_t size,
+                                                           int) noexcept {
+  return size;
+}
+
+ABSL_ATTRIBUTE_WEAK ABSL_ATTRIBUTE_NOINLINE __sized_ptr_t
+__size_returning_new(size_t size) {
+  return {::operator new(size), size};
+}

--- a/src/s2/base/malloc_extension.h
+++ b/src/s2/base/malloc_extension.h
@@ -1,0 +1,47 @@
+// Copyright Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef S2_BASE_MALLOC_EXTENSION_H_
+#define S2_BASE_MALLOC_EXTENSION_H_
+
+// Some s2geometry functions use TCMalloc extensions.  Here, we provide
+// default implementations so s2geometry can be used with other allocators.
+//
+// See
+// https://github.com/google/tcmalloc/blob/master/tcmalloc/malloc_extension.h
+
+#include <cstddef>
+
+extern "C" {
+
+// `nallocx` performs the same size computation that `malloc` would perform.
+// The default weak implementation just returns the `size` argument.
+// See https://jemalloc.net/jemalloc.3.html
+size_t nallocx(size_t size, int flags) noexcept;
+
+// `__size_returning_new` returns a pointer to the allocated memory along
+// with the (possibly rounded up) actual allocation size used.  The default
+// weak implementation just returns the requested size.
+// This is a TCMalloc prototype of P0901R5 "Size feedback in operator new".
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0901r5.html
+struct __sized_ptr_t {
+  void* p;
+  size_t n;
+};
+__sized_ptr_t __size_returning_new(size_t size);
+
+}  // extern "C"
+
+#endif  // S2_BASE_MALLOC_EXTENSION_H_

--- a/src/s2/base/port.h
+++ b/src/s2/base/port.h
@@ -18,11 +18,27 @@
 
 // This file contains things that are not used in third_party/absl but needed by
 // s2geometry. It is structured into the following high-level categories:
+// - Utility functions
 // - Endianness
 // - Performance optimization (alignment)
 
 #include <cstdint>
 #include <cstring>
+
+// -----------------------------------------------------------------------------
+// Utility Functions
+// -----------------------------------------------------------------------------
+
+// C++14 sized deallocation
+namespace base {
+inline void sized_delete(void *ptr, size_t size) {
+  ::operator delete(ptr, size);
+}
+
+inline void sized_delete_array(void *ptr, size_t size) {
+  ::operator delete[](ptr, size);
+}
+}  // namespace base
 
 // -----------------------------------------------------------------------------
 // Endianness

--- a/src/s2/encoded_s2cell_id_vector.cc
+++ b/src/s2/encoded_s2cell_id_vector.cc
@@ -24,7 +24,6 @@
 #include "absl/log/absl_check.h"
 #include "absl/numeric/bits.h"
 #include "absl/types/span.h"
-#include "s2/util/bits/bits.h"
 #include "s2/util/coding/coder.h"
 #include "s2/encoded_uint_vector.h"
 #include "s2/s2cell_id.h"
@@ -107,7 +106,7 @@ void EncodeS2CellIdVector(Span<const S2CellId> v, Encoder* encoder) {
     // which case the shift is odd and the preceding bit is implicitly on).
     // There is no point in allowing shifts > 56 since deltas are encoded in
     // at least 1 byte each.
-    e_shift = min(56, Bits::FindLSBSetNonZero64(v_or) & ~1);
+    e_shift = min(56, absl::countr_zero(v_or) & ~1);
     if (v_and & (1ULL << e_shift)) ++e_shift;  // All S2CellIds same level.
 
     // "base" consists of the "base_len" most significant bytes of the minimum

--- a/src/s2/encoded_s2cell_id_vector.h
+++ b/src/s2/encoded_s2cell_id_vector.h
@@ -19,7 +19,6 @@
 #define S2_ENCODED_S2CELL_ID_VECTOR_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <vector>
 

--- a/src/s2/encoded_s2cell_id_vector_test.cc
+++ b/src/s2/encoded_s2cell_id_vector_test.cc
@@ -19,13 +19,13 @@
 
 #include <cstddef>
 #include <cstdint>
-
 #include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "absl/log/log_streamer.h"
 #include "absl/random/random.h"
+#include "absl/types/span.h"
 #include "s2/util/coding/coder.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1angle.h"
@@ -48,8 +48,8 @@ namespace {
 
 // Encodes the given vector and returns the corresponding
 // EncodedS2CellIdVector (which points into the Encoder's data buffer).
-EncodedS2CellIdVector MakeEncodedS2CellIdVector(const vector<S2CellId>& input,
-                                                Encoder* encoder) {
+EncodedS2CellIdVector MakeEncodedS2CellIdVector(
+    absl::Span<const S2CellId> input, Encoder* encoder) {
   EncodeS2CellIdVector(input, encoder);
   Decoder decoder(encoder->base(), encoder->length());
   EncodedS2CellIdVector cell_ids;
@@ -69,7 +69,7 @@ void TestEncodedS2CellIdVector(const vector<S2CellId>& expected,
 
 // Like the above, but accepts a vector<uint64_t> rather than a
 // vector<S2CellId>.
-void TestEncodedS2CellIdVector(const vector<uint64_t>& raw_expected,
+void TestEncodedS2CellIdVector(absl::Span<const uint64_t> raw_expected,
                                size_t expected_bytes) {
   vector<S2CellId> expected;
   for (uint64_t raw_id : raw_expected) {

--- a/src/s2/encoded_s2point_vector.h
+++ b/src/s2/encoded_s2point_vector.h
@@ -18,18 +18,20 @@
 #ifndef S2_ENCODED_S2POINT_VECTOR_H_
 #define S2_ENCODED_S2POINT_VECTOR_H_
 
-#include <cstddef>
-
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
+#include "absl/base/attributes.h"
+#include "absl/base/optimization.h"
 #include "absl/log/absl_log.h"
 #include "absl/types/span.h"
 #include "s2/util/coding/coder.h"
 #include "s2/encoded_string_vector.h"
 #include "s2/encoded_uint_vector.h"
 #include "s2/s2coder.h"
+#include "s2/s2error.h"
 #include "s2/s2point.h"
 
 namespace s2coding {
@@ -59,8 +61,22 @@ class EncodedS2PointVector {
 
   // Initializes the EncodedS2PointVector.
   //
+  // Encoded types do not necessarily read all of their data when calling
+  // Init(), instead only data necessary to decode further is read, which means
+  // that encoded types may in general log ERROR errors when reading from an
+  // untrusted byte stream using unchecked accessors (e.g. operator[]).
+  //
+  // Checked accessors such as Decode(S2Error&) will instead set an error
+  // condition, at the cost of potentially more overhead when decoding.
+  //
   // REQUIRES: The Decoder data buffer must outlive this object.
-  bool Init(Decoder* decoder);
+  ABSL_MUST_USE_RESULT bool Init(Decoder* decoder);
+
+  // Initializes the EncodedS2PointVector as above.  Setting S2Error if
+  // initialization fails.  A true return status does -not- mean that the byte
+  // stream is without errors.  The individual points must still be checked with
+  // a checked accessor such as Decode(S2Error&).
+  ABSL_MUST_USE_RESULT bool Init(Decoder* decoder, S2Error& error);
 
   // Returns the size of the original vector.
   size_t size() const;
@@ -70,6 +86,18 @@ class EncodedS2PointVector {
 
   // Decodes and returns the entire original vector.
   std::vector<S2Point> Decode() const;
+
+  // Decodes the entire original vector and stores it in the given span.
+  bool Decode(absl::Span<S2Point> points) const;
+
+  // Decodes and returns the entire original vector, checking for errors as it
+  // goes.  If an error occurs, a truncated vector is returned.
+  std::vector<S2Point> Decode(S2Error& error) const;
+
+  // Decodes the entire original vector and stores it in the given span.  Checks
+  // for errors as it goes.  If an error occurs returns false and the span may
+  // be incompletely written.
+  bool Decode(absl::Span<S2Point> points, S2Error& error) const;
 
   // Copy the encoded data to the encoder. This allows for "reserialization" of
   // encoded shapes created through lazy decoding.
@@ -84,9 +112,13 @@ class EncodedS2PointVector {
   friend void EncodeS2PointVectorFast(absl::Span<const S2Point>, Encoder*);
   friend void EncodeS2PointVectorCompact(absl::Span<const S2Point>, Encoder*);
 
+  // Decodes and returns the point at the given index.  If any errors occur when
+  // decoding, the error is set and a default constructed point returned.
+  S2Point At(int i, S2Error& error) const;
+
   bool InitUncompressedFormat(Decoder* decoder);
   bool InitCellIdsFormat(Decoder* decoder);
-  S2Point DecodeCellIdsFormat(int i) const;
+  S2Point DecodeCellIdsFormat(int i, S2Error* error) const;
 
   // We use a tagged union to represent multiple formats, as opposed to an
   // abstract base class or templating.  This represents the best compromise
@@ -128,18 +160,45 @@ inline size_t EncodedS2PointVector::size() const {
   return size_;
 }
 
-inline S2Point EncodedS2PointVector::operator[](int i) const {
+inline S2Point EncodedS2PointVector::At(int i, S2Error& error) const {
   switch (format_) {
     case Format::UNCOMPRESSED:
       return uncompressed_.points[i];
 
     case Format::CELL_IDS:
-      return DecodeCellIdsFormat(i);
+      return DecodeCellIdsFormat(i, &error);
 
     default:
-      ABSL_DLOG(FATAL) << "Unrecognized format";
-      return S2Point();
+      error = S2Error::DataLoss("Unrecognized format");
+      return {};
   }
+
+  ABSL_UNREACHABLE();
+}
+
+inline S2Point EncodedS2PointVector::operator[](int i) const {
+  // Check error conditions in debug mode, elide them otherwise.
+#ifndef NDEBUG
+  S2Error error;
+  S2Point point = At(i, error);
+  if (!error.ok()) {
+    ABSL_LOG(ERROR) << error.message();
+  }
+  return point;
+#else
+  switch (format_) {
+    case Format::UNCOMPRESSED:
+      return uncompressed_.points[i];
+
+    case Format::CELL_IDS:
+      return DecodeCellIdsFormat(i, nullptr);
+
+    default:
+      return {};
+  }
+
+  ABSL_UNREACHABLE();
+#endif
 }
 
 }  // namespace s2coding

--- a/src/s2/encoded_s2shape_index.cc
+++ b/src/s2/encoded_s2shape_index.cc
@@ -24,7 +24,8 @@
 #include <vector>
 
 #include "s2/base/casts.h"
-#include "s2/util/bits/bits.h"
+#include "absl/base/optimization.h"
+#include "absl/numeric/bits.h"
 #include "s2/util/coding/coder.h"
 #include "s2/util/coding/varint.h"
 #include "s2/encoded_s2cell_id_vector.h"
@@ -179,7 +180,8 @@ void EncodedS2ShapeIndex::Minimize() {
       uint64_t bits = cells_decoded_[i].load(std::memory_order_relaxed);
       if (bits == 0) continue;
       do {
-        int offset = Bits::FindLSBSetNonZero64(bits);
+        ABSL_ASSUME(bits != 0);
+        int offset = absl::countr_zero(bits);
         delete cells_[(i << 6) + offset];
         bits &= bits - 1;
       } while (bits != 0);

--- a/src/s2/encoded_s2shape_index.h
+++ b/src/s2/encoded_s2shape_index.h
@@ -18,9 +18,8 @@
 #ifndef S2_ENCODED_S2SHAPE_INDEX_H_
 #define S2_ENCODED_S2SHAPE_INDEX_H_
 
-#include <cstddef>
-
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -364,6 +363,7 @@ inline bool EncodedS2ShapeIndex::cell_decoded(int i) const {
 // Marks the given cell as having been decoded.
 // REQUIRES: cells_lock_ is held
 inline void EncodedS2ShapeIndex::set_cell_decoded(int i) const {
+  ABSL_DCHECK(cells_lock_.IsHeld());
   // We use memory_order_release for the store operation below to ensure that
   // cells_decoded(i) sees the most recent value, however we can use
   // memory_order_relaxed for the load because cells_lock_ is held.

--- a/src/s2/encoded_s2shape_index_test.cc
+++ b/src/s2/encoded_s2shape_index_test.cc
@@ -285,7 +285,7 @@ TEST(EncodedS2ShapeIndex, SnappedFractalPolylines) {
     builder.AddPolyline(polyline);
   }
   S2Error error;
-  ASSERT_TRUE(builder.Build(&error)) << error.text();
+  ASSERT_TRUE(builder.Build(&error)) << error.message();
   TestEncodedS2ShapeIndex<S2LaxPolylineShape, EncodedS2LaxPolylineShape>(
       index, 8698);
 }

--- a/src/s2/encoded_string_vector.cc
+++ b/src/s2/encoded_string_vector.cc
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-
 #include <string>
 #include <vector>
 

--- a/src/s2/encoded_string_vector.h
+++ b/src/s2/encoded_string_vector.h
@@ -19,7 +19,6 @@
 #define S2_ENCODED_STRING_VECTOR_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -124,7 +123,7 @@ class EncodedStringVector {
 
  private:
   EncodedUintVector<uint64_t> offsets_;
-  const char* data_;
+  const char* data_ = nullptr;
 };
 
 
@@ -159,7 +158,7 @@ inline absl::string_view EncodedStringVector::operator[](size_t i) const {
 inline Decoder EncodedStringVector::GetDecoder(size_t i) const {
   // Return an empty decoder if we don't have enough data.
   if (i >= offsets_.size()) {
-    return Decoder();
+    return Decoder(nullptr, 0);
   }
 
   uint64_t start = (i == 0) ? 0 : offsets_[i - 1];

--- a/src/s2/encoded_string_vector_test.cc
+++ b/src/s2/encoded_string_vector_test.cc
@@ -18,12 +18,12 @@
 #include "s2/encoded_string_vector.h"
 
 #include <cstddef>
-
 #include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "s2/util/coding/coder.h"
 
 using absl::string_view;
@@ -32,7 +32,7 @@ using std::vector;
 
 namespace s2coding {
 
-void TestEncodedStringVector(const vector<string>& input,
+void TestEncodedStringVector(absl::Span<const string> input,
                              size_t expected_bytes) {
   Encoder encoder;
   StringVectorEncoder::Encode(input, &encoder);

--- a/src/s2/encoded_uint_vector.h
+++ b/src/s2/encoded_uint_vector.h
@@ -19,17 +19,16 @@
 #define S2_ENCODED_UINT_VECTOR_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <limits>
 #include <type_traits>
 #include <vector>
 
-#include "s2/base/port.h"
+#include "absl/base/optimization.h"
 #include "absl/log/absl_check.h"
 #include "absl/types/span.h"
 
-#include "s2/util/bits/bits.h"
+#include "s2/base/port.h"
 #include "s2/util/coding/coder.h"
 #include "s2/util/coding/varint.h"
 
@@ -218,7 +217,8 @@ void EncodeUintVector(absl::Span<const T> v, Encoder* encoder) {
 
   T one_bits = 1;  // Ensures len >= 1.
   for (auto x : v) one_bits |= x;
-  int len = (Bits::FindMSBSetNonZero64(one_bits) >> 3) + 1;
+  ABSL_ASSUME(one_bits != 0);
+  int len = ((absl::bit_width(one_bits) - 1) >> 3) + 1;
   ABSL_DCHECK(len >= 1 && len <= 8);
 
   // Note that the multiplication is optimized into a bit shift.

--- a/src/s2/encoded_uint_vector_test.cc
+++ b/src/s2/encoded_uint_vector_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/encoded_uint_vector.h"
 
-#include <cstddef>
-
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/s2/gmock_matchers.cc
+++ b/src/s2/gmock_matchers.cc
@@ -17,7 +17,6 @@
 
 #include <cfloat>
 #include <cmath>
-
 #include <memory>
 #include <ostream>
 #include <string>

--- a/src/s2/id_set_lexicon.h
+++ b/src/s2/id_set_lexicon.h
@@ -19,7 +19,6 @@
 #define S2_ID_SET_LEXICON_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <iterator>
 #include <limits>

--- a/src/s2/id_set_lexicon_test.cc
+++ b/src/s2/id_set_lexicon_test.cc
@@ -24,10 +24,11 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/types/span.h"
 
 using std::vector;
 
-void ExpectIdSet(const vector<int32_t>& expected,
+void ExpectIdSet(absl::Span<const int32_t> expected,
                  const IdSetLexicon::IdSet& actual) {
   EXPECT_EQ(expected.size(), actual.size());
   EXPECT_TRUE(std::equal(expected.begin(), expected.end(), actual.begin()));

--- a/src/s2/internal/BUILD
+++ b/src/s2/internal/BUILD
@@ -1,6 +1,0 @@
-package(default_visibility = ["//visibility:public"])
-
-cc_library(
-    name = "internal",
-    hdrs = ["s2meta.h"]
-)

--- a/src/s2/internal/s2disjoint_set.h
+++ b/src/s2/internal/s2disjoint_set.h
@@ -1,0 +1,151 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#ifndef S2_INTERNAL_S2DISJOINT_SET_H_
+#define S2_INTERNAL_S2DISJOINT_SET_H_
+
+#include <optional>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/log/absl_check.h"
+
+namespace internal {
+
+// A disjoint set (AKA union-find set, AKA merge-find set) is a data structure
+// that stores a partition of a set into disjoint subsets.  It allows us to
+// efficiently add, merge and find a representative member of a set.
+//
+// In practice, disjoint sets are used for connected-component like algorithms
+// where we want to build up relationships between subsets and query the final
+// connected pieces.
+//
+// This implementation uses both path compression and union-by-size, so both the
+// Union and FindRoot operations have O(a(N)) amortized complexity, where a(n)
+// is the inverse Ackermann function.  For any value that we'll ever care about,
+// a(n) is less than 5, which is, for all practical purposes, constant.
+template <typename T>
+class DisjointSet {
+ public:
+  // Adds a new element to the set.  The root of the element is itself, that is,
+  // it's disjoint from all the other elements of the set.
+  //
+  // If the element is already in the set, no changes are made and false is
+  // returned, otherwise true.
+  //
+  // Immediately after calling Add(val), FindRoot(val) == val.
+  bool Add(const T& val);
+
+  // Finds the root of the given element. If the element isn't in the set,
+  // the returned optional has no value, otherwise it will contain the root.
+  std::optional<T> FindRoot(const T& val);
+
+  // Performs union of two subsets.  Makes the parent of a's subset equal to the
+  // parent of b's subset.  If either a or b isn't in the set, returns false and
+  // does not modify the set.
+  bool Union(const T& a, const T& b);
+
+  // Returns the total number of elements in the set.
+  int Size() const { return nodes_.size(); }
+
+  // Clears the set so that Size() == 0.
+  void Clear() { nodes_.clear(); }
+
+  // Reserve space for at least num elements.
+  void Reserve(int num) { nodes_.reserve(num); }
+
+ private:
+  struct Node {
+    explicit Node(const T& value) : value(value) {}
+    T value;
+    int size = 1;
+  };
+
+  // Implementation for find root, expects that val is in the set.  Recursively
+  // seeks to the root of the set and sets each element's parent to the root as
+  // it goes, returning a reference to the root node.
+  Node& FindRootImpl(const T& val);
+
+  absl::flat_hash_map<T, Node> nodes_;
+};
+
+template <typename T>
+bool DisjointSet<T>::Add(const T& val) {
+  return nodes_.emplace(val, Node(val)).second;
+}
+
+template <typename T>
+std::optional<T> DisjointSet<T>::FindRoot(const T& val) {
+  // Val might not be in the table at all, so use find for first lookup.
+  auto iter = nodes_.find(val);
+  if (iter == nodes_.end()) {
+    return {};
+  }
+
+  Node& node = iter->second;
+  if (node.value == val) {
+    return val;
+  }
+  return node.value = FindRootImpl(node.value).value;
+}
+
+template <typename T>
+typename DisjointSet<T>::Node& DisjointSet<T>::FindRootImpl(const T& val) {
+  auto iter = nodes_.find(val);
+  ABSL_DCHECK(iter != nodes_.end());
+
+  Node& node = iter->second;
+  if (node.value == val) {
+    return node;
+  }
+
+  // It can be shown that a disjoint set of size N has an upper bound on its
+  // height of floor(log(N)).  So even a billion element set will only recurse
+  // 30 levels in the worst case here.
+  Node& root = FindRootImpl(node.value);
+  node.value = root.value;
+  return root;
+}
+
+template <typename T>
+bool DisjointSet<T>::Union(const T& a, const T& b) {
+  auto iter_a = nodes_.find(a);
+  if (iter_a == nodes_.end()) {
+    return false;
+  }
+
+  auto iter_b = nodes_.find(b);
+  if (iter_b == nodes_.end()) {
+    return false;
+  }
+
+  Node& root_a = FindRootImpl(iter_a->second.value);
+  Node& root_b = FindRootImpl(iter_b->second.value);
+
+  if (root_a.value != root_b.value) {
+    if (root_a.size < root_b.size) {
+      root_a.value = root_b.value;
+      root_b.size += root_a.size;
+    } else {
+      root_b.value = root_a.value;
+      root_a.size += root_b.size;
+    }
+  }
+  return true;
+}
+
+}  // namespace internal
+
+#endif  // S2_INTERNAL_S2DISJOINT_SET_H_

--- a/src/s2/internal/s2disjoint_set_test.cc
+++ b/src/s2/internal/s2disjoint_set_test.cc
@@ -1,0 +1,105 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#include "s2/internal/s2disjoint_set.h"
+
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "absl/log/absl_check.h"
+#include "s2/s2point.h"
+
+namespace internal {
+namespace {
+
+TEST(DisjointSetTest, S2PointSetCompiles) {
+  DisjointSet<S2Point> set;
+  (void)set;
+}
+
+TEST(DisjointSetTest, InsertMoreThanOnceFails) {
+  DisjointSet<int> set;
+  EXPECT_TRUE(set.Add(1));
+  EXPECT_FALSE(set.Add(1));
+  EXPECT_FALSE(set.Add(1));
+}
+
+TEST(DisjointSetTest, FindRootWorks) {
+  DisjointSet<int> set;
+  set.Add(1);
+  std::optional<int> root = set.FindRoot(1);
+  ABSL_CHECK(root.has_value());
+  EXPECT_EQ(root.value(), 1);
+  EXPECT_FALSE(set.FindRoot(2).has_value());
+}
+
+TEST(DisjointSetTest, UnionWorks) {
+  DisjointSet<int> set;
+  for (int i = 0; i < 10; ++i) {
+    ABSL_CHECK(set.Add(i));
+  }
+
+  // Union into two disjoint sets
+  for (int i = 0; i < 4; ++i) {
+    ABSL_CHECK(set.Union(i + 0, i + 1));
+    ABSL_CHECK(set.Union(i + 5, i + 6));
+  }
+
+  // The values in the two sets should all have the same root now.
+  for (int i = 0; i < 5; ++i) {
+    std::optional<int> root = set.FindRoot(i);
+    ABSL_CHECK(root.has_value());
+    EXPECT_EQ(root.value(), 0);
+
+    root = set.FindRoot(i + 5);
+    ABSL_CHECK(root.has_value());
+    EXPECT_EQ(root.value(), 5);
+  }
+
+  // Check that attempting to union with something not in the set fails.
+  EXPECT_FALSE(set.Union(0, 13));
+  EXPECT_FALSE(set.Union(13, 0));
+  EXPECT_FALSE(set.Union(12, 13));
+
+  // Union of two elements from two sets should unify the sets
+  ABSL_CHECK(set.Union(3, 7));
+  for (int i = 0; i < 10; ++i) {
+    std::optional<int> root = set.FindRoot(i);
+    ABSL_CHECK(root.has_value());
+    EXPECT_EQ(root.value(), 0);
+  }
+}
+
+TEST(DisjointSetTest, SizeAndClearWorks) {
+  DisjointSet<int> set;
+  set.Reserve(10);
+  for (int i = 0; i < 10; ++i) {
+    ABSL_CHECK(set.Add(i));
+  }
+
+  EXPECT_EQ(set.Size(), 10);
+  for (int i = 0; i < set.Size() - 1; ++i) {
+    ABSL_CHECK(set.Union(i, i + 1));
+  }
+
+  // Unioning doesn't change size.
+  EXPECT_EQ(set.Size(), 10);
+  set.Clear();
+  EXPECT_EQ(set.Size(), 0);
+}
+
+}  // namespace
+}  // namespace internal

--- a/src/s2/internal/s2incident_edge_tracker.cc
+++ b/src/s2/internal/s2incident_edge_tracker.cc
@@ -1,0 +1,92 @@
+// Copyright Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "s2/internal/s2incident_edge_tracker.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/log/absl_check.h"
+
+namespace internal {
+
+void S2IncidentEdgeTracker::StartShape(int shape_id) {
+  nursery_.clear();
+  current_shape_ = shape_id;
+}
+
+void S2IncidentEdgeTracker::AddEdge(int edge_id, const S2Shape::Edge& edge) {
+  ABSL_DCHECK_GE(current_shape_, 0);
+
+  // Push non-degenerate edges into the nursery.
+  nursery_.push_back({edge.v0, edge_id});
+  if (!edge.IsDegenerate()) {
+    nursery_.push_back({edge.v1, edge_id});
+  }
+}
+
+void S2IncidentEdgeTracker::FinishShape() {
+  ABSL_DCHECK_GE(current_shape_, 0);
+
+  using std::swap;
+
+  // We want to keep any vertices with more than two incident edges.  We could
+  // sort the array by vertex and remove any with fewer, but that would require
+  // shifting the array and could turn quadratic quickly.
+  //
+  // Instead we'll scan forward from each vertex, swapping entries with the same
+  // vertex into a contiguous range.  Once we've done all the swapping we can
+  // just make sure that we have at least three edges in the range.
+  const int nursery_size = nursery_.size();
+  for (int start = 0; start < nursery_size;) {
+    int end = start + 1;
+
+    // Scan to the end of the array, swap entries so that entries with the same
+    // vertex as the start are adjacent.
+    int next = start;
+    const S2Point& curr_vertex = nursery_[start].vertex;
+    while (++next < nursery_size) {
+      if (nursery_[next].vertex == curr_vertex) {
+        swap(nursery_[next], nursery_[end++]);
+      }
+    }
+
+    // Most vertices will have two incident edges (the incoming edge and the
+    // outgoing edge), which aren't interesting, skip them.
+    const int num_edges = end - start;
+    if (ABSL_PREDICT_TRUE(num_edges <= 2)) {
+      start = end;
+      continue;
+    }
+
+    const IncidentEdgeKey key = {current_shape_, nursery_[start].vertex};
+
+    // If we don't have this key yet, create it manually with a pre-sized
+    // hash set to avoid rehashes.  Start with a size of 8, which is four
+    // edges with a load factor of 50%.
+    auto iter = incident_edge_map_.find(key);
+    if (iter == incident_edge_map_.end()) {
+      iter = incident_edge_map_.emplace(key, 8).first;
+    }
+
+    absl::flat_hash_set<int32_t>& edges = iter->second;
+    edges.reserve(edges.size() + num_edges);
+    while (start != end) {
+      edges.insert({nursery_[start++].edge_id});
+    }
+  }
+}
+
+}  // namespace internal

--- a/src/s2/internal/s2incident_edge_tracker.h
+++ b/src/s2/internal/s2incident_edge_tracker.h
@@ -1,0 +1,134 @@
+// Copyright Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef S2_INTERNAL_S2INCIDENT_EDGE_TRACKER_H_
+#define S2_INTERNAL_S2INCIDENT_EDGE_TRACKER_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "absl/container/btree_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "s2/s2point.h"
+#include "s2/s2shape.h"
+
+namespace internal {
+
+// A tuple of (shape id, vertex) that compares by shape id.
+struct IncidentEdgeKey {
+  IncidentEdgeKey() = default;
+
+  explicit IncidentEdgeKey(int shape_id)
+      : shape_id(shape_id) { /* Leave vertex undefined */
+  }
+
+  IncidentEdgeKey(int shape_id, S2Point vertex)
+      : shape_id(shape_id), vertex(vertex) {}
+
+  int32_t shape_id;
+  S2Point vertex;
+
+  // We need a strict ordering to be a valid key for an ordered container, but
+  // we don't actually care about the ordering of the vertices (as long as
+  // they're grouped by shape id).  Vertices are 3D points so they don't have a
+  // natural ordering, so we'll just compare them lexicographically.
+  bool operator<(const IncidentEdgeKey& b) const {
+    if (shape_id < b.shape_id) return true;
+    if (shape_id > b.shape_id) return false;
+    for (int i = 0; i < 3; ++i) {
+      if (vertex[i] < b.vertex[i]) return true;
+      if (vertex[i] > b.vertex[i]) return false;
+    }
+    return false;  // Must be equal.
+  }
+};
+
+// Map from keys of (shape id, vertex) to a set of edge_ids.  We can and do
+// encounter the same edges multiple times, so we need to use a set to
+// deduplicate edges as they're inserted.
+using IncidentEdgeSet =
+    absl::btree_map<IncidentEdgeKey, absl::flat_hash_set<int32_t>>;
+
+// A class for detecting and tracking shape edges that are incident on the same
+// vertex.  Edges of multiple shapes may be tracked, but lookup is by shape id
+// and vertex: there is no facility to get all edges of all shapes at a vertex.
+// Edge vertices must compare exactly equal to be considered the same vertex, no
+// tolerance is applied as this isn't intended for e.g.: snapping shapes
+// together, which S2Builder does better and more robustly.
+//
+// To use, instantiate and then add edges with one or more sequences of calls,
+// where each sequence begins with StartShape(), followed by AddEdge() calls to
+// add edges for that shape, and ends with FinishShape().  Those sequences do
+// not need to visit shapes or edges in order. Then, call incidentEdges() to get
+// the resulting map from IncidentEdgeKeys (which are shapeId, vertex pairs) to
+// a set of edgeIds of the shape that are incident to that vertex..
+//
+// This works on a block of edges at a time, meaning that to detect incident
+// edges on a particular vertex, we must have at least three edges incident
+// at that vertex when FinishShape() is called. We don't maintain partial
+// information between calls.  However, subject to this constraint, a single
+// shape's edges may be defined with multiple sequences of StartShape(),
+// AddEdge()... , FinishShape() calls.
+//
+// The reason for this is simple: most edges don't have more than two incident
+// edges (the incoming and outgoing edge). If we had to maintain information
+// between calls, we'd end up with a map that contains every vertex, to no
+// benefit.  Instead, when FinishShape() is called, we discard vertices that
+// contain two or fewer incident edges.
+//
+// In principle this isn't a real limitation because generally we process an
+// S2ShapeIndex cell at a time, and, if a vertex has multiple edges, we'll see
+// all the edges in the same cell as the vertex, and, in general, it's possible
+// to aggregate edges before calling.
+//
+// The tracker maintains incident edges until it's cleared.  If you call it with
+// each cell from an S2ShapeIndex, then at the end you will have all the
+// incident edge information for the whole index.  If only a subset is needed,
+// call Reset() when you're done.
+class S2IncidentEdgeTracker {
+ public:
+  // Add edges to the edge tracker.  After calling, any vertices with multiple
+  // (> 2) incident edges will appear in the incident edge map.
+  void StartShape(int shape_id);
+  void AddEdge(int edge_id, const S2Shape::Edge& edge);
+  void FinishShape();
+
+  // Clear any accumulated state.
+  void Reset() { incident_edge_map_.clear(); }
+
+  // Returns a const reference to the incident edge map.
+  const IncidentEdgeSet& IncidentEdges() const { return incident_edge_map_; }
+
+ private:
+  // Scratch space to temporarily store incident edges in.  Having a separate
+  // space for these lets us remove vertices with only one incident edge
+  // easily.
+  struct VertexEdge {
+    S2Point vertex;
+    int32_t edge_id;
+  };
+  std::vector<VertexEdge> nursery_;
+
+  int current_shape_ = -1;
+
+  // Actual incident edge map.
+  IncidentEdgeSet incident_edge_map_;
+};
+
+}  // namespace internal
+
+#endif  // S2_INTERNAL_S2INCIDENT_EDGE_TRACKER_H_

--- a/src/s2/internal/s2index_cell_data.cc
+++ b/src/s2/internal/s2index_cell_data.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-#include "s2/s2index_cell_data.h"
+#include "s2/internal/s2index_cell_data.h"
 
 #include <algorithm>
 #include <atomic>
@@ -24,6 +24,8 @@
 #include "s2/s2cell.h"
 #include "s2/s2padded_cell.h"
 #include "s2/s2shape.h"
+
+namespace internal {
 
 void S2IndexCellData::LoadCell(const S2ShapeIndex* index, S2CellId id,
                                const S2ShapeIndexCell* cell) {
@@ -204,3 +206,5 @@ bool S2IndexCellData::ShapeContains(const S2ClippedShape& clipped,
   }
   return inside;
 }
+
+}  // namespace internal

--- a/src/s2/internal/s2index_cell_data.h
+++ b/src/s2/internal/s2index_cell_data.h
@@ -13,26 +13,28 @@
 // limitations under the License.
 //
 
-#ifndef S2_S2INDEX_CELL_DATA_H_
-#define S2_S2INDEX_CELL_DATA_H_
+#ifndef S2_INTERNAL_S2INDEX_CELL_DATA_H_
+#define S2_INTERNAL_S2INDEX_CELL_DATA_H_
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <utility>
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
-#include "absl/container/flat_hash_set.h"
 #include "absl/log/absl_check.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
 #include "s2/s2cell.h"
+#include "s2/s2cell_id.h"
 #include "s2/s2contains_point_query.h"
+#include "s2/s2point.h"
 #include "s2/s2shape.h"
 #include "s2/s2shape_index.h"
 
 // A class for working with S2ShapeIndexCell data.  For larger queries like
-// validation, we often look up up edges multiple times, and sometimes need to
+// validation, we often look up edges multiple times, and sometimes need to
 // work with the edges themselves, their edge ids, or their chain and offset.
 //
 // S2ShapeIndexCell and the S2ClippedShape APIs fundamentally work with edge ids
@@ -71,6 +73,8 @@
 //
 // The clipped shapes in a cell are exposed through the Shapes() method.
 //
+namespace internal {
+
 class S2IndexCellData {
  public:
   // Extension of Edge with fields for the edge id, chain id, and offset.  It's
@@ -236,7 +240,7 @@ class S2IndexCellData {
   // access the values through a const reference though, so we have to
   // synchronize access ourselves.
   //
-  // TODO: We can use std::atomic_flag instead when C++20 is allowed.
+  // TODO(b/335677213): Use std::atomic_flag instead when C++20 is allowed.
   mutable std::atomic<bool> s2cell_set_ = false;
   mutable std::atomic<bool> center_set_ = false;
   mutable absl::Mutex lock_;
@@ -262,4 +266,6 @@ class S2IndexCellData {
   Region dim_regions_[3];
 };
 
-#endif  // S2_S2INDEX_CELL_DATA_H_
+}  // namespace internal
+
+#endif  // S2_INTERNAL_S2INDEX_CELL_DATA_H_

--- a/src/s2/internal/s2index_cell_data_test.cc
+++ b/src/s2/internal/s2index_cell_data_test.cc
@@ -14,7 +14,7 @@
 //
 
 
-#include "s2/s2index_cell_data.h"
+#include "s2/internal/s2index_cell_data.h"
 
 #include <memory>
 
@@ -25,6 +25,7 @@
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
 
+namespace internal {
 namespace {
 
 using ::std::unique_ptr;
@@ -153,3 +154,4 @@ TEST(S2IndexCellData, CellAndCenterRecomputed) {
 }
 
 }  // namespace
+}  // namespace internal

--- a/src/s2/mutable_s2shape_index.h
+++ b/src/s2/mutable_s2shape_index.h
@@ -31,6 +31,7 @@
 #include "absl/container/btree_map.h"
 #include "absl/log/absl_check.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/span.h"
 
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/base/commandlineflags.h"
@@ -136,7 +137,8 @@ class BTreeMap : public absl::btree_map<Key, Value> {
 // in the S2ShapeIndexCell that contains that point.
 class MutableS2ShapeIndex final : public S2ShapeIndex {
  private:
-  using CellMap = s2internal::BTreeMap<S2CellId, S2ShapeIndexCell*>;
+  using CellMap =
+      s2internal::BTreeMap<S2CellId, std::unique_ptr<S2ShapeIndexCell>>;
 
  public:
   // The amount by which cells are "padded" to compensate for numerical errors
@@ -465,7 +467,7 @@ class MutableS2ShapeIndex final : public S2ShapeIndex {
                    InteriorTracker* tracker) const;
   void FinishPartialShape(int shape_id);
   void AddFaceEdge(FaceEdge* edge, std::vector<FaceEdge> all_edges[6]) const;
-  void UpdateFaceEdges(int face, const std::vector<FaceEdge>& face_edges,
+  void UpdateFaceEdges(int face, absl::Span<const FaceEdge> face_edges,
                        InteriorTracker* tracker);
   S2CellId ShrinkToFit(const S2PaddedCell& pcell, const R2Rect& bound) const;
   void SkipCellRange(S2CellId begin, S2CellId end, InteriorTracker* tracker,

--- a/src/s2/mutable_s2shape_index_test.cc
+++ b/src/s2/mutable_s2shape_index_test.cc
@@ -17,10 +17,9 @@
 
 #include "s2/mutable_s2shape_index.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
-
-#include <algorithm>
 #include <memory>
 #include <numeric>
 #include <thread>
@@ -39,11 +38,11 @@
 #include "absl/random/random.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/types/span.h"
 
 #include "s2/base/commandlineflags.h"
 #include "s2/base/commandlineflags_declare.h"
 #include "s2/base/log_severity.h"
-#include "s2/base/types.h"
 #include "s2/r2.h"
 #include "s2/r2rect.h"
 #include "s2/s1angle.h"
@@ -113,14 +112,14 @@ class MutableS2ShapeIndexTest : public ::testing::Test {
   using BatchDescriptor = MutableS2ShapeIndex::BatchDescriptor;
 
   // Converts the given vector of batches to a human-readable form.
-  static string ToString(const vector<BatchDescriptor>& batches);
+  static string ToString(absl::Span<const BatchDescriptor> batches);
 
   // Verifies that removing and adding the given combination of shapes with
   // the given memory budget yields the expected vector of batches.
   void TestBatchGenerator(int num_edges_removed,
-                          const vector<int>& shape_edges_added,
+                          absl::Span<const int> shape_edges_added,
                           int64_t tmp_memory_budget, int shape_id_begin,
-                          const vector<BatchDescriptor>& expected_batches);
+                          absl::Span<const BatchDescriptor> expected_batches);
 };
 
 void MutableS2ShapeIndexTest::QuadraticValidate() {
@@ -237,7 +236,7 @@ void MutableS2ShapeIndexTest::TestEncodeDecode() {
 }
 
 /*static*/ string MutableS2ShapeIndexTest::ToString(
-    const vector<BatchDescriptor>& batches) {
+    absl::Span<const BatchDescriptor> batches) {
   string result;
   for (const auto& batch : batches) {
     if (!result.empty()) result += ", ";
@@ -250,9 +249,9 @@ void MutableS2ShapeIndexTest::TestEncodeDecode() {
 }
 
 void MutableS2ShapeIndexTest::TestBatchGenerator(
-    int num_edges_removed, const vector<int>& shape_edges_added,
+    int num_edges_removed, absl::Span<const int> shape_edges_added,
     int64_t tmp_memory_budget, int shape_id_begin,
-    const vector<BatchDescriptor>& expected_batches) {
+    absl::Span<const BatchDescriptor> expected_batches) {
   absl::FlagSaver fs;
   absl::SetFlag(&FLAGS_s2shape_index_tmp_memory_budget, tmp_memory_budget);
 

--- a/src/s2/r1interval.h
+++ b/src/s2/r1interval.h
@@ -171,7 +171,7 @@ class R1Interval {
   // The interval must be non-empty.
   double Project(double p) const {
     ABSL_DCHECK(!is_empty());
-    return std::max(lo(), std::min(hi(), p));
+    return std::clamp(p, lo(), hi());
   }
 
   // Return an interval that has been expanded on each side by the given

--- a/src/s2/s1angle.cc
+++ b/src/s2/s1angle.cc
@@ -54,7 +54,7 @@ void S1Angle::Coder::Encode(Encoder& encoder, const S1Angle& angle) const {
 bool S1Angle::Coder::Decode(Decoder& decoder, S1Angle& angle,
                             S2Error& error) const {
   if (decoder.avail() < sizeof(double)) {
-    error.Init(S2Error::DATA_LOSS, "Could not decode S1Angle.");
+    error = S2Error::DataLoss("Could not decode S1Angle.");
     return false;
   }
   angle = Radians(decoder.getdouble());

--- a/src/s2/s1angle_test.cc
+++ b/src/s2/s1angle_test.cc
@@ -23,7 +23,6 @@
 
 #include <gtest/gtest.h>
 
-#include "absl/flags/flag.h"
 #include "absl/log/log_streamer.h"
 #include "absl/random/random.h"
 
@@ -130,6 +129,15 @@ TEST(S1Angle, Trigonometry) {
   EXPECT_DOUBLE_EQ(1, cos(S1Angle::Degrees(0)));
   EXPECT_DOUBLE_EQ(1, sin(S1Angle::Degrees(90)));
   EXPECT_DOUBLE_EQ(1, tan(S1Angle::Degrees(45)));
+
+  // Expect that SinCos is exactly [sin, cos].
+  for (int k = -1000; k <= 1000; ++k) {
+    const S1Angle angle = S1Angle::Degrees(k);
+    const S1Angle::SinCosPair sin_cos = angle.SinCos();
+    // If this fails once, it will likely fail many times.
+    ASSERT_EQ(sin_cos.sin, sin(angle));
+    ASSERT_EQ(sin_cos.cos, cos(angle));
+  }
 }
 
 TEST(S1Angle, ConstructorsThatMeasureAngles) {

--- a/src/s2/s1chord_angle.cc
+++ b/src/s2/s1chord_angle.cc
@@ -79,6 +79,19 @@ double S1ChordAngle::GetS1AngleConstructorMaxError() const {
 }
 
 S1ChordAngle operator+(S1ChordAngle a, S1ChordAngle b) {
+  // Error Analysis:
+  //
+  //   u is the unit round-off, equal to ε/2 = 2^-53
+  //   x and y below are both computed with (1+u)² error.  So we have
+  //     length2 = x + y + 2*sqrt(x * y)
+  //     length2 = ((x + y)(1+u)³ + 2*sqrt((x * y)((1+u)³))(1+u))(1+u)
+  //
+  //   Taking (1+u)^1.5 out of the square root and rounding (1+u)^2.5 to (1+u)³:
+  //     length2 = (x + y + 2*sqrt(x * y))(1+u)⁴
+  //
+  //   Bounding (1+u)⁴ as 4*1.01u = 4.04*ε/2 = 2.02ε, total relative error is:
+  //     length2()*2.02ε.
+
   // Note that this method is much more efficient than converting the chord
   // angles to S1Angles and adding those.  It requires only one square root
   // plus a few additions and multiplications.

--- a/src/s2/s1chord_angle.h
+++ b/src/s2/s1chord_angle.h
@@ -19,6 +19,7 @@
 #define S2_S1CHORD_ANGLE_H_
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -122,6 +123,11 @@
 // the default copy constructor and assignment operator.
 class S1ChordAngle {
  public:
+  // Maximum relative error when summing two S1ChordAngles together.
+  // Absolute error is length2() of the summed S1ChordAngle() times this value.
+  // See the definition of operator+() for the error analysis.
+  static constexpr double kRelativeSumError = 2.02 * DBL_EPSILON;
+
   // The default constructor yields a zero angle.  This is useful for STL
   // containers and class methods with output arguments.
   constexpr S1ChordAngle() = default;

--- a/src/s2/s1chord_angle_test.cc
+++ b/src/s2/s1chord_angle_test.cc
@@ -15,11 +15,9 @@
 
 #include "s2/s1chord_angle.h"
 
-#include <cmath>
-
 #include <cfloat>
+#include <cmath>
 #include <limits>
-#include <string>
 
 #include <gtest/gtest.h>
 #include "absl/log/log_streamer.h"
@@ -30,6 +28,7 @@
 #include "s2/s2predicates.h"
 #include "s2/s2random.h"
 #include "s2/s2testing.h"
+#include "s2/util/math/matrix3x3.h"
 
 using std::numeric_limits;
 

--- a/src/s2/s1interval.h
+++ b/src/s2/s1interval.h
@@ -228,7 +228,7 @@ inline S1Interval::S1Interval(double lo, double hi) : bounds_(lo, hi) {
 }
 
 inline S1Interval::S1Interval(double lo, double hi, ArgsChecked dummy)
-  : bounds_(lo, hi) {
+    : bounds_(lo, hi) {
   ABSL_DCHECK(is_valid());
 }
 

--- a/src/s2/s2boolean_operation_test.cc
+++ b/src/s2/s2boolean_operation_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2boolean_operation.h"
 
 #include <cmath>
-
 #include <memory>
 #include <string>
 #include <utility>
@@ -37,6 +36,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 #include "s2/base/commandlineflags_declare.h"
 #include "s2/mutable_s2shape_index.h"
@@ -1058,7 +1058,7 @@ class DegeneracyCoverageTest : public ::testing::Test {
   // Verifies that the S2BooleanOperation results for the given OpType and
   // PolygonModel match the given set of rules (encoded as described below).
   void Run(OpType op_type, PolygonModel polygon_model,
-           const vector<string>& rules);
+           absl::Span<const string> rules);
 
  private:
   // The inputs to the test cases are intended to span all possible types of
@@ -1147,7 +1147,7 @@ class DegeneracyCoverageTest : public ::testing::Test {
 };
 
 void DegeneracyCoverageTest::Run(OpType op_type, PolygonModel polygon_model,
-                                 const vector<string>& rules) {
+                                 absl::Span<const string> rules) {
   ABSL_CHECK_EQ(rules.size(), kInputChars.size());
 
   // For the symmetric operators (i.e., all except difference) we only need to

--- a/src/s2/s2buffer_operation.cc
+++ b/src/s2/s2buffer_operation.cc
@@ -762,8 +762,8 @@ void S2BufferOperation::AddShapeIndex(const S2ShapeIndex& index) {
 
 bool S2BufferOperation::Build(S2Error* error) {
   if (buffer_sign_ < 0 && num_polygon_layers_ > 1) {
-    error->Init(S2Error::FAILED_PRECONDITION,
-                "Negative buffer radius requires at most one polygon layer");
+    *error = S2Error::FailedPrecondition(
+        "Negative buffer radius requires at most one polygon layer");
     return false;
   }
   return op_.Build(ref_point_, ref_winding_,

--- a/src/s2/s2buffer_operation_test.cc
+++ b/src/s2/s2buffer_operation_test.cc
@@ -17,11 +17,10 @@
 
 #include "s2/s2buffer_operation.h"
 
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <cstdlib>
-
-#include <algorithm>
 #include <functional>
 #include <iostream>
 #include <memory>

--- a/src/s2/s2builder.cc
+++ b/src/s2/s2builder.cc
@@ -68,11 +68,10 @@
 
 #include "s2/s2builder.h"
 
-#include <cstddef>
-
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <memory>
@@ -85,6 +84,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
+#include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 
 #include "s2/base/casts.h"
@@ -356,7 +356,8 @@ void S2Builder::set_label(Label label) {
 
 bool S2Builder::IsFullPolygonUnspecified(const S2Builder::Graph& g,
                                          S2Error* error) {
-  error->Init(S2Error::BUILDER_IS_FULL_PREDICATE_NOT_SPECIFIED,
+  *error =
+      S2Error(S2Error::BUILDER_IS_FULL_PREDICATE_NOT_SPECIFIED,
               "A degenerate polygon was found, but no predicate was specified "
               "to determine whether the polygon is empty or full.  Call "
               "S2Builder::AddIsFullPolygonPredicate() to fix this problem.");
@@ -531,7 +532,7 @@ bool S2Builder::Build(S2Error* error) {
   // clients think about error handling.
   ABSL_CHECK(error != nullptr);
   error_ = error;
-  error_->Clear();
+  *error_ = S2Error::Ok();
 
   // Mark the end of the last layer.
   layer_begins_.push_back(input_edges_.size());
@@ -623,16 +624,18 @@ void S2Builder::ChooseAllVerticesAsSites() {
 
 vector<S2Builder::InputVertexKey> S2Builder::SortInputVertices() {
   // Sort all the input vertices in the order that we wish to consider them as
-  // candidate Voronoi sites.  Any sort order will produce correct output, so
-  // we have complete flexibility in choosing the sort key.  We could even
-  // leave them unsorted, although this would have the disadvantage that
-  // changing the order of the input edges could cause S2Builder to snap to a
-  // different set of Voronoi sites.
+  // candidate Voronoi sites.  ChooseAllVerticesAsSites() requires duplicate
+  // points be adjacent in the sorted output for deduplication.  Otherwise, any
+  // sort order will produce correct output, so we have complete flexibility in
+  // choosing the sort key.  We could even leave them unsorted, although this
+  // would have the disadvantage that changing the order of the input edges
+  // could cause S2Builder to snap to a different set of Voronoi sites.
   //
   // We have chosen to sort them primarily by S2CellId since this improves the
-  // performance of many S2Builder phases (due to better spatial locality).
-  // It also allows the possibility of replacing the current S2PointIndex
-  // approach with a more efficient recursive divide-and-conquer algorithm.
+  // performance of many S2Builder phases (due to better spatial locality).  It
+  // also allows the possibility of replacing the current S2PointIndex approach
+  // with a more efficient recursive divide-and-conquer algorithm.  Ties are
+  // broken by comparing the S2Point values of vertices lexicographically.
   //
   // However, sorting by leaf S2CellId alone has two small disadvantages in
   // the case where the candidate sites are densely spaced relative to the
@@ -798,12 +801,14 @@ S2Point S2Builder::SnapSite(const S2Point& point) const {
   S2Point site = options_.snap_function().SnapPoint(point);
   S1ChordAngle dist_moved(site, point);
   if (dist_moved > site_snap_radius_ca_) {
-    error_->Init(S2Error::BUILDER_SNAP_RADIUS_TOO_SMALL,
-                 "Snap function moved vertex (%.15g, %.15g, %.15g) "
-                 "by %.15g, which is more than the specified snap "
-                 "radius of %.15g", point.x(), point.y(), point.z(),
-                 dist_moved.ToAngle().radians(),
-                 site_snap_radius_ca_.ToAngle().radians());
+    *error_ = S2Error(
+        S2Error::BUILDER_SNAP_RADIUS_TOO_SMALL,
+        absl::StrFormat("Snap function moved vertex (%.15g, %.15g, %.15g) "
+                        "by %.15g, which is more than the specified snap "
+                        "radius of %.15g",
+                        point.x(), point.y(), point.z(),
+                        dist_moved.ToAngle().radians(),
+                        site_snap_radius_ca_.ToAngle().radians()));
   }
   return site;
 }
@@ -938,7 +943,7 @@ void S2Builder::AddExtraSites(const MutableS2ShapeIndex& input_edge_index) {
 }
 
 void S2Builder::MaybeAddExtraSites(
-    InputEdgeId edge_id, const vector<SiteId>& chain,
+    InputEdgeId edge_id, absl::Span<const SiteId> chain,
     const MutableS2ShapeIndex& input_edge_index,
     flat_hash_set<InputEdgeId>* edges_to_resnap) {
   // If the memory tracker has a periodic callback function, tally an amount
@@ -1326,8 +1331,8 @@ void S2Builder::BuildLayers() {
   }
 }
 
-static void DumpEdges(const vector<S2Builder::Graph::Edge>& edges,
-                      const vector<S2Point>& vertices) {
+static void DumpEdges(absl::Span<const S2Builder::Graph::Edge> edges,
+                      absl::Span<const S2Point> vertices) {
   for (const auto& e : edges) {
     vector<S2Point> v;
     v.push_back(vertices[e.first]);
@@ -1496,9 +1501,8 @@ class S2Builder::EdgeChainSimplifier {
                   flat_hash_set<VertexId>* used_vertices,
                   S2PolylineSimplifier* simplifier) const;
   void MergeChain(const vector<VertexId>& vertices);
-  void AssignDegenerateEdges(
-      const vector<InputEdgeId>& degenerate_ids,
-      vector<vector<InputEdgeId>>* merged_ids) const;
+  void AssignDegenerateEdges(absl::Span<const InputEdgeId> degenerate_ids,
+                             vector<vector<InputEdgeId>>* merged_ids) const;
 
   // LINT.IfChange
   const S2Builder& builder_;
@@ -1574,8 +1578,8 @@ void S2Builder::SimplifyEdgeChains(
 // that we can construct a single graph.  The sort is stable, which means that
 // any duplicate edges within each layer will still be sorted by InputEdgeId.
 void S2Builder::MergeLayerEdges(
-    const vector<vector<Edge>>& layer_edges,
-    const vector<vector<InputEdgeIdSetId>>& layer_input_edge_ids,
+    absl::Span<const vector<Edge>> layer_edges,
+    absl::Span<const vector<InputEdgeIdSetId>> layer_input_edge_ids,
     vector<Edge>* edges, vector<InputEdgeIdSetId>* input_edge_ids,
     vector<int>* edge_layers) const {
   vector<LayerEdgeId> order;
@@ -1585,9 +1589,9 @@ void S2Builder::MergeLayerEdges(
     }
   }
   std::sort(order.begin(), order.end(),
-    [&layer_edges](const LayerEdgeId& ai, const LayerEdgeId& bi) {
-         return StableLessThan(layer_edges[ai.first][ai.second],
-                               layer_edges[bi.first][bi.second], ai, bi);
+            [layer_edges](const LayerEdgeId& ai, const LayerEdgeId& bi) {
+              return StableLessThan(layer_edges[ai.first][ai.second],
+                                    layer_edges[bi.first][bi.second], ai, bi);
             });
   edges->reserve(order.size());
   input_edge_ids->reserve(order.size());
@@ -2041,7 +2045,7 @@ void S2Builder::EdgeChainSimplifier::MergeChain(
 // interior of an edge chain, assigns each input edge id to one of the output
 // edges.
 void S2Builder::EdgeChainSimplifier::AssignDegenerateEdges(
-    const vector<InputEdgeId>& degenerate_ids,
+    absl::Span<const InputEdgeId> degenerate_ids,
     vector<vector<InputEdgeId>>* merged_ids) const {
   // Each degenerate edge is assigned to an output edge in the appropriate
   // layer.  If there is more than one candidate, we use heuristics so that if
@@ -2094,7 +2098,6 @@ void S2Builder::EdgeChainSimplifier::AssignDegenerateEdges(
     (*merged_ids)[it[0]].push_back(degenerate_id);
   }
 }
-
 
 /////////////////////// S2Builder::MemoryTracker /////////////////////////
 
@@ -2157,8 +2160,8 @@ bool S2Builder::MemoryTracker::DoneSiteIndex(
 // Called to indicate that edge simplification was requested.
 // LINT.IfChange(TallySimplifyEdgeChains)
 bool S2Builder::MemoryTracker::TallySimplifyEdgeChains(
-    const vector<compact_array<InputVertexId>>& site_vertices,
-    const vector<vector<Edge>>& layer_edges) {
+    absl::Span<const compact_array<InputVertexId>> site_vertices,
+    absl::Span<const vector<Edge>> layer_edges) {
   if (!is_active()) return true;
 
   // The simplify_edge_chains() option uses temporary memory per site
@@ -2202,7 +2205,7 @@ bool S2Builder::MemoryTracker::TallySimplifyEdgeChains(
 // Tracks the temporary memory used by Graph::FilterVertices.
 // LINT.IfChange(TallyFilterVertices)
 bool S2Builder::MemoryTracker::TallyFilterVertices(
-    int num_sites, const vector<vector<Edge>>& layer_edges) {
+    int num_sites, absl::Span<const vector<Edge>> layer_edges) {
   if (!is_active()) return true;
 
   // Vertex filtering (see BuildLayers) uses temporary space of one VertexId

--- a/src/s2/s2builder.h
+++ b/src/s2/s2builder.h
@@ -32,6 +32,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
+#include "absl/types/span.h"
 
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/id_set_lexicon.h"
@@ -332,7 +333,7 @@ class S2Builder {
     bool split_crossing_edges() const;
     void set_split_crossing_edges(bool split_crossing_edges);
 
-    // Specifes the maximum allowable distance between a vertex added by
+    // Specifies the maximum allowable distance between a vertex added by
     // AddIntersection() and the edge(s) that it is intended to snap to.  This
     // method must be called before AddIntersection() can be used.  It has the
     // effect of increasing the snap radius for edges (but not vertices) by
@@ -803,11 +804,11 @@ class S2Builder {
     bool DoneSiteIndex(const S2PointIndex<SiteId>& index);
 
     bool TallySimplifyEdgeChains(
-        const std::vector<gtl::compact_array<InputVertexId>>& site_vertices,
-        const std::vector<std::vector<Edge>>& layer_edges);
+        absl::Span<const gtl::compact_array<InputVertexId>> site_vertices,
+        absl::Span<const std::vector<Edge>> layer_edges);
 
     bool TallyFilterVertices(int num_sites,
-                             const std::vector<std::vector<Edge>>& layer_edges);
+                             absl::Span<const std::vector<Edge>> layer_edges);
     bool DoneFilterVertices();
 
    private:
@@ -836,7 +837,7 @@ class S2Builder {
   void InsertSiteByDistance(SiteId new_site_id, const S2Point& x,
                             gtl::compact_array<SiteId>* sites);
   void AddExtraSites(const MutableS2ShapeIndex& input_edge_index);
-  void MaybeAddExtraSites(InputEdgeId edge_id, const std::vector<SiteId>& chain,
+  void MaybeAddExtraSites(InputEdgeId edge_id, absl::Span<const SiteId> chain,
                           const MutableS2ShapeIndex& input_edge_index,
                           absl::flat_hash_set<InputEdgeId>* edges_to_resnap);
   void AddExtraSite(const S2Point& new_site,
@@ -870,10 +871,9 @@ class S2Builder {
       std::vector<std::vector<InputEdgeIdSetId>>* layer_input_edge_ids,
       IdSetLexicon* input_edge_id_set_lexicon);
   void MergeLayerEdges(
-      const std::vector<std::vector<Edge>>& layer_edges,
-      const std::vector<std::vector<InputEdgeIdSetId>>& layer_input_edge_ids,
-      std::vector<Edge>* edges,
-      std::vector<InputEdgeIdSetId>* input_edge_ids,
+      absl::Span<const std::vector<Edge>> layer_edges,
+      absl::Span<const std::vector<InputEdgeIdSetId>> layer_input_edge_ids,
+      std::vector<Edge>* edges, std::vector<InputEdgeIdSetId>* input_edge_ids,
       std::vector<int>* edge_layers) const;
   static bool StableLessThan(const Edge& a, const Edge& b,
                              const LayerEdgeId& ai, const LayerEdgeId& bi);

--- a/src/s2/s2builder_graph.h
+++ b/src/s2/s2builder_graph.h
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2error.h"
@@ -341,7 +342,7 @@ class S2Builder::Graph {
   // Returns a vector of EdgeIds sorted by minimum input edge id.  This is an
   // approximation of the input edge ordering.
   std::vector<EdgeId> GetInputEdgeOrder(
-      const std::vector<InputEdgeId>& min_input_edge_ids) const;
+      absl::Span<const InputEdgeId> min_input_edge_ids) const;
 
   // Convenience class to return the set of labels associated with a given
   // graph edge.  Note that due to snapping, one graph edge may correspond to
@@ -437,24 +438,22 @@ class S2Builder::Graph {
   // is not possible to make a left turn will have its entry set to -1.
   //
   // "in_edge_ids" should be equal to GetInEdgeIds() or GetSiblingMap().
-  bool GetLeftTurnMap(const std::vector<EdgeId>& in_edge_ids,
-                      std::vector<EdgeId>* left_turn_map,
-                      S2Error* error) const;
+  bool GetLeftTurnMap(absl::Span<const EdgeId> in_edge_ids,
+                      std::vector<EdgeId>* left_turn_map, S2Error* error) const;
 
   // Rotates the edges of "loop" if necessary so that the edge(s) with the
   // largest input edge ids are last.  This ensures that when an output loop
   // is equivalent to an input loop, their cyclic edge orders are the same.
   // "min_input_ids" is the output of GetMinInputEdgeIds().
-  static void CanonicalizeLoopOrder(
-      const std::vector<InputEdgeId>& min_input_ids,
-      std::vector<EdgeId>* loop);
+  static void CanonicalizeLoopOrder(absl::Span<const InputEdgeId> min_input_ids,
+                                    std::vector<EdgeId>* loop);
 
   // Sorts the given edge chains (i.e., loops or polylines) by the minimum
   // input edge id of each chains's first edge.  This ensures that when the
   // output consists of multiple loops or polylines, they are sorted in the
   // same order as they were provided in the input.
   static void CanonicalizeVectorOrder(
-      const std::vector<InputEdgeId>& min_input_ids,
+      absl::Span<const InputEdgeId> min_input_ids,
       std::vector<std::vector<EdgeId>>* chains);
 
   // A loop consisting of a sequence of edge ids.

--- a/src/s2/s2builder_graph_test.cc
+++ b/src/s2/s2builder_graph_test.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_layer.h"
@@ -232,8 +233,8 @@ struct TestEdge {
 
 namespace {
 
-void TestProcessEdges(const vector<TestEdge>& input,
-                      const vector<TestEdge>& expected,
+void TestProcessEdges(absl::Span<const TestEdge> input,
+                      absl::Span<const TestEdge> expected,
                       GraphOptions* options,
                       S2Error::Code expected_code = S2Error::OK) {
   vector<Edge> edges;

--- a/src/s2/s2builderutil_closed_set_normalizer.cc
+++ b/src/s2/s2builderutil_closed_set_normalizer.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"
@@ -154,13 +155,13 @@ inline Edge ClosedSetNormalizer::Advance(const Graph& g, EdgeId* e) const {
 // Helper function that advances to the next incoming edge in the given graph,
 // returning a sentinel value once all edges are exhausted.
 inline Edge ClosedSetNormalizer::AdvanceIncoming(
-    const Graph& g, const vector<EdgeId>& in_edges, int* i) const {
+    const Graph& g, absl::Span<const EdgeId> in_edges, int* i) const {
   return ((static_cast<size_t>(++*i) == in_edges.size())
               ? sentinel_
               : Graph::reverse(g.edge(in_edges[*i])));
-  }
+}
 
-void ClosedSetNormalizer::NormalizeEdges(const vector<Graph>& g,
+void ClosedSetNormalizer::NormalizeEdges(absl::Span<const Graph> g,
                                          S2Error* error) {
   // Find the degenerate polygon edges and sibling pairs, and classify each
   // edge as belonging to either a shell or a hole.

--- a/src/s2/s2builderutil_closed_set_normalizer.h
+++ b/src/s2/s2builderutil_closed_set_normalizer.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"
@@ -131,8 +132,8 @@ class ClosedSetNormalizer {
       const S2Builder::Graph& g, S2Builder::Graph::EdgeId* id) const;
   S2Builder::Graph::Edge AdvanceIncoming(
       const S2Builder::Graph& g,
-      const std::vector<S2Builder::Graph::EdgeId>& in_edges, int* i) const;
-  void NormalizeEdges(const std::vector<S2Builder::Graph>& g, S2Error* error);
+      absl::Span<const S2Builder::Graph::EdgeId> in_edges, int* i) const;
+  void NormalizeEdges(absl::Span<const S2Builder::Graph> g, S2Error* error);
   void AddEdge(int new_dim, const S2Builder::Graph& g,
                S2Builder::Graph::EdgeId e);
   bool is_suppressed(S2Builder::Graph::VertexId v) const;

--- a/src/s2/s2builderutil_closed_set_normalizer_test.cc
+++ b/src/s2/s2builderutil_closed_set_normalizer_test.cc
@@ -89,7 +89,7 @@ class NormalizeTest : public testing::Test {
 
  private:
   static string ToString(const Graph& g);
-  void AddLayers(string_view str, const vector<GraphOptions>& graph_options,
+  void AddLayers(string_view str, absl::Span<const GraphOptions> graph_options,
                  vector<Graph>* graphs_out, S2Builder* builder);
 
   vector<unique_ptr<GraphClone>> graph_clones_;
@@ -116,7 +116,7 @@ void NormalizeTest::Run(string_view input_str, string_view expected_str) {
 }
 
 void NormalizeTest::AddLayers(string_view str,
-                              const vector<GraphOptions>& graph_options,
+                              absl::Span<const GraphOptions> graph_options,
                               vector<Graph>* graphs_out, S2Builder* builder) {
   auto index = s2textformat::MakeIndexOrDie(str);
   for (int dim = 0; dim < 3; ++dim) {
@@ -142,6 +142,20 @@ string NormalizeTest::ToString(const Graph& g) {
     msg += "; ";
   }
   return msg;
+}
+
+TEST_F(NormalizeTest, OptionsAccessorSuppressLowerDimensionsTrue) {
+  ClosedSetNormalizer::Options options;
+  options.set_suppress_lower_dimensions(/*suppress_lower_dimensions=*/true);
+  ClosedSetNormalizer normalizer(options, graph_options_out_);
+  EXPECT_TRUE(normalizer.options().suppress_lower_dimensions());
+}
+
+TEST_F(NormalizeTest, OptionsAccessorSuppressLowerDimensionsFalse) {
+  ClosedSetNormalizer::Options options;
+  options.set_suppress_lower_dimensions(/*suppress_lower_dimensions=*/false);
+  ClosedSetNormalizer normalizer(options, graph_options_out_);
+  EXPECT_FALSE(normalizer.options().suppress_lower_dimensions());
 }
 
 TEST_F(NormalizeTest, EmptyGraphs) {

--- a/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
+++ b/src/s2/s2builderutil_find_polygon_degeneracies_test.cc
@@ -29,6 +29,7 @@
 #include "absl/log/absl_check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"
@@ -92,7 +93,7 @@ class DegeneracyCheckingLayer : public S2Builder::Layer {
   vector<TestDegeneracy> expected_;
 };
 
-std::ostream& operator<<(std::ostream& os, const vector<TestDegeneracy>& v) {
+std::ostream& operator<<(std::ostream& os, absl::Span<const TestDegeneracy> v) {
   for (const auto& degeneracy : v) {
     os << (degeneracy.is_hole ? "Hole(" : "Shell(");
     os << degeneracy.edge_str + ") ";

--- a/src/s2/s2builderutil_get_snapped_winding_delta.cc
+++ b/src/s2/s2builderutil_get_snapped_winding_delta.cc
@@ -139,8 +139,8 @@ bool BuildChain(
   while (chain_in->back() != chain_in->front()) {
     const auto& range = input_vertex_edge_map->equal_range(chain_in->back());
     if (range.first == range.second) {
-      error->Init(S2Error::INVALID_ARGUMENT,
-                  "Input edges (after filtering) do not form loops");
+      *error = S2Error::InvalidArgument(
+          "Input edges (after filtering) do not form loops");
       return false;
     }
     EdgeSnap snap = range.first->second;

--- a/src/s2/s2builderutil_get_snapped_winding_delta_test.cc
+++ b/src/s2/s2builderutil_get_snapped_winding_delta_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2builderutil_get_snapped_winding_delta.h"
 
 #include <cmath>
-
 #include <iostream>
 #include <memory>
 #include <string>
@@ -392,7 +391,7 @@ void WindingNumberCheckingLayer::Build(const Graph& g, S2Error* error) {
   Graph::VertexOutMap out_map(g);
   if (out_map.degree(iso_v) != 1 ||
       g.input_edge_ids(*out_map.edge_ids(iso_v).begin()).size() != 1) {
-    error->Init(S2Error::FAILED_PRECONDITION, "Isolated vertex not isolated");
+    *error = S2Error::FailedPrecondition("Isolated vertex not isolated");
     return;
   }
 

--- a/src/s2/s2builderutil_lax_polygon_layer.cc
+++ b/src/s2/s2builderutil_lax_polygon_layer.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"
@@ -86,7 +87,7 @@ GraphOptions LaxPolygonLayer::graph_options() const {
 }
 
 void LaxPolygonLayer::AppendPolygonLoops(
-    const Graph& g, const vector<Graph::EdgeLoop>& edge_loops,
+    const Graph& g, absl::Span<const Graph::EdgeLoop> edge_loops,
     vector<vector<S2Point>>* loops) const {
   for (const auto& edge_loop : edge_loops) {
     vector<S2Point> vertices;
@@ -99,8 +100,7 @@ void LaxPolygonLayer::AppendPolygonLoops(
 }
 
 void LaxPolygonLayer::AppendEdgeLabels(
-    const Graph& g,
-    const vector<Graph::EdgeLoop>& edge_loops) {
+    const Graph& g, absl::Span<const Graph::EdgeLoop> edge_loops) {
   if (!label_set_ids_) return;
 
   vector<Label> labels;  // Temporary storage for labels.
@@ -210,7 +210,7 @@ void LaxPolygonLayer::Build(const Graph& g, S2Error* error) {
   if (g.options().edge_type() == EdgeType::DIRECTED) {
     BuildDirected(g, error);
   } else {
-    error->Init(S2Error::UNIMPLEMENTED, "Undirected edges not supported yet");
+    *error = S2Error::Unimplemented("Undirected edges not supported yet");
   }
 }
 

--- a/src/s2/s2builderutil_lax_polygon_layer.h
+++ b/src/s2/s2builderutil_lax_polygon_layer.h
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
@@ -129,7 +130,7 @@ class LaxPolygonLayer : public S2Builder::Layer {
 
   // Specifies that a polygon should be constructed using the given options,
   // and that any labels attached to the input edges should be returned in
-  // "label_set_ids" and "label_set_lexicion".
+  // "label_set_ids" and "label_set_lexicon".
   //
   // The labels associated with the edge "polygon.chain_edge(i, j)"
   // can be retrieved as follows:
@@ -148,10 +149,10 @@ class LaxPolygonLayer : public S2Builder::Layer {
   void Init(S2LaxPolygonShape* polygon, LabelSetIds* label_set_ids,
             IdSetLexicon* label_set_lexicon, const Options& options);
   void AppendPolygonLoops(const Graph& g,
-                          const std::vector<Graph::EdgeLoop>& edge_loops,
+                          absl::Span<const Graph::EdgeLoop> edge_loops,
                           std::vector<std::vector<S2Point>>* loops) const;
   void AppendEdgeLabels(const Graph& g,
-                        const std::vector<Graph::EdgeLoop>& edge_loops);
+                        absl::Span<const Graph::EdgeLoop> edge_loops);
   void BuildDirected(Graph g, S2Error* error);
 
   S2LaxPolygonShape* polygon_;

--- a/src/s2/s2builderutil_lax_polyline_layer.cc
+++ b/src/s2/s2builderutil_lax_polyline_layer.cc
@@ -79,8 +79,8 @@ void LaxPolylineLayer::Build(const Graph& g, S2Error* error) {
   vector<Graph::EdgePolyline> edge_polylines =
       g.GetPolylines(PolylineType::WALK);
   if (edge_polylines.size() != 1) {
-    error->Init(S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE,
-                "Input edges cannot be assembled into polyline");
+    *error = S2Error(S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE,
+                     "Input edges cannot be assembled into polyline");
     return;
   }
   const Graph::EdgePolyline& edge_polyline = edge_polylines[0];

--- a/src/s2/s2builderutil_lax_polyline_layer_test.cc
+++ b/src/s2/s2builderutil_lax_polyline_layer_test.cc
@@ -25,6 +25,7 @@
 #include "s2/base/casts.h"
 #include <gtest/gtest.h>
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
@@ -49,7 +50,7 @@ using EdgeType = S2Builder::EdgeType;
 namespace {
 
 void TestS2LaxPolylineShape(
-    const vector<string_view>& input_strs, string_view expected_str,
+    absl::Span<const string_view> input_strs, string_view expected_str,
     EdgeType edge_type,
     const S2Builder::Options& options = S2Builder::Options()) {
   SCOPED_TRACE(edge_type == EdgeType::DIRECTED ? "DIRECTED" : "UNDIRECTED");
@@ -67,7 +68,7 @@ void TestS2LaxPolylineShape(
 
 // Convenience function that tests both directed and undirected edges.
 void TestS2LaxPolylineShape(
-    const vector<string_view>& input_strs, string_view expected_str,
+    absl::Span<const string_view> input_strs, string_view expected_str,
     const S2Builder::Options& options = S2Builder::Options()) {
   TestS2LaxPolylineShape(input_strs, expected_str, EdgeType::DIRECTED, options);
   TestS2LaxPolylineShape(input_strs, expected_str, EdgeType::UNDIRECTED,

--- a/src/s2/s2builderutil_s2point_vector_layer.cc
+++ b/src/s2/s2builderutil_s2point_vector_layer.cc
@@ -63,7 +63,7 @@ void S2PointVectorLayer::Build(const Graph& g, S2Error* error) {
        edge_id++) {
     auto& edge = g.edge(edge_id);
     if (edge.first != edge.second) {
-      error->Init(S2Error::INVALID_ARGUMENT, "Found non-degenerate edges");
+      *error = S2Error::InvalidArgument("Found non-degenerate edges");
       continue;
     }
     points_->push_back(g.vertex(edge.first));

--- a/src/s2/s2builderutil_s2point_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2point_vector_layer_test.cc
@@ -26,6 +26,7 @@
 
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
@@ -51,9 +52,9 @@ namespace {
 
 void VerifyS2PointVectorLayerResults(
     const S2PointVectorLayer::LabelSetIds& label_set_ids,
-    const IdSetLexicon& label_set_lexicon, const vector<S2Point>& output,
+    const IdSetLexicon& label_set_lexicon, absl::Span<const S2Point> output,
     string_view str_expected_points,
-    const vector<vector<int32_t>>& expected_labels) {
+    absl::Span<const vector<int32_t>> expected_labels) {
   vector<S2Point> expected_points =
       s2textformat::ParsePointsOrDie(str_expected_points);
 
@@ -144,7 +145,7 @@ TEST(S2PointVectorLayer, Error) {
   S2Error error;
   EXPECT_FALSE(builder.Build(&error));
   EXPECT_EQ(error.code(), S2Error::INVALID_ARGUMENT);
-  EXPECT_EQ(error.text(), "Found non-degenerate edges");
+  EXPECT_EQ(error.message(), "Found non-degenerate edges");
 
   EXPECT_EQ(2, output.size());
   EXPECT_EQ(MakePointOrDie("0:1"), output[0]);

--- a/src/s2/s2builderutil_s2polygon_layer.cc
+++ b/src/s2/s2builderutil_s2polygon_layer.cc
@@ -25,6 +25,7 @@
 
 #include "absl/container/btree_map.h"
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/s2builder.h"
 #include "s2/s2builder_graph.h"
@@ -87,7 +88,7 @@ GraphOptions S2PolygonLayer::graph_options() const {
 }
 
 void S2PolygonLayer::AppendS2Loops(const Graph& g,
-                                   const vector<Graph::EdgeLoop>& edge_loops,
+                                   absl::Span<const Graph::EdgeLoop> edge_loops,
                                    vector<unique_ptr<S2Loop>>* loops) const {
   vector<S2Point> vertices;
   for (const auto& edge_loop : edge_loops) {
@@ -102,8 +103,7 @@ void S2PolygonLayer::AppendS2Loops(const Graph& g,
 }
 
 void S2PolygonLayer::AppendEdgeLabels(
-    const Graph& g,
-    const vector<Graph::EdgeLoop>& edge_loops) {
+    const Graph& g, absl::Span<const Graph::EdgeLoop> edge_loops) {
   if (!label_set_ids_) return;
 
   vector<Label> labels;  // Temporary storage for labels.
@@ -119,7 +119,7 @@ void S2PolygonLayer::AppendEdgeLabels(
   }
 }
 
-void S2PolygonLayer::InitLoopMap(const vector<unique_ptr<S2Loop>>& loops,
+void S2PolygonLayer::InitLoopMap(absl::Span<const unique_ptr<S2Loop>> loops,
                                  LoopMap* loop_map) const {
   if (!label_set_ids_) return;
   for (const auto& loop : loops) {

--- a/src/s2/s2builderutil_s2polygon_layer.h
+++ b/src/s2/s2builderutil_s2polygon_layer.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
@@ -134,12 +135,12 @@ class S2PolygonLayer : public S2Builder::Layer {
   void Init(S2Polygon* polygon, LabelSetIds* label_set_ids,
             IdSetLexicon* label_set_lexicon, const Options& options);
   void AppendS2Loops(const Graph& g,
-                     const std::vector<Graph::EdgeLoop>& edge_loops,
+                     absl::Span<const Graph::EdgeLoop> edge_loops,
                      std::vector<std::unique_ptr<S2Loop>>* loops) const;
   void AppendEdgeLabels(const Graph& g,
-                        const std::vector<Graph::EdgeLoop>& edge_loops);
+                        absl::Span<const Graph::EdgeLoop> edge_loops);
   using LoopMap = absl::flat_hash_map<S2Loop*, std::pair<int, bool>>;
-  void InitLoopMap(const std::vector<std::unique_ptr<S2Loop>>& loops,
+  void InitLoopMap(absl::Span<const std::unique_ptr<S2Loop>> loops,
                    LoopMap* loop_map) const;
   void ReorderEdgeLabels(const LoopMap& loop_map);
 

--- a/src/s2/s2builderutil_s2polygon_layer_test.cc
+++ b/src/s2/s2builderutil_s2polygon_layer_test.cc
@@ -29,9 +29,8 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
-#include "s2/base/casts.h"
-#include "s2/base/types.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
@@ -61,7 +60,7 @@ namespace {
 
 using ::testing::Contains;
 
-void TestS2Polygon(const vector<string_view>& input_strs,
+void TestS2Polygon(absl::Span<const string_view> input_strs,
                    string_view expected_str, EdgeType edge_type) {
   SCOPED_TRACE(edge_type == EdgeType::DIRECTED ? "DIRECTED" : "UNDIRECTED");
   S2Builder builder{S2Builder::Options()};
@@ -94,7 +93,7 @@ void TestS2PolygonUnchanged(string_view input_str) {
 }
 
 // Unlike the methods above, the input consists of a set of *polylines*.
-void TestS2PolygonError(const vector<string_view>& input_strs,
+void TestS2PolygonError(absl::Span<const string_view> input_strs,
                         absl::Span<const S2Error::Code> expected_codes,
                         EdgeType edge_type) {
   SCOPED_TRACE(edge_type == EdgeType::DIRECTED ? "DIRECTED" : "UNDIRECTED");

--- a/src/s2/s2builderutil_s2polyline_layer.cc
+++ b/src/s2/s2builderutil_s2polyline_layer.cc
@@ -86,8 +86,8 @@ void S2PolylineLayer::Build(const Graph& g, S2Error* error) {
   vector<Graph::EdgePolyline> edge_polylines =
       g.GetPolylines(PolylineType::WALK);
   if (edge_polylines.size() != 1) {
-    error->Init(S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE,
-                "Input edges cannot be assembled into polyline");
+    *error = S2Error(S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE,
+                     "Input edges cannot be assembled into polyline");
     return;
   }
   const Graph::EdgePolyline& edge_polyline = edge_polylines[0];

--- a/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
+++ b/src/s2/s2builderutil_s2polyline_vector_layer_test.cc
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2builder.h"
@@ -53,7 +54,7 @@ using PolylineType = S2PolylineVectorLayer::Options::PolylineType;
 namespace {
 
 void TestS2PolylineVector(
-    const vector<string_view>& input_strs,
+    absl::Span<const string_view> input_strs,
     const vector<string_view>& expected_strs, EdgeType edge_type,
     S2PolylineVectorLayer::Options layer_options =  // by value
     S2PolylineVectorLayer::Options(),
@@ -79,7 +80,7 @@ void TestS2PolylineVector(
 
 // Convenience function that tests both directed and undirected edges.
 void TestS2PolylineVector(
-    const vector<string_view>& input_strs,
+    absl::Span<const string_view> input_strs,
     const vector<string_view>& expected_strs,
     const S2PolylineVectorLayer::Options& layer_options =
         S2PolylineVectorLayer::Options(),

--- a/src/s2/s2builderutil_snap_functions.cc
+++ b/src/s2/s2builderutil_snap_functions.cc
@@ -344,8 +344,8 @@ S1Angle IntLatLngSnapFunction::min_edge_vertex_separation() const {
 S2Point IntLatLngSnapFunction::SnapPoint(const S2Point& point) const {
   ABSL_DCHECK_GE(exponent_, 0);  // Make sure the snap function was initialized.
   S2LatLng input(point);
-  int64_t lat = MathUtil::FastInt64Round(input.lat().degrees() * from_degrees_);
-  int64_t lng = MathUtil::FastInt64Round(input.lng().degrees() * from_degrees_);
+  int64_t lat = MathUtil::Round<int64_t>(input.lat().degrees() * from_degrees_);
+  int64_t lng = MathUtil::Round<int64_t>(input.lng().degrees() * from_degrees_);
   return S2LatLng::FromDegrees(lat * to_degrees_, lng * to_degrees_).ToPoint();
 }
 

--- a/src/s2/s2builderutil_snap_functions_test.cc
+++ b/src/s2/s2builderutil_snap_functions_test.cc
@@ -24,12 +24,11 @@
 
 #include "s2/s2builderutil_snap_functions.h"
 
-#include <cstdlib>
-
 #include <algorithm>
 #include <cinttypes>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <string>
 #include <utility>
 #include <vector>
@@ -497,8 +496,8 @@ static bool HasValidVertices(const IntLatLng& ll, int64_t scale) {
 }
 
 static IntLatLng Rescale(const IntLatLng&ll, double scale_factor) {
-  return IntLatLng(MathUtil::FastInt64Round(scale_factor * ll[0]),
-                   MathUtil::FastInt64Round(scale_factor * ll[1]));
+  return IntLatLng(MathUtil::Round<int64_t>(scale_factor * ll[0]),
+                   MathUtil::Round<int64_t>(scale_factor * ll[1]));
 }
 
 static S2Point ToPoint(const IntLatLng& ll, int64_t scale) {

--- a/src/s2/s2builderutil_testing.cc
+++ b/src/s2/s2builderutil_testing.cc
@@ -102,9 +102,9 @@ void IndexMatchingLayer::Build(const Graph& g, S2Error* error) {
     // existing error text.
     string label;
     if (dimension_ >= 0) label = absl::StrFormat("Dimension %d: ", dimension_);
-    error->Init(S2Error::FAILED_PRECONDITION,
-                "%s%sMissing edges: %s Extra edges: %s\n", error->text(), label,
-                ToString(missing), ToString(extra));
+    *error = S2Error::FailedPrecondition(absl::StrFormat(
+        "%s%sMissing edges: %s Extra edges: %s\n", error->message(), label,
+        ToString(missing), ToString(extra)));
   }
 }
 

--- a/src/s2/s2builderutil_testing_test.cc
+++ b/src/s2/s2builderutil_testing_test.cc
@@ -127,7 +127,7 @@ TEST(IndexMatchingLayer, DifferentResult) {
   S2Error error;
   EXPECT_FALSE(builder.Build(&error));
   EXPECT_FALSE(error.ok());
-  EXPECT_EQ(error.text(),
+  EXPECT_EQ(error.message(),
             "Missing edges: 3:4, 3:3; 3:3, 3:4; 1:1, 2:2; 0:0, 0:0 "
             "Extra edges: 1:0, 1:0\n");
 }

--- a/src/s2/s2cap.cc
+++ b/src/s2/s2cap.cc
@@ -104,9 +104,10 @@ void S2Cap::AddCap(const S2Cap& other) {
     *this = other;
   } else if (!other.is_empty()) {
     // We round up the distance to ensure that the cap is actually contained.
-    // TODO(ericv): Do some error analysis in order to guarantee this.
     S1ChordAngle dist = S1ChordAngle(center_, other.center_) + other.radius_;
-    radius_ = max(radius_, dist.PlusError(DBL_EPSILON * dist.length2()));
+    dist = dist.PlusError(  //
+        (2 * DBL_EPSILON + S1ChordAngle::kRelativeSumError) * dist.length2());
+    radius_ = max(radius_, dist);
   }
 }
 

--- a/src/s2/s2cap.h
+++ b/src/s2/s2cap.h
@@ -34,8 +34,6 @@
 #include "s2/s2pointutil.h"
 #include "s2/s2region.h"
 
-class Decoder;
-class Encoder;
 class S2Cell;
 class S2CellId;
 class S2LatLngRect;
@@ -198,10 +196,10 @@ class S2Cap final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2Cap encoded with Encode().  Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   ///////////////////////////////////////////////////////////////////////
   // The following static methods are convenience functions for assertions

--- a/src/s2/s2cap_test.cc
+++ b/src/s2/s2cap_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2cap.h"
 
-#include <cmath>
-
 #include <cfloat>
+#include <cmath>
 #include <string>
 #include <vector>
 

--- a/src/s2/s2cell.h
+++ b/src/s2/s2cell.h
@@ -32,8 +32,6 @@
 #include "s2/util/coding/coder.h"
 #include "s2/util/math/vector.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2LatLng;
 class S2LatLngRect;
@@ -268,10 +266,10 @@ class S2Cell final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2Cell encoded with Encode().  Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
  private:
   // Returns the latitude or longitude of the cell vertex given by (i,j),

--- a/src/s2/s2cell_id.h
+++ b/src/s2/s2cell_id.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "absl/base/attributes.h"
+#include "absl/base/optimization.h"
 #include "absl/hash/hash.h"
 #include "absl/log/absl_check.h"
 #include "absl/numeric/bits.h"
@@ -120,6 +121,7 @@ class S2CellId {
   explicit S2CellId(const S2Point& p);
 
   // Construct a leaf cell containing the given normalized S2LatLng.
+  // REQUIRES: Latitude and longitude are finite.
   explicit S2CellId(const S2LatLng& ll);
 
   // The default constructor returns an invalid cell id.
@@ -210,7 +212,7 @@ class S2CellId {
   S2LatLng ToLatLng() const;
 
   // The 64-bit unique identifier for this cell.
-  uint64_t id() const { return id_; }
+  constexpr uint64_t id() const { return id_; }
 
   // Return true if id() represents a valid cell.
   //
@@ -396,10 +398,10 @@ class S2CellId {
 
   // Use encoder to generate a serialized representation of this cell id.
   // Can also encode an invalid cell.
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2CellId encoded by Encode(). Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   // Creates a human readable debug string.  Used for << and available for
   // direct usage as well.  The format is "f/dd..d" where "f" is a digit in
@@ -462,7 +464,7 @@ class S2CellId {
   uint64_t lsb() const { return id_ & (~id_ + 1); }
 
   // Return the lowest-numbered bit that is on for cells at the given level.
-  static uint64_t lsb_for_level(int level) {
+  static constexpr uint64_t lsb_for_level(int level) {
     return uint64_t{1} << (2 * (kMaxLevel - level));
   }
 
@@ -496,27 +498,27 @@ class S2CellId {
 } ABSL_ATTRIBUTE_PACKED;  // Necessary so that structures containing S2CellId's
                           // can be ABSL_ATTRIBUTE_PACKED.
 
-inline bool operator==(S2CellId x, S2CellId y) {
+inline constexpr bool operator==(S2CellId x, S2CellId y) {
   return x.id() == y.id();
 }
 
-inline bool operator!=(S2CellId x, S2CellId y) {
+inline constexpr bool operator!=(S2CellId x, S2CellId y) {
   return x.id() != y.id();
 }
 
-inline bool operator<(S2CellId x, S2CellId y) {
+inline constexpr bool operator<(S2CellId x, S2CellId y) {
   return x.id() < y.id();
 }
 
-inline bool operator>(S2CellId x, S2CellId y) {
+inline constexpr bool operator>(S2CellId x, S2CellId y) {
   return x.id() > y.id();
 }
 
-inline bool operator<=(S2CellId x, S2CellId y) {
+inline constexpr bool operator<=(S2CellId x, S2CellId y) {
   return x.id() <= y.id();
 }
 
-inline bool operator>=(S2CellId x, S2CellId y) {
+inline constexpr bool operator>=(S2CellId x, S2CellId y) {
   return x.id() >= y.id();
 }
 
@@ -574,10 +576,10 @@ inline int S2CellId::level() const {
   // We can't just ABSL_DCHECK(is_valid()) because we want level() to be
   // defined for end-iterators, i.e. S2CellId::End(kLevel).  However there is
   // no good way to define S2CellId::None().level(), so we do prohibit that.
-  ABSL_DCHECK_NE(id_, uint64_t{0});
+  ABSL_ASSUME(id_ != 0);
 
   // A special case for leaf cells is not worthwhile.
-  return kMaxLevel - (Bits::FindLSBSetNonZero64(id_) >> 1);
+  return kMaxLevel - (absl::countr_zero(id_) >> 1);
 }
 
 inline int S2CellId::GetSizeIJ() const {

--- a/src/s2/s2cell_id_test.cc
+++ b/src/s2/s2cell_id_test.cc
@@ -17,10 +17,9 @@
 
 #include "s2/s2cell_id.h"
 
-#include <cstdint>
-
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <ios>
 #include <sstream>
 #include <string>
@@ -37,6 +36,7 @@
 #include "absl/log/log_streamer.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 #include "s2/r1interval.h"

--- a/src/s2/s2cell_index_test.cc
+++ b/src/s2/s2cell_index_test.cc
@@ -29,8 +29,10 @@
 #include "absl/log/log_streamer.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "s2/s1angle.h"
 #include "s2/s2cell_id.h"
 #include "s2/s2cell_union.h"
@@ -75,9 +77,9 @@ class S2CellIndexTest : public ::testing::Test {
   void VerifyRangeIterators() const;
   void VerifyIndexContents() const;
   void TestIntersection(const S2CellUnion& target);
-  void ExpectContents(string_view target_str,
-                      S2CellIndex::ContentsIterator* contents,
-                      const vector<pair<string, Label>>& expected_strs) const;
+  void ExpectContents(
+      string_view target_str, S2CellIndex::ContentsIterator* contents,
+      absl::Span<const pair<string, Label>> expected_strs) const;
 
  protected:
   S2CellIndex index_;
@@ -293,7 +295,7 @@ TEST_F(S2CellIndexTest, RandomCellUnions) {
 // (cell_id, label) pairs given by "expected_strs".
 void S2CellIndexTest::ExpectContents(
     string_view target_str, S2CellIndex::ContentsIterator* contents,
-    const vector<pair<string, Label>>& expected_strs) const {
+    absl::Span<const pair<string, Label>> expected_strs) const {
   S2CellIndex::RangeIterator range(&index_);
   range.Seek(S2CellId::FromDebugString(target_str).range_min());
   vector<LabelledCell> expected, actual;

--- a/src/s2/s2cell_iterator_join.h
+++ b/src/s2/s2cell_iterator_join.h
@@ -302,7 +302,8 @@ bool S2CellIteratorJoin<A, B>::TolerantJoin(Visitor& visitor) {
     return cells;
   };
 
-  // Seed the recursion with a coarse covering of each input iterator.
+  // Seed the recursion with a coarse covering of each input iterator's current
+  // position.
   return ProcessNearby(Covering(iter_a_), Covering(iter_b_), visitor);
 }
 
@@ -389,17 +390,17 @@ bool S2CellIteratorJoin<A, B>::ProcessCellPairs(
       return true;
     }
 
-    const S2Cell cell_a(iter_a_.id());
+    const S2Cell sub_cell_a(iter_a_.id());
 
-    // For each A cell, scan each B cell in the cell union and send the
-    // resulting (A,B) pairs to the visitor.  If it returns false at any point
-    // then stop the join and return false.
+    // For each sub cell in the cell_a range, scan each B cell in the cell union
+    // and send the resulting (A,B) pairs to the visitor.  If it returns false
+    // at any point then stop the join and return false.
     int idx = 0;
     bool success = true;
     for (int i = 0; i < cells_b.size() && success; ++i) {
       S2CellId id = cells_b[i].id();
       success &= ScanCellRange(iter_b_, id, [&](const auto& iter_b) {
-        if (cell_a.GetDistance(matched_cells_[idx++]) <= tolerance_) {
+        if (sub_cell_a.GetDistance(matched_cells_[idx++]) <= tolerance_) {
           if (!visitor(iter_a.iterator(), iter_b.iterator())) {
             return false;
           }

--- a/src/s2/s2cell_union.cc
+++ b/src/s2/s2cell_union.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2cell_union.h"
 
-#include <cstddef>
-
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>

--- a/src/s2/s2cell_union.h
+++ b/src/s2/s2cell_union.h
@@ -43,8 +43,6 @@
 #include "s2/s2region.h"
 #include "s2/util/coding/coder.h"
 
-class Decoder;
-class Encoder;
 class S1Angle;
 class S2Cap;
 class S2Cell;
@@ -352,10 +350,10 @@ class S2CellUnion final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2CellUnion encoded with Encode().  Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   ////////////////////////////////////////////////////////////////////////
   // Static methods intended for high-performance clients that prefer to

--- a/src/s2/s2cell_union_test.cc
+++ b/src/s2/s2cell_union_test.cc
@@ -482,7 +482,9 @@ TEST(S2CellUnion, CapBoundContainsAllCells) {
     S2CellUnion cellunion(input);
     S2Cap cap = cellunion.GetCapBound();
     for (S2CellId id : cellunion) {
-      EXPECT_TRUE(cap.Contains(S2Cell(id)));
+      EXPECT_TRUE(cap.Contains(S2Cell(id)))
+          << "cap: " << cap << " cellunion: " << cellunion << " id: " << id
+          << " iter: " << i;
     }
   }
 }

--- a/src/s2/s2centroids_test.cc
+++ b/src/s2/s2centroids_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2centroids.h"
 
 #include <cmath>
-
 #include <string>
 
 #include <gtest/gtest.h>

--- a/src/s2/s2chain_interpolation_query_test.cc
+++ b/src/s2/s2chain_interpolation_query_test.cc
@@ -74,7 +74,7 @@ TEST(S2ChainInterpolationQueryTest, SimplePolylines) {
                                          1.e6};
 
   for (const double& distance : distances) {
-    double lat = std::max(0.0, std::min(kTotalLengthAbc, distance));
+    double lat = std::clamp(distance, 0.0, kTotalLengthAbc);
     const S2Point point = S2LatLng::FromDegrees(lat, 0).ToPoint();
     int32_t edge_id = distance < kLatitudeB ? 0 : 1;
     ground_truth.emplace_back(point, edge_id, S1Angle::Degrees(lat));

--- a/src/s2/s2closest_cell_query_base.h
+++ b/src/s2/s2closest_cell_query_base.h
@@ -20,9 +20,8 @@
 #ifndef S2_S2CLOSEST_CELL_QUERY_BASE_H_
 #define S2_S2CLOSEST_CELL_QUERY_BASE_H_
 
-#include <cstddef>
-
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <queue>
@@ -591,10 +590,7 @@ void S2ClosestCellQueryBase<Distance>::FindClosestCellsOptimized() {
     // it before adding any new entries to the queue.
     QueueEntry entry = queue_.top();
     queue_.pop();
-    // Work around weird parse error in gcc 4.9 by using a local variable for
-    // entry.distance.
-    Distance distance = entry.distance;
-    if (!(distance < distance_limit_)) {
+    if (!(entry.distance < distance_limit_)) {
       queue_ = CellQueue();  // Clear any remaining entries.
       break;
     }

--- a/src/s2/s2closest_cell_query_test.cc
+++ b/src/s2/s2closest_cell_query_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2closest_cell_query.h"
 
-#include <cmath>
-
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <random>
@@ -439,15 +438,7 @@ TEST(S2ClosestCellQuery, ConservativeCellDistanceIsUsed) {
   absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
       "CONSERVATIVE_CELL_DISTANCE_IS_USED",
       absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
-  // Don't use absl::FlagSaver, so it works in opensource without gflags.
-  const int saved_seed = absl::GetFlag(FLAGS_s2_random_seed);
-  // These specific test cases happen to fail if max_error() is not properly
-  // taken into account when measuring distances to S2ShapeIndex cells.
-  for (int seed : {32, 109, 253, 342, 948, 1535, 1884, 1887, 2133}) {
-    absl::SetFlag(&FLAGS_s2_random_seed, seed);
-    TestWithIndexFactory(PointCloudCellIndexFactory(), 5, 100, 10, bitgen);
-  }
-  absl::SetFlag(&FLAGS_s2_random_seed, saved_seed);
+  TestWithIndexFactory(PointCloudCellIndexFactory(), 5, 100, 10, bitgen);
 }
 
 }  // namespace

--- a/src/s2/s2closest_edge_query.h
+++ b/src/s2/s2closest_edge_query.h
@@ -265,7 +265,7 @@ class S2ClosestEdgeQuery {
   // Note that if options().include_interiors() is true, the result vector may
   // include some entries with edge_id == -1.  This indicates that the target
   // intersects the indexed polygon with the given shape_id.  Such results may
-  // be identifed by calling Result::is_interior().
+  // be identified by calling Result::is_interior().
   std::vector<Result> FindClosestEdges(Target* target, ShapeFilter filter = {});
 
   // This version can be more efficient when this method is called many times,

--- a/src/s2/s2closest_edge_query_base.h
+++ b/src/s2/s2closest_edge_query_base.h
@@ -775,10 +775,7 @@ void S2ClosestEdgeQueryBase<Distance>::FindClosestEdgesOptimized(
     // remove it before adding any new entries to the queue.
     QueueEntry entry = queue_.top();
     queue_.pop();
-    // Work around weird parse error in gcc 4.9 by using a local variable for
-    // entry.distance.
-    Distance distance = entry.distance;
-    if (!(distance < distance_limit_)) {
+    if (!(entry.distance < distance_limit_)) {
       queue_ = CellQueue();  // Clear any remaining entries.
       break;
     }

--- a/src/s2/s2closest_edge_query_test.cc
+++ b/src/s2/s2closest_edge_query_test.cc
@@ -34,6 +34,7 @@
 #include "absl/log/log_streamer.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "absl/types/span.h"
 
 #include "s2/encoded_s2shape_index.h"
 #include "s2/mutable_s2shape_index.h"
@@ -615,7 +616,7 @@ using TestingResult = pair<S2MinDistance, ShapeEdgeId>;
 
 // Converts to the format required by CheckDistanceResults() in s2testing.h.
 vector<TestingResult> ConvertResults(
-    const vector<S2ClosestEdgeQuery::Result>& results) {
+    absl::Span<const S2ClosestEdgeQuery::Result> results) {
   vector<TestingResult> testing_results;
   for (const auto& result : results) {
     testing_results.push_back(

--- a/src/s2/s2closest_point_query_base.h
+++ b/src/s2/s2closest_point_query_base.h
@@ -553,10 +553,7 @@ void S2ClosestPointQueryBase<Distance, Data>::FindClosestPointsOptimized() {
     // it before adding any new entries to the queue.
     QueueEntry entry = queue_.top();
     queue_.pop();
-    // Work around weird parse error in gcc 4.9 by using a local variable for
-    // entry.distance.
-    Distance distance = entry.distance;
-    if (!(distance < distance_limit_)) {
+    if (!(entry.distance < distance_limit_)) {
       queue_ = CellQueue();  // Clear any remaining entries.
       break;
     }

--- a/src/s2/s2closest_point_query_test.cc
+++ b/src/s2/s2closest_point_query_test.cc
@@ -339,15 +339,6 @@ TEST(S2ClosestPointQueryTest, ConservativeCellDistanceIsUsed) {
   absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
       "CONSERVATIVE_CELL_DISTANCE_IS_USED",
       absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
-  const int saved_seed = absl::GetFlag(FLAGS_s2_random_seed);
-  // These specific test cases happen to fail if max_error() is not properly
-  // taken into account when measuring distances to S2PointIndex cells.  They
-  // all involve S2ShapeIndexTarget, which takes advantage of max_error() to
-  // optimize its distance calculation.
-  for (int seed : {16, 586, 589, 822, 1959, 2298, 3155, 3490, 3723, 4953}) {
-    absl::SetFlag(&FLAGS_s2_random_seed, seed);
-    TestWithIndexFactory(FractalPointIndexFactory(), 5, 100, 10, bitgen);
-  }
-  absl::SetFlag(&FLAGS_s2_random_seed, saved_seed);
+  TestWithIndexFactory(FractalPointIndexFactory(), 5, 100, 10, bitgen);
 }
 

--- a/src/s2/s2coder.h
+++ b/src/s2/s2coder.h
@@ -120,7 +120,7 @@ class S2LegacyCoder : public S2Coder<T> {
 
   bool Decode(Decoder& decoder, T& v, S2Error& error) const override {
     if (!v.Decode(&decoder)) {
-      error.Init(S2Error::DATA_LOSS, "Unknown decoding error");
+      error = S2Error::DataLoss("Unknown decoding error");
       return false;
     }
     return true;
@@ -141,7 +141,7 @@ class S2LegacyHintCoder : public S2Coder<T> {
 
   bool Decode(Decoder& decoder, T& v, S2Error& error) const override {
     if (!v.Decode(&decoder)) {
-      error.Init(S2Error::DATA_LOSS, "Unknown decoding error");
+      error = S2Error::DataLoss("Unknown decoding error");
       return false;
     }
     return true;

--- a/src/s2/s2contains_vertex_query.cc
+++ b/src/s2/s2contains_vertex_query.cc
@@ -18,7 +18,6 @@
 #include "s2/s2contains_vertex_query.h"
 
 #include <cstdlib>
-
 #include <utility>
 
 #include "absl/log/absl_check.h"

--- a/src/s2/s2coords.cc
+++ b/src/s2/s2coords.cc
@@ -18,7 +18,7 @@
 #include "s2/s2coords.h"
 
 #include "absl/log/absl_check.h"
-#include "s2/util/bits/bits.h"
+#include "absl/numeric/bits.h"
 #include "s2/s2coords_internal.h"
 #include "s2/s2point.h"
 
@@ -125,9 +125,9 @@ int XYZtoFaceSiTi(const S2Point& p, int* face, unsigned int* si,
   // center.  The si,ti values 0 and kMaxSiTi need to be handled specially
   // because they do not correspond to cell centers at any valid level; they
   // are mapped to level -1 by the code below.
-  int level = kMaxCellLevel - Bits::FindLSBSetNonZero(*si | kMaxSiTi);
+  int level = kMaxCellLevel - absl::countr_zero(*si | kMaxSiTi);
   if (level < 0 ||
-      level != kMaxCellLevel - Bits::FindLSBSetNonZero(*ti | kMaxSiTi)) {
+      level != kMaxCellLevel - absl::countr_zero(*ti | kMaxSiTi)) {
     return -1;
   }
   ABSL_DCHECK_LE(level, kMaxCellLevel);

--- a/src/s2/s2crossing_edge_query_test.cc
+++ b/src/s2/s2crossing_edge_query_test.cc
@@ -17,10 +17,9 @@
 
 #include "s2/s2crossing_edge_query.h"
 
+#include <algorithm>
 #include <cfloat>
 #include <cmath>
-
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -33,6 +32,7 @@
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
 #include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
 
 #include "s2/base/casts.h"
 #include "s2/mutable_s2shape_index.h"
@@ -122,7 +122,7 @@ void GetCapEdges(absl::BitGenRef bitgen, const S2Cap& center_cap,
 // Project ShapeEdges to ShapeEdgeIds.  Useful because
 // ShapeEdge does not have operator==, but ShapeEdgeId does.
 static vector<ShapeEdgeId> GetShapeEdgeIds(
-    const vector<ShapeEdge>& shape_edges) {
+    absl::Span<const ShapeEdge> shape_edges) {
   vector<ShapeEdgeId> shape_edge_ids;
   for (const auto& shape_edge : shape_edges) {
     shape_edge_ids.push_back(shape_edge.id());
@@ -130,7 +130,7 @@ static vector<ShapeEdgeId> GetShapeEdgeIds(
   return shape_edge_ids;
 }
 
-void TestAllCrossings(const vector<TestEdge>& edges) {
+void TestAllCrossings(absl::Span<const TestEdge> edges) {
   auto shape = new S2EdgeVectorShape;  // raw pointer since "shape" used below
   for (const TestEdge& edge : edges) {
     shape->Add(edge.first, edge.second);

--- a/src/s2/s2density_tree_internal.h
+++ b/src/s2/s2density_tree_internal.h
@@ -16,11 +16,10 @@
 #ifndef S2_S2DENSITY_TREE_INTERNAL_H_
 #define S2_S2DENSITY_TREE_INTERNAL_H_
 
-#include <cstddef>
-#include <cstdint>
-
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 #include "absl/log/absl_check.h"

--- a/src/s2/s2density_tree_test.cc
+++ b/src/s2/s2density_tree_test.cc
@@ -15,9 +15,8 @@
 
 #include "s2/s2density_tree.h"
 
-#include <cstdint>
-
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>
@@ -35,6 +34,7 @@
 #include "absl/meta/type_traits.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "absl/types/span.h"
 #include "s2/util/coding/coder.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2cap.h"
@@ -316,7 +316,7 @@ TEST(S2DensityTreeTest, VisitorCancellation) {
   S2Error error;
   S2DensityTree tree;
   ASSERT_TRUE(tree.InitToVertexDensity(index, 10000, 30, &error))
-      << error.text();
+      << error.message();
 
   ASSERT_FALSE(tree.VisitCells(
       [](S2CellId, const S2DensityTree::Cell&) {
@@ -381,15 +381,15 @@ TEST(S2DensityTreeTest, S2CoderWorks) {
   tree.InitToVertexDensity(*index, 10'000, 20, &error);
   ASSERT_TRUE(error.ok()) << error;
 
-  error.Clear();
+  error = S2Error::Ok();
   auto decoded = s2coding::RoundTrip(S2DensityTree::Coder(), tree, error);
 
   // Fully decode density trees and compare to check the decoding.
-  error.Clear();
+  error = S2Error::Ok();
   absl::btree_map<S2CellId, int64_t> tree_a = tree.Decode(&error);
   EXPECT_TRUE(error.ok());
 
-  error.Clear();
+  error = S2Error::Ok();
   absl::btree_map<S2CellId, int64_t> tree_b = decoded.Decode(&error);
   EXPECT_TRUE(error.ok());
 
@@ -858,7 +858,7 @@ class SumDensityTreesTest : public ::testing::TestWithParam<bool> {
   }
 
   void CheckSum(const absl::btree_map<S2CellId, int64_t>& expected,
-                const vector<S2CellId>& roots, int max_level = 30) {
+                absl::Span<const S2CellId> roots, int max_level = 30) {
     S2Error error;
     vector<S2DensityTree> trees;
     for (S2CellId root : roots) {

--- a/src/s2/s2edge_crosser_test.cc
+++ b/src/s2/s2edge_crosser_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2edge_crosser.h"
 
 #include <cmath>
-
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/src/s2/s2edge_crossings.h
+++ b/src/s2/s2edge_crossings.h
@@ -49,6 +49,21 @@
 #include "s2/util/math/vector.h"
 
 namespace S2 {
+namespace internal {
+
+// Returns whether (a0,a1) is less than (b0,b1) with respect to a total
+// ordering on edges that is invariant under edge reversals.
+template <class T>
+inline bool CompareEdges(const Vector3<T>& a0, const Vector3<T>& a1,
+                         const Vector3<T>& b0, const Vector3<T>& b1) {
+  const Vector3<T>*pa0 = &a0, *pa1 = &a1;
+  const Vector3<T>*pb0 = &b0, *pb1 = &b1;
+  if (*pa0 >= *pa1) std::swap(pa0, pa1);
+  if (*pb0 >= *pb1) std::swap(pb0, pb1);
+  return *pa0 < *pb0 || (*pa0 == *pb0 && *pa1 < *pb1);
+}
+
+}  // namespace internal
 
 // Returns a vector whose direction is guaranteed to be very close to the exact
 // mathematical cross product of the given unit-length vectors "a" and "b", but

--- a/src/s2/s2edge_crossings_test.cc
+++ b/src/s2/s2edge_crossings_test.cc
@@ -608,4 +608,13 @@ TEST(S2, GetIntersectionInvariants) {
   }
 }
 
+TEST(S2, CompareEdgesOrderInvariant) {
+  const S2Point v0(0, 1, 0);
+  const S2Point v1(1, 0, 0);
+  EXPECT_FALSE(S2::internal::CompareEdges(v0, v1, v0, v1));
+  EXPECT_FALSE(S2::internal::CompareEdges(v1, v0, v0, v1));
+  EXPECT_FALSE(S2::internal::CompareEdges(v0, v1, v1, v0));
+  EXPECT_FALSE(S2::internal::CompareEdges(v1, v0, v1, v0));
+}
+
 }  // namespace

--- a/src/s2/s2edge_distances.h
+++ b/src/s2/s2edge_distances.h
@@ -280,14 +280,15 @@ inline S2Point GetPointOnRay(const S2Point& origin, const S2Point& dir,
 }
 
 inline S2Point GetPointOnRay(const S2Point& origin, const S2Point& dir,
-                             S1Angle r) {
+                             const S1Angle r) {
   // See comments above.
   ABSL_DCHECK(S2::IsUnitLength(origin));
   ABSL_DCHECK(S2::IsUnitLength(dir));
   ABSL_DCHECK_LE(origin.DotProd(dir),
                  S2::kRobustCrossProdError.radians() + 0.75 * DBL_EPSILON);
 
-  return (cos(r) * origin + sin(r) * dir).Normalize();
+  const S1Angle::SinCosPair trig_r = r.SinCos();
+  return (trig_r.cos * origin + trig_r.sin * dir).Normalize();
 }
 
 }  // namespace S2

--- a/src/s2/s2edge_distances_test.cc
+++ b/src/s2/s2edge_distances_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2edge_distances.h"
 
 #include <cmath>
-
 #include <limits>
 #include <memory>
 #include <string>

--- a/src/s2/s2edge_tessellator.cc
+++ b/src/s2/s2edge_tessellator.cc
@@ -137,9 +137,9 @@ using std::vector;
 // in a Plate Carree edge of length 90 degrees or less.  This turns out to be
 // an edge from 45:-90 to 45:90 (in lat:lng format).  The corresponding error
 // as a function of "x" in the range [-1, 1] can be computed as the distance
-// between the the the Plate Caree edge point (45, 90 * x) and the geodesic
-// edge point (90 - 45 * abs(x), 90 * sgn(x)).  Using the Haversine formula,
-// the corresponding function E1 (normalized to have a maximum value of 1) is:
+// between the Plate Caree edge point (45, 90 * x) and the geodesic edge point
+// (90 - 45 * abs(x), 90 * sgn(x)).  Using the Haversine formula, the
+// corresponding function E1 (normalized to have a maximum value of 1) is:
 //
 //   E1(x) =
 //     asin(sqrt(sin(Pi / 8 * (1 - x)) ^ 2 +

--- a/src/s2/s2edge_tessellator_test.cc
+++ b/src/s2/s2edge_tessellator_test.cc
@@ -543,4 +543,41 @@ TEST(S2EdgeTessellator, ProjectedAccuracyRandomCheck) {
   }
 }
 
+TEST(S2EdgeTessellator, UnwrappingDcheckRegression) {
+  // Before it was fixed, this series of points would cause a ABSL_DCHECK failure
+  // when tessellating due to rounding in the unwrapping code.
+  const double kPoints[][2] = {
+      {-16.876721435218865253, -179.986547984808964884},
+      {-16.874909244632696925, -179.991889238369623172},
+      {-16.880241814330226191, -179.990858688466971671},
+      {-16.883762104047619346, -179.995169553755403058},
+      {-16.881949690252106677, +179.999489074621124018},
+      {-16.876617071405430437, +179.998458788144517939},
+      {-16.880137137875717457, +179.994147804931060364},
+      {-16.878324446969305228, +179.988806637264332267},
+      {-16.872991774409559440, +179.987776672537478362},
+      {-16.869471841739493101, +179.992087611973005323},
+      {-16.867659097232969856, +179.986746766061799008},
+      {-16.862326415537093993, +179.985716917832945683},
+      {-16.858806527326652969, +179.990027652027180238},
+      {-16.860619186956174786, +179.995368278278732532},
+      {-16.855286549828541354, +179.994338224830613626},
+      {-16.851766483129139829, +179.998648636203512297},
+      {-16.849953908374558864, +179.993308229628894424},
+  };
+
+  S2::MercatorProjection projection(0.5);
+
+  S2EdgeTessellator tessellator(&projection, S1Angle::E7(1));
+
+  vector<R2Point> vertices;
+  for (int i = 0; i + 1 < sizeof(kPoints) / sizeof(kPoints[0]); ++i) {
+    tessellator.AppendProjected(
+        S2LatLng::FromDegrees(kPoints[i + 0][0], kPoints[i + 0][1]).ToPoint(),
+        S2LatLng::FromDegrees(kPoints[i + 1][0], kPoints[i + 1][1]).ToPoint(),
+        &vertices);
+  }
+  EXPECT_EQ(vertices.size(), 17);
+}
+
 }  // namespace

--- a/src/s2/s2error.cc
+++ b/src/s2/s2error.cc
@@ -35,39 +35,39 @@ S2Error ToS2Error(const absl::Status& status) {
 
   switch (status.code()) {
     case absl::StatusCode::kCancelled:
-      error.Init(S2Error::CANCELLED, "%s", message);
+      error = S2Error::Cancelled(message);
       break;
 
     case absl::StatusCode::kInvalidArgument:
-      error.Init(S2Error::INVALID_ARGUMENT, "%s", message);
+      error = S2Error::InvalidArgument(message);
       break;
 
     case absl::StatusCode::kDataLoss:
-      error.Init(S2Error::DATA_LOSS, "%s", message);
+      error = S2Error::DataLoss(message);
       break;
 
     case absl::StatusCode::kResourceExhausted:
-      error.Init(S2Error::RESOURCE_EXHAUSTED, "%s", message);
+      error = S2Error::ResourceExhausted(message);
       break;
 
     case absl::StatusCode::kFailedPrecondition:
-      error.Init(S2Error::FAILED_PRECONDITION, "%s", message);
+      error = S2Error::FailedPrecondition(message);
       break;
 
     case absl::StatusCode::kOutOfRange:
-      error.Init(S2Error::OUT_OF_RANGE, "%s", message);
+      error = S2Error::OutOfRange(message);
       break;
 
     case absl::StatusCode::kUnimplemented:
-      error.Init(S2Error::UNIMPLEMENTED, "%s", message);
+      error = S2Error::Unimplemented(message);
       break;
 
     case absl::StatusCode::kInternal:
-      error.Init(S2Error::INTERNAL, "%s", message);
+      error = S2Error::Internal(message);
       break;
 
     default:
-      error.Init(S2Error::UNKNOWN, "%s", message);
+      error = S2Error::Unknown(message);
   }
 
   return error;
@@ -79,7 +79,7 @@ absl::Status ToStatus(const S2Error& error) {
   if (S2Error::USER_DEFINED_START <= error.code() &&
       error.code() <= S2Error::USER_DEFINED_END) {
     return absl::UnknownError(
-        absl::StrCat(error.text(), " (", error.code(), ")"));
+        absl::StrCat(error.message(), " (", error.code(), ")"));
   }
 
   switch (static_cast<S2Error::Code>(error.code())) {
@@ -87,19 +87,19 @@ absl::Status ToStatus(const S2Error& error) {
       return absl::OkStatus();
 
     case S2Error::CANCELLED:
-      return absl::CancelledError(error.text());
+      return absl::CancelledError(error.message());
 
     case S2Error::INVALID_ARGUMENT:
-      return absl::InvalidArgumentError(error.text());
+      return absl::InvalidArgumentError(error.message());
 
     case S2Error::DATA_LOSS:
-      return absl::DataLossError(error.text());
+      return absl::DataLossError(error.message());
 
     case S2Error::RESOURCE_EXHAUSTED:
-      return absl::ResourceExhaustedError(error.text());
+      return absl::ResourceExhaustedError(error.message());
 
     case S2Error::FAILED_PRECONDITION:
-      return absl::FailedPreconditionError(error.text());
+      return absl::FailedPreconditionError(error.message());
 
     // Custom error space are deprecated and not open-sourced, so we map
     // these to invalid argument errors.
@@ -127,23 +127,26 @@ absl::Status ToStatus(const S2Error& error) {
     case S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE:
     case S2Error::BUILDER_IS_FULL_PREDICATE_NOT_SPECIFIED:
       return absl::InvalidArgumentError(
-          absl::StrCat(error.text(), " (", error.code(), ")"));
+          absl::StrCat(error.message(), " (", error.code(), ")"));
 
     case S2Error::OUT_OF_RANGE:
-      return absl::OutOfRangeError(error.text());
+      return absl::OutOfRangeError(error.message());
 
     case S2Error::UNIMPLEMENTED:
-      return absl::UnimplementedError(error.text());
+      return absl::UnimplementedError(error.message());
 
     case S2Error::INTERNAL:
-      return absl::InternalError(error.text());
+      return absl::InternalError(error.message());
 
     case S2Error::UNKNOWN:
+      return absl::UnknownError(
+          absl::StrCat(error.message(), " (", error.code(), ")"));
+
     case S2Error::USER_DEFINED_START:
     case S2Error::USER_DEFINED_END:
-      // USER_DEFINED_START/END can't happen here; they're handled above.
-      return absl::UnknownError(
-          absl::StrCat(error.text(), " (", error.code(), ")"));
+      // USER_DEFINED_START/END (or anything in between) can't happen here;
+      // they're handled above.
+      ABSL_UNREACHABLE();
   }
   ABSL_UNREACHABLE();
 }

--- a/src/s2/s2error.h
+++ b/src/s2/s2error.h
@@ -28,6 +28,7 @@
 #include "absl/base/attributes.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
 
 #include "s2/base/port.h"
 
@@ -123,36 +124,74 @@ class S2Error {
     // (containing all points).
     BUILDER_IS_FULL_PREDICATE_NOT_SPECIFIED = 305,
   };
-  S2Error() : code_(OK), text_() {}
 
-  // Convenience constructor that calls Init().
-  template <typename... Args>
-  S2Error(Code code, const absl::FormatSpec<Args...>& format,
-          const Args&... args) {
-    Init(code, format, args...);
-  }
+  // Creates error with OK status and empty message.
+  S2Error() = default;
 
-  // Set the error to the given code and absl::StrFormat-style message.
-  // Note that you can prepend text to an existing error by calling Init()
-  // more than once:
+  // Create an error with the specified code and message.
   //
-  //   error->Init(error->code(), "Loop %d: %s", j, error->text());
-  template <typename... Args>
-  void Init(Code code, const absl::FormatSpec<Args...>& format,
-            const Args&... args) {
-    code_ = code;
-    text_ = absl::StrFormat(format, args...);
+  // Note that you can prepend text to an existing error by reinitializeing
+  // like this:
+  //
+  //   error = S2Error(error.code(),
+  //                   absl::StrFormat("Loop %d: %s", j, error.message()));
+  S2Error(Code code, absl::string_view message) : code_(code), text_(message) {}
+
+  ABSL_MUST_USE_RESULT bool ok() const { return code_ == OK; }
+  Code code() const { return code_; }
+  absl::string_view message() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return text_;
+  }
+  [[deprecated("Use message() instead.")]]
+  std::string text() const {
+    return text_;
   }
 
-  bool ok() const { return code_ == OK; }
-  Code code() const { return code_; }
-  std::string text() const { return text_; }
+  // Returns a value with an `OK` code.  Prefer this to `S2Error()`.
+  static S2Error Ok() {
+    // This will be changed to `return absl::OkStatus();` when we switch over.
+    return S2Error();
+  }
 
-  // Clear the error to contain the OK code and no error message.
-  void Clear();
+  static S2Error Unknown(absl::string_view message) {
+    // This will be changed to `absl::UnknownError()` when we switch over.
+    return S2Error(UNKNOWN, message);
+  }
+
+  static S2Error Unimplemented(absl::string_view message) {
+    return S2Error(UNIMPLEMENTED, message);
+  }
+
+  static S2Error OutOfRange(absl::string_view message) {
+    return S2Error(OUT_OF_RANGE, message);
+  }
+
+  static S2Error InvalidArgument(absl::string_view message) {
+    return S2Error(INVALID_ARGUMENT, message);
+  }
+
+  static S2Error FailedPrecondition(absl::string_view message) {
+    return S2Error(FAILED_PRECONDITION, message);
+  }
+
+  static S2Error Internal(absl::string_view message) {
+    return S2Error(INTERNAL, message);
+  }
+
+  static S2Error DataLoss(absl::string_view message) {
+    return S2Error(DATA_LOSS, message);
+  }
+
+  static S2Error ResourceExhausted(absl::string_view message) {
+    return S2Error(RESOURCE_EXHAUSTED, message);
+  }
+
+  static S2Error Cancelled(absl::string_view message) {
+    return S2Error(CANCELLED, message);
+  }
 
  private:
-  Code code_;
+  Code code_ = OK;
   std::string text_;
 };
 
@@ -186,12 +225,7 @@ absl::Status ToStatus(const S2Error& error);
 
 
 inline std::ostream& operator<<(std::ostream& os, const S2Error& error) {
-  return os << error.text();
-}
-
-inline void S2Error::Clear() {
-  code_ = OK;
-  text_.clear();
+  return os << error.message();
 }
 
 #endif  // S2_S2ERROR_H_

--- a/src/s2/s2error_test.cc
+++ b/src/s2/s2error_test.cc
@@ -22,22 +22,62 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
+#include "absl/strings/str_format.h"
 
 TEST(S2Error, Basic) {
   S2Error error;
-  error.Init(S2Error::DUPLICATE_VERTICES,
-             "Vertex %d is the same as vertex %d", 23, 47);
+  error = S2Error(S2Error::DUPLICATE_VERTICES,
+                  "Vertex 23 is the same as vertex 47");
   // Prepend additional context to the message.
-  error.Init(error.code(), "Loop %d: %s", 5, error.text());
+  error =
+      S2Error(error.code(), absl::StrFormat("Loop %d: %s", 5, error.message()));
   EXPECT_EQ(error.code(), S2Error::DUPLICATE_VERTICES);
-  EXPECT_EQ(error.text(), "Loop 5: Vertex 23 is the same as vertex 47");
+  EXPECT_EQ(error.message(), "Loop 5: Vertex 23 is the same as vertex 47");
 }
 
 TEST(S2Error, Constructor) {
   S2Error error(S2Error::RESOURCE_EXHAUSTED,
-                "Memory limit exceeded (%d vs %d)", 100, 50);
+                "Memory limit exceeded (100 vs 50)");
   EXPECT_EQ(error.code(), S2Error::RESOURCE_EXHAUSTED);
-  EXPECT_EQ(error.text(), "Memory limit exceeded (100 vs 50)");
+  EXPECT_EQ(error.message(), "Memory limit exceeded (100 vs 50)");
+}
+
+TEST(S2Error, OkIsOk) {
+  EXPECT_TRUE(S2Error::Ok().ok());
+  EXPECT_EQ(S2Error::Ok().code(), S2Error::OK);
+}
+
+TEST(S2Error, UnknownCode) {
+  EXPECT_EQ(S2Error::Unknown("").code(), S2Error::UNKNOWN);
+}
+
+TEST(S2Error, UnimplementedCode) {
+  EXPECT_EQ(S2Error::Unimplemented("").code(), S2Error::UNIMPLEMENTED);
+}
+
+TEST(S2Error, OutOfRangeCode) {
+  EXPECT_EQ(S2Error::OutOfRange("").code(), S2Error::OUT_OF_RANGE);
+}
+
+TEST(S2Error, InvalidArgumentCode) {
+  EXPECT_EQ(S2Error::InvalidArgument("").code(), S2Error::INVALID_ARGUMENT);
+}
+
+TEST(S2Error, FailedPreconditionCode) {
+  EXPECT_EQ(S2Error::FailedPrecondition("").code(),
+            S2Error::FAILED_PRECONDITION);
+}
+
+TEST(S2Error, InternalCode) {
+  EXPECT_EQ(S2Error::Internal("").code(), S2Error::INTERNAL);
+}
+
+TEST(S2Error, ResourceExhaustedCode) {
+  EXPECT_EQ(S2Error::ResourceExhausted("").code(), S2Error::RESOURCE_EXHAUSTED);
+}
+
+TEST(S2Error, CancelledCode) {
+  EXPECT_EQ(S2Error::Cancelled("").code(), S2Error::CANCELLED);
 }
 
 TEST(S2Error, ToS2Error) {
@@ -46,43 +86,43 @@ TEST(S2Error, ToS2Error) {
 
   const S2Error cancelled = ToS2Error(absl::CancelledError("cancelled"));
   EXPECT_EQ(cancelled.code(), S2Error::CANCELLED);
-  EXPECT_EQ(cancelled.text(), "cancelled");
+  EXPECT_EQ(cancelled.message(), "cancelled");
 
   const S2Error invalid_argument =
       ToS2Error(absl::InvalidArgumentError("invalid_argument"));
   EXPECT_EQ(invalid_argument.code(), S2Error::INVALID_ARGUMENT);
-  EXPECT_EQ(invalid_argument.text(), "invalid_argument");
+  EXPECT_EQ(invalid_argument.message(), "invalid_argument");
 
   const S2Error data_loss = ToS2Error(absl::DataLossError("data_loss"));
   EXPECT_EQ(data_loss.code(), S2Error::DATA_LOSS);
-  EXPECT_EQ(data_loss.text(), "data_loss");
+  EXPECT_EQ(data_loss.message(), "data_loss");
 
   const S2Error resource_exhausted =
       ToS2Error(absl::ResourceExhaustedError("resource_exhausted"));
   EXPECT_EQ(resource_exhausted.code(), S2Error::RESOURCE_EXHAUSTED);
-  EXPECT_EQ(resource_exhausted.text(), "resource_exhausted");
+  EXPECT_EQ(resource_exhausted.message(), "resource_exhausted");
 
   const S2Error failed_precondition =
       ToS2Error(absl::FailedPreconditionError("failed_precondition"));
   EXPECT_EQ(failed_precondition.code(), S2Error::FAILED_PRECONDITION);
-  EXPECT_EQ(failed_precondition.text(), "failed_precondition");
+  EXPECT_EQ(failed_precondition.message(), "failed_precondition");
 
   const S2Error out_of_range = ToS2Error(absl::OutOfRangeError("out_of_range"));
   EXPECT_EQ(out_of_range.code(), S2Error::OUT_OF_RANGE);
-  EXPECT_EQ(out_of_range.text(), "out_of_range");
+  EXPECT_EQ(out_of_range.message(), "out_of_range");
 
   const S2Error unimplemented =
       ToS2Error(absl::UnimplementedError("unimplemented"));
   EXPECT_EQ(unimplemented.code(), S2Error::UNIMPLEMENTED);
-  EXPECT_EQ(unimplemented.text(), "unimplemented");
+  EXPECT_EQ(unimplemented.message(), "unimplemented");
 
   const S2Error internal = ToS2Error(absl::InternalError("internal"));
   EXPECT_EQ(internal.code(), S2Error::INTERNAL);
-  EXPECT_EQ(internal.text(), "internal");
+  EXPECT_EQ(internal.message(), "internal");
 
   const S2Error unknown = ToS2Error(absl::UnknownError("unknown"));
   EXPECT_EQ(unknown.code(), S2Error::UNKNOWN);
-  EXPECT_THAT(unknown.text(), "unknown");
+  EXPECT_THAT(unknown.message(), "unknown");
 
   // All absl::Status codes that don't have an exact mapping to S2Error codes
   // should be mapped to S2Error::UNKNOWN.
@@ -93,7 +133,7 @@ TEST(S2Error, ToS2Error) {
         absl::UnauthenticatedError("other"), absl::UnavailableError("other")}) {
     const S2Error other = ToS2Error(status);
     EXPECT_EQ(other.code(), S2Error::UNKNOWN);
-    EXPECT_EQ(other.text(), "other");
+    EXPECT_EQ(other.message(), "other");
   }
 }
 
@@ -103,27 +143,27 @@ TEST(S2Error, ToStatus) {
   const absl::Status ok = ToStatus(error);
   EXPECT_EQ(ok.code(), absl::StatusCode::kOk);
 
-  error.Init(S2Error::CANCELLED, "cancelled");
+  error = S2Error::Cancelled("cancelled");
   const absl::Status cancelled = ToStatus(error);
   EXPECT_EQ(cancelled.code(), absl::StatusCode::kCancelled);
   EXPECT_EQ(cancelled.message(), "cancelled");
 
-  error.Init(S2Error::INVALID_ARGUMENT, "invalid_argument");
+  error = S2Error::InvalidArgument("invalid_argument");
   const absl::Status invalid_argument = ToStatus(error);
   EXPECT_EQ(invalid_argument.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(invalid_argument.message(), "invalid_argument");
 
-  error.Init(S2Error::DATA_LOSS, "data_loss");
+  error = S2Error::DataLoss("data_loss");
   const absl::Status data_loss = ToStatus(error);
   EXPECT_EQ(data_loss.code(), absl::StatusCode::kDataLoss);
   EXPECT_EQ(data_loss.message(), "data_loss");
 
-  error.Init(S2Error::RESOURCE_EXHAUSTED, "resource_exhausted");
+  error = S2Error::ResourceExhausted("resource_exhausted");
   const absl::Status resource_exhausted = ToStatus(error);
   EXPECT_EQ(resource_exhausted.code(), absl::StatusCode::kResourceExhausted);
   EXPECT_EQ(resource_exhausted.message(), "resource_exhausted");
 
-  error.Init(S2Error::FAILED_PRECONDITION, "failed_precondition");
+  error = S2Error::FailedPrecondition("failed_precondition");
   const absl::Status failed_precondition = ToStatus(error);
   EXPECT_EQ(failed_precondition.code(), absl::StatusCode::kFailedPrecondition);
   EXPECT_EQ(failed_precondition.message(), "failed_precondition");
@@ -147,29 +187,29 @@ TEST(S2Error, ToStatus) {
         S2Error::BUILDER_EDGES_DO_NOT_FORM_LOOPS,
         S2Error::BUILDER_EDGES_DO_NOT_FORM_POLYLINE,
         S2Error::BUILDER_IS_FULL_PREDICATE_NOT_SPECIFIED}) {
-    error.Init(code, "other_invalid_argument");
+    error = S2Error(code, "other_invalid_argument");
     const absl::Status other = ToStatus(error);
     EXPECT_EQ(other.code(), absl::StatusCode::kInvalidArgument);
     EXPECT_THAT(other.message(),
                 testing::HasSubstr("other_invalid_argument"));
   }
 
-  error.Init(S2Error::OUT_OF_RANGE, "out_of_range");
+  error = S2Error::OutOfRange("out_of_range");
   const absl::Status out_of_range = ToStatus(error);
   EXPECT_EQ(out_of_range.code(), absl::StatusCode::kOutOfRange);
   EXPECT_EQ(out_of_range.message(), "out_of_range");
 
-  error.Init(S2Error::UNIMPLEMENTED, "unimplemented");
+  error = S2Error::Unimplemented("unimplemented");
   const absl::Status unimplemented = ToStatus(error);
   EXPECT_EQ(unimplemented.code(), absl::StatusCode::kUnimplemented);
   EXPECT_EQ(unimplemented.message(), "unimplemented");
 
-  error.Init(S2Error::INTERNAL, "internal");
+  error = S2Error::Internal("internal");
   const absl::Status internal = ToStatus(error);
   EXPECT_EQ(internal.code(), absl::StatusCode::kInternal);
   EXPECT_EQ(internal.message(), "internal");
 
-  error.Init(S2Error::UNKNOWN, "unknown");
+  error = S2Error::Unknown("unknown");
   const absl::Status unknown = ToStatus(error);
   EXPECT_EQ(unknown.code(), absl::StatusCode::kUnknown);
   EXPECT_THAT(unknown.message(), testing::HasSubstr("unknown"));
@@ -179,7 +219,7 @@ TEST(S2Error, ToStatus) {
   for (const S2Error::Code code :
        {S2Error::USER_DEFINED_START,
         S2Error::USER_DEFINED_END}) {
-    error.Init(code, "other");
+    error = S2Error(code, "other");
     const absl::Status other = ToStatus(error);
     EXPECT_EQ(other.code(), absl::StatusCode::kUnknown);
     EXPECT_THAT(other.message(), testing::HasSubstr("other"));

--- a/src/s2/s2furthest_edge_query.h
+++ b/src/s2/s2furthest_edge_query.h
@@ -308,7 +308,7 @@ class S2FurthestEdgeQuery {
   // Note that if options().include_interiors() is true, the result vector may
   // include some entries with edge_id == -1.  This indicates that the
   // furthest distance is attained at a point in the interior of the indexed
-  // polygon with the given shape_id.  Such results may be identifed by
+  // polygon with the given shape_id.  Such results may be identified by
   // calling Result::is_interior().
   std::vector<Result> FindFurthestEdges(Target* target);
 

--- a/src/s2/s2furthest_edge_query_test.cc
+++ b/src/s2/s2furthest_edge_query_test.cc
@@ -15,9 +15,8 @@
 
 #include "s2/s2furthest_edge_query.h"
 
-#include <cmath>
-
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -30,6 +29,7 @@
 #include "absl/log/log_streamer.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "absl/types/span.h"
 
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1angle.h"
@@ -371,7 +371,7 @@ using Result = pair<S2MaxDistance, s2shapeutil::ShapeEdgeId>;
 // of the following code may become redundant with that in
 // s2closest_edge_query.cc.
 vector<Result> ConvertResults(
-    const vector<S2FurthestEdgeQuery::Result>& edges) {
+    absl::Span<const S2FurthestEdgeQuery::Result> edges) {
   vector<Result> results;
   for (const auto& edge : edges) {
     results.push_back(

--- a/src/s2/s2latlng.h
+++ b/src/s2/s2latlng.h
@@ -102,7 +102,7 @@ class S2LatLng {
 
   // Clamps the latitude to the range [-90, 90] degrees, and adds or subtracts
   // a multiple of 360 degrees to the longitude if necessary to reduce it to
-  // the range [-180, 180].
+  // the range [-180, 180]. Returns Invalid() if not finite.
   S2LatLng Normalized() const;
 
   // Converts an S2LatLng to the equivalent unit-length vector.  Unnormalized
@@ -117,6 +117,9 @@ class S2LatLng {
   // Can be used just like an S2Point constructor.  For example:
   //   S2Cap cap;
   //   cap.AddPoint(S2Point(latlng));
+  //
+  // REQUIRES: Latitude and longitude are finite.  (This is weaker than
+  // `is_valid()`.
   explicit operator S2Point() const;
 
   // Converts to an S2Point (equivalent to the operator above).

--- a/src/s2/s2latlng_rect.h
+++ b/src/s2/s2latlng_rect.h
@@ -35,8 +35,6 @@
 #include "s2/s2point.h"
 #include "s2/s2region.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2Cell;
 
@@ -358,10 +356,10 @@ class S2LatLngRect final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2LatLngRect encoded with Encode().  Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   // Returns true if the edge AB intersects the given edge of constant
   // longitude.

--- a/src/s2/s2latlng_rect_bounder_test.cc
+++ b/src/s2/s2latlng_rect_bounder_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2latlng_rect_bounder.h"
 
-#include <cmath>
-
 #include <cfloat>
+#include <cmath>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/s2/s2latlng_test.cc
+++ b/src/s2/s2latlng_test.cc
@@ -18,6 +18,8 @@
 #include "s2/s2latlng.h"
 
 #include <cmath>
+#include <cstdio>
+#include <limits>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -124,6 +126,44 @@ TEST(S2LatLng, NegativeZeros) {
       S2LatLng::Longitude(S2Point(-0., 0., 1.)).radians(), +0.));
   EXPECT_TRUE(IsIdentical(
       S2LatLng::Longitude(S2Point(-0., -0., 1.)).radians(), +0.));
+}
+
+TEST(S2LatLng, InfIsInvalid) {
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(std::numeric_limits<double>::infinity(), -122)
+          .is_valid());
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(37, std::numeric_limits<double>::infinity())
+          .is_valid());
+
+  // Also check the results of .Normalized()
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(std::numeric_limits<double>::infinity(), -122)
+          .Normalized()
+          .is_valid());
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(37, std::numeric_limits<double>::infinity())
+          .Normalized()
+          .is_valid());
+}
+
+TEST(S2LatLng, NanIsInvalid) {
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(std::numeric_limits<double>::quiet_NaN(), -122)
+          .is_valid());
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(std::numeric_limits<double>::quiet_NaN(), -122)
+          .is_valid());
+
+  // Also check the results of .Normalized()
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(37, std::numeric_limits<double>::quiet_NaN())
+          .Normalized()
+          .is_valid());
+  EXPECT_FALSE(
+      S2LatLng::FromDegrees(37, std::numeric_limits<double>::quiet_NaN())
+          .Normalized()
+          .is_valid());
 }
 
 TEST(S2LatLng, TestDistance) {

--- a/src/s2/s2lax_polygon_shape.cc
+++ b/src/s2/s2lax_polygon_shape.cc
@@ -20,14 +20,16 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <utility>
 #include <vector>
 
 #include "absl/log/absl_check.h"
+#include "absl/memory/memory.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 
-#include "s2/base/types.h"
 #include "s2/encoded_s2point_vector.h"
 #include "s2/encoded_uint_vector.h"
 #include "s2/s2coder.h"
@@ -62,7 +64,7 @@ unique_ptr<T> make_unique_for_overwrite(size_t n) {
 static const unsigned char kCurrentEncodingVersionNumber = 1;
 
 S2LaxPolygonShape::S2LaxPolygonShape(
-    const vector<S2LaxPolygonShape::Loop>& loops) {
+    absl::Span<const S2LaxPolygonShape::Loop> loops) {
   Init(loops);
 }
 
@@ -94,7 +96,7 @@ S2LaxPolygonShape& S2LaxPolygonShape::operator=(
   return *this;
 }
 
-void S2LaxPolygonShape::Init(const vector<S2LaxPolygonShape::Loop>& loops) {
+void S2LaxPolygonShape::Init(absl::Span<const S2LaxPolygonShape::Loop> loops) {
   vector<Span<const S2Point>> spans;
   spans.reserve(loops.size());
   for (const S2LaxPolygonShape::Loop& loop : loops) {
@@ -190,43 +192,63 @@ void S2LaxPolygonShape::Encode(Encoder* encoder,
   }
 }
 
-bool S2LaxPolygonShape::Init(Decoder* decoder) {
-  if (decoder->avail() < 1) return false;
+bool S2LaxPolygonShape::Init(Decoder* decoder, S2Error* error) {
+  const auto Error = [&error](absl::string_view message) {
+    if (error != nullptr) {
+      *error = S2Error::DataLoss(message);
+    }
+    return false;
+  };
+
+  if (decoder->avail() < 1) {
+    return Error("Insufficient data in decoder");
+  }
+
   uint8_t version = decoder->get8();
-  if (version != kCurrentEncodingVersionNumber) return false;
+  if (version != kCurrentEncodingVersionNumber) {
+    return Error("Bad version number in byte string");
+  }
 
   uint32_t num_loops;
-  if (!decoder->get_varint32(&num_loops)) return false;
+  if (!decoder->get_varint32(&num_loops)) {
+    return Error("Failed to decode number of loops");
+  }
+
   num_loops_ = num_loops;
   s2coding::EncodedS2PointVector vertices;
-  if (!vertices.Init(decoder)) return false;
+  if (!vertices.Init(decoder)) {
+    return Error("Failed to decode vertices");
+  }
 
   if (num_loops_ == 0) {
     num_vertices_ = 0;
   } else {
     num_vertices_ = vertices.size();
     vertices_ = make_unique<S2Point[]>(num_vertices_);  // TODO(see above)
-    for (int i = 0; i < num_vertices_; ++i) {
-      vertices_[i] = vertices[i];
+
+    // Load the polygon vertices from the encoded s2point vector.
+    if (error == nullptr) {
+      vertices.Decode(absl::MakeSpan(vertices_.get(), num_vertices_));
+    } else {
+      vertices.Decode(absl::MakeSpan(vertices_.get(), num_vertices_), *error);
+      if (!error->ok()) {
+        return false;
+      }
     }
+
     if (num_loops_ > 1) {
       s2coding::EncodedUintVector<uint32_t> loop_starts;
-      if (!loop_starts.Init(decoder)) return false;
+      if (!loop_starts.Init(decoder) || loop_starts.size() != num_loops_ + 1) {
+        return Error("Failed to decode loop offsets");
+      }
+
       loop_starts_ = make_unique_for_overwrite<uint32_t[]>(loop_starts.size());
       for (size_t i = 0; i < loop_starts.size(); ++i) {
         loop_starts_[i] = loop_starts[i];
       }
     }
   }
-  return true;
-}
 
-bool S2LaxPolygonShape::Init(Decoder* decoder, S2Error& error) {
-  if (!Init(decoder)) {
-    error.Init(S2Error::DATA_LOSS,
-               "Unknown error occurred decoding S2LaxPolygonShape");
-    return false;
-  }
   return true;
 }
 

--- a/src/s2/s2lax_polygon_shape_test.cc
+++ b/src/s2/s2lax_polygon_shape_test.cc
@@ -26,8 +26,10 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/algorithm/container.h"
 #include "absl/log/absl_log.h"
 #include "absl/log/log_streamer.h"
 #include "absl/random/bit_gen_ref.h"
@@ -58,53 +60,87 @@
 #include "s2/s2text_format.h"
 
 using absl::string_view;
+using s2coding::CodingHint;
+using s2textformat::MakePointOrDie;
 using s2textformat::MakePolygonOrDie;
 using std::make_unique;
 using std::unique_ptr;
 using std::vector;
+using testing::HasSubstr;
 
-// Verifies that EncodedS2LaxPolygonShape behaves identically to
-// S2LaxPolygonShape. Also supports testing that the encoded form is identical
-// to the re-encoded form.
-
-void TestEncodedS2LaxPolygonShape(const S2LaxPolygonShape& original) {
-  Encoder encoder;
-  original.Encode(&encoder, s2coding::CodingHint::COMPACT);
-  Decoder decoder(encoder.base(), encoder.length());
-  EncodedS2LaxPolygonShape encoded;
-  ASSERT_TRUE(encoded.Init(&decoder));
-  EXPECT_EQ(encoded.num_loops(), original.num_loops());
-  EXPECT_EQ(encoded.num_vertices(), original.num_vertices());
-  EXPECT_EQ(encoded.num_edges(), original.num_edges());
-  EXPECT_EQ(encoded.num_chains(), original.num_chains());
-  EXPECT_EQ(encoded.dimension(), original.dimension());
-  EXPECT_EQ(encoded.is_empty(), original.is_empty());
-  EXPECT_EQ(encoded.is_full(), original.is_full());
-  EXPECT_EQ(encoded.GetReferencePoint(), original.GetReferencePoint());
-  for (int i = 0; i < original.num_loops(); ++i) {
-    EXPECT_EQ(encoded.num_loop_vertices(i), original.num_loop_vertices(i));
-    EXPECT_EQ(encoded.chain(i), original.chain(i));
-    for (int j = 0; j < original.num_loop_vertices(i); ++j) {
-      EXPECT_EQ(encoded.loop_vertex(i, j), original.loop_vertex(i, j));
-      EXPECT_EQ(encoded.chain_edge(i, j), original.chain_edge(i, j));
+template <typename LaxShape>
+void TestLaxDecoding(const LaxShape& shape, const S2LaxPolygonShape& expected) {
+  EXPECT_EQ(shape.num_loops(), expected.num_loops());
+  EXPECT_EQ(shape.num_vertices(), expected.num_vertices());
+  EXPECT_EQ(shape.num_edges(), expected.num_edges());
+  EXPECT_EQ(shape.num_chains(), expected.num_chains());
+  EXPECT_EQ(shape.dimension(), expected.dimension());
+  EXPECT_EQ(shape.is_empty(), expected.is_empty());
+  EXPECT_EQ(shape.is_full(), expected.is_full());
+  EXPECT_EQ(shape.GetReferencePoint(), expected.GetReferencePoint());
+  for (int i = 0; i < expected.num_loops(); ++i) {
+    EXPECT_EQ(shape.num_loop_vertices(i), expected.num_loop_vertices(i));
+    EXPECT_EQ(shape.chain(i), expected.chain(i));
+    for (int j = 0; j < expected.num_loop_vertices(i); ++j) {
+      EXPECT_EQ(shape.loop_vertex(i, j), expected.loop_vertex(i, j));
+      EXPECT_EQ(shape.chain_edge(i, j), expected.chain_edge(i, j));
     }
   }
   // Now test all the edges in a random order in order to exercise the cases
   // involving prev_loop_.
-  vector<int> edge_ids(original.num_edges());
+  vector<int> edge_ids(expected.num_edges());
   std::iota(edge_ids.begin(), edge_ids.end(), 0);
   std::shuffle(edge_ids.begin(), edge_ids.end(), std::mt19937_64());
   for (int e : edge_ids) {
-    EXPECT_EQ(encoded.chain_position(e), original.chain_position(e));
-    EXPECT_EQ(encoded.edge(e), original.edge(e));
+    EXPECT_EQ(shape.chain_position(e), expected.chain_position(e));
+    EXPECT_EQ(shape.edge(e), expected.edge(e));
   }
+}
 
+template <typename LaxShape>
+void TestLaxRecoding(const LaxShape& shape, const Encoder& expected) {
   // Let's also test that the encoded form can be encoded, yielding the same
   // bytes as the originally encoded form.
   Encoder reencoder;
-  encoded.Encode(&reencoder, s2coding::CodingHint::COMPACT);
-  ASSERT_EQ(string_view(encoder.base(), encoder.length()),
+  shape.Encode(&reencoder, s2coding::CodingHint::COMPACT);
+  ASSERT_EQ(string_view(expected.base(), expected.length()),
             string_view(reencoder.base(), reencoder.length()));
+}
+
+// Tests encoding an S2LaxPolygonShape and decoding it through both
+// EncodedS2LaxPolygonShape and the Init() methods of S2LaxPolygonShape.
+void TestS2LaxPolygonShapeEncoding(const S2LaxPolygonShape& original) {
+  Encoder encoder;
+  original.Encode(&encoder, s2coding::CodingHint::COMPACT);
+
+  // Test EncodedS2LaxPolygonShape API.
+  {
+    Decoder decoder(encoder.base(), encoder.length());
+    EncodedS2LaxPolygonShape shape;
+    ASSERT_TRUE(shape.Init(&decoder));
+    TestLaxDecoding(shape, original);
+    TestLaxRecoding(shape, encoder);
+  }
+
+  // Test S2LaxPolygon::Init() API.
+  {
+    Decoder decoder(encoder.base(), encoder.length());
+    S2LaxPolygonShape shape;
+    ASSERT_TRUE(shape.Init(&decoder));
+    TestLaxDecoding(shape, original);
+    TestLaxRecoding(shape, encoder);
+  }
+
+  // Test S2LaxPolygon::Init(S2Error&) API.
+  {
+    Decoder decoder(encoder.base(), encoder.length());
+    S2Error error;
+    S2LaxPolygonShape shape;
+    ASSERT_TRUE(shape.Init(&decoder, error));
+    ASSERT_TRUE(error.ok());
+    TestLaxDecoding(shape, original);
+    TestLaxRecoding(shape, encoder);
+  }
 }
 
 TEST(S2LaxPolygonShape, EmptyPolygon) {
@@ -122,7 +158,7 @@ TEST(S2LaxPolygonShape, EmptyPolygon) {
   EXPECT_TRUE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
   EXPECT_FALSE(shape.GetReferencePoint().contained);
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, Move) {
@@ -138,7 +174,7 @@ TEST(S2LaxPolygonShape, Move) {
   // Test the move constructor.
   S2LaxPolygonShape move1(std::move(to_move));
   s2testing::ExpectEqual(correct, move1);
-  TestEncodedS2LaxPolygonShape(move1);
+  TestS2LaxPolygonShapeEncoding(move1);
   ASSERT_EQ(loops.size(), move1.num_loops());
   ASSERT_EQ(6, move1.num_vertices());
   for (int i = 0; i < loops.size(); ++i) {
@@ -151,7 +187,7 @@ TEST(S2LaxPolygonShape, Move) {
   S2LaxPolygonShape move2;
   move2 = std::move(move1);
   s2testing::ExpectEqual(correct, move2);
-  TestEncodedS2LaxPolygonShape(move2);
+  TestS2LaxPolygonShapeEncoding(move2);
   ASSERT_EQ(loops.size(), move2.num_loops());
   ASSERT_EQ(6, move2.num_vertices());
   for (int i = 0; i < loops.size(); ++i) {
@@ -171,7 +207,7 @@ TEST(S2LaxPolygonShape, FullPolygon) {
   EXPECT_FALSE(shape.is_empty());
   EXPECT_TRUE(shape.is_full());
   EXPECT_TRUE(shape.GetReferencePoint().contained);
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, SingleVertexPolygon) {
@@ -194,7 +230,7 @@ TEST(S2LaxPolygonShape, SingleVertexPolygon) {
   EXPECT_FALSE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
   EXPECT_FALSE(shape.GetReferencePoint().contained);
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, SingleLoopPolygon) {
@@ -221,7 +257,7 @@ TEST(S2LaxPolygonShape, SingleLoopPolygon) {
   EXPECT_FALSE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
   EXPECT_FALSE(s2shapeutil::ContainsBruteForce(shape, S2::Origin()));
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, MultiLoopPolygon) {
@@ -254,7 +290,7 @@ TEST(S2LaxPolygonShape, MultiLoopPolygon) {
   EXPECT_FALSE(shape.is_empty());
   EXPECT_FALSE(shape.is_full());
   EXPECT_FALSE(s2shapeutil::ContainsBruteForce(shape, S2::Origin()));
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, MultiLoopS2Polygon) {
@@ -322,7 +358,7 @@ TEST(S2LaxPolygonShape, ManyLoopPolygon) {
     auto v1 = loops[i][(j + 1) % loops[i].size()];
     EXPECT_EQ(shape.edge(e), S2Shape::Edge(v0, v1));
   }
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, DegenerateLoops) {
@@ -332,7 +368,7 @@ TEST(S2LaxPolygonShape, DegenerateLoops) {
       s2textformat::ParsePointsOrDie("5:5, 6:6")};
   S2LaxPolygonShape shape(loops);
   EXPECT_FALSE(shape.GetReferencePoint().contained);
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 TEST(S2LaxPolygonShape, InvertedLoops) {
@@ -341,7 +377,7 @@ TEST(S2LaxPolygonShape, InvertedLoops) {
       s2textformat::ParsePointsOrDie("3:4, 3:3, 4:4")};
   S2LaxPolygonShape shape(loops);
   EXPECT_TRUE(s2shapeutil::ContainsBruteForce(shape, S2::Origin()));
-  TestEncodedS2LaxPolygonShape(shape);
+  TestS2LaxPolygonShapeEncoding(shape);
 }
 
 void CompareS2LoopToShape(absl::BitGenRef bitgen, const S2Loop& loop,
@@ -465,4 +501,48 @@ TEST(S2LaxPolygonShape, ChainVertexIteratorWorks) {
 
     ++chain_counter;
   }
+}
+
+std::string DecodeS2LaxPolygonShape(absl::string_view data) {
+  Decoder decoder(data.data(), data.size());
+  S2Error error;
+
+  S2LaxPolygonShape shape;
+  (void)shape.Init(&decoder, error);
+  if (!error.ok()) {
+    return std::string(error.message());
+  }
+  return {};
+}
+
+TEST(S2LaxPolygonShapeTest, InsufficientDataInEncoder) {
+  EXPECT_THAT(DecodeS2LaxPolygonShape(""), HasSubstr("Insufficient data"));
+}
+
+TEST(S2LaxPolygonShapeTest, BadVersionNumber) {
+  EXPECT_THAT(DecodeS2LaxPolygonShape("\373"), HasSubstr("Bad version number"));
+}
+
+TEST(S2LaxPolygonShapeTest, BadLoopNumber) {
+  EXPECT_THAT(DecodeS2LaxPolygonShape("\001"), HasSubstr("number of loops"));
+}
+
+TEST(S2LaxPolygonShapeTest, BadVerticesInit) {
+  EXPECT_THAT(DecodeS2LaxPolygonShape("\001\003"),
+              HasSubstr("decode vertices"));
+}
+
+TEST(S2LaxPolygonShapeTest, BadVertices) {
+  EXPECT_THAT(
+      DecodeS2LaxPolygonShape(std::string(
+          "\0014\331\227\360\360."
+          "\010\010\010\010\010\010\010\010\010\010\010\000\010\010\360\360\360"
+          "\360\360\360\360\360\360\360\360\360\360\000\251\021\021\014",
+          39)),
+      HasSubstr("Invalid exception delta outside of block size"));
+}
+
+TEST(S2LaxPolygonShapeTest, BadLoopOffsets) {
+  EXPECT_THAT(DecodeS2LaxPolygonShape(std::string("\001\225\243C\000\373", 6)),
+              HasSubstr("Failed to decode loop offsets"));
 }

--- a/src/s2/s2lax_polyline_shape.cc
+++ b/src/s2/s2lax_polyline_shape.cc
@@ -84,19 +84,16 @@ bool S2LaxPolylineShape::Init(Decoder* decoder) {
   if (!vertices.Init(decoder)) return false;
   num_vertices_ = vertices.size();
   vertices_ = make_unique<S2Point[]>(vertices.size());
-  for (int i = 0; i < num_vertices_; ++i) {
-    vertices_[i] = vertices[i];
-  }
-  return true;
+  return vertices.Decode(absl::MakeSpan(vertices_.get(), vertices.size()));
 }
 
 bool S2LaxPolylineShape::Init(Decoder* decoder, S2Error& error) {
-  if (!Init(decoder)) {
-    error.Init(S2Error::DATA_LOSS,
-               "Unknown error occurred decoding S2LaxPolylineShape");
-    return false;
-  }
-  return true;
+  s2coding::EncodedS2PointVector vertices;
+  if (!vertices.Init(decoder, error)) return false;
+  num_vertices_ = vertices.size();
+  vertices_ = make_unique<S2Point[]>(vertices.size());
+  vertices.Decode(absl::MakeSpan(vertices_.get(), vertices.size()), error);
+  return error.ok();
 }
 
 S2Shape::Edge S2LaxPolylineShape::edge(int e) const {

--- a/src/s2/s2loop.h
+++ b/src/s2/s2loop.h
@@ -49,8 +49,6 @@
 #include "s2/util/math/matrix3x3.h"
 #include "s2/util/math/vector.h"
 
-class Decoder;
-class Encoder;
 class LoopCrosser;
 class LoopRelation;
 class MergingIterator;
@@ -417,14 +415,14 @@ class S2Loop final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes a loop encoded with Encode() or the private method
   // EncodeCompressed() (used by the S2Polygon encoder).  Returns true on
   // success.
   //
   // This method may be called with loops that have already been initialized.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   ////////////////////////////////////////////////////////////////////////
   // Methods intended primarily for use by the S2Polygon implementation:
@@ -452,17 +450,6 @@ class S2Loop final : public S2Region {
   // REQUIRES: neither loop is empty.
   // REQUIRES: if b->is_full(), then !b->is_hole().
   int CompareBoundary(const S2Loop& b) const;
-
-  // Given another loop 'B' whose boundaries does not cross this loop's
-  // boundaries (see CompareBoundary), return true if this loop contains the
-  // boundary of B. If "reverse_b" is true, the boundary of B is reversed first
-  // (which only affects the result when there are shared edges).  This method
-  // is cheaper than CompareBoundary() because it does not test for edge
-  // intersections.
-  //
-  // REQUIRES: neither loop is empty.
-  // REQUIRES: if b->is_full(), then reverse_b == false.
-  bool ContainsNonCrossingBoundary(const S2Loop& b, bool reverse_b) const;
 
   // Wrapper class for indexing a loop (see S2ShapeIndex).  Once this object
   // is inserted into an S2ShapeIndex it is owned by that index, and will be
@@ -576,7 +563,7 @@ class S2Loop final : public S2Region {
   bool FindValidationErrorNoIndex(S2Error* error) const;
 
   // Internal implementation of the Decode method above.
-  bool DecodeInternal(Decoder* const decoder);
+  bool DecodeInternal(Decoder* decoder);
 
   // Converts the loop vertices to the S2XYZFaceSiTi format and store the result
   // in the given array, which must be large enough to store all the vertices.

--- a/src/s2/s2loop_measures_test.cc
+++ b/src/s2/s2loop_measures_test.cc
@@ -17,11 +17,10 @@
 
 #include "s2/s2loop_measures.h"
 
-#include <cfloat>
-#include <cstdint>
-
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -43,7 +42,6 @@
 #include "s2/s2random.h"
 #include "s2/s2testing.h"
 #include "s2/s2text_format.h"
-#include "s2/util/math/mathutil.h"
 
 using absl::string_view;
 using s2textformat::ParsePointsOrDie;
@@ -166,7 +164,7 @@ TEST(PruneDegeneracies, AllSmallCases) {
       // Do all base^exponent strings of length `exponent` using a `base`-letter
       // alphabet (as long as there are 5000 or fewer of them).
 
-      const int64_t num_strings = MathUtil::IPow<int64_t>(base, exponent);
+      const int64_t num_strings = std::pow(int64_t{base}, int64_t{exponent});
       if (num_strings > 5000) break;   // getting too many, for this base
       if (num_strings == 0) continue;  // base=0 and exponent>0 is not useful
       if (base > exponent) continue;  // more chars than positions is not useful

--- a/src/s2/s2max_distance_targets.cc
+++ b/src/s2/s2max_distance_targets.cc
@@ -16,7 +16,6 @@
 #include "s2/s2max_distance_targets.h"
 
 #include <cmath>
-
 #include <memory>
 
 #include "absl/functional/function_ref.h"

--- a/src/s2/s2max_distance_targets_test.cc
+++ b/src/s2/s2max_distance_targets_test.cc
@@ -24,6 +24,7 @@
 #include "absl/container/btree_set.h"
 #include "absl/log/log_streamer.h"
 #include "absl/random/random.h"
+#include "absl/types/span.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1chord_angle.h"
 #include "s2/s2cap.h"
@@ -323,7 +324,7 @@ TEST(CellTarget, VisitContainingShapes) {
 }
 
 // Negates S2 points to reflect them through the sphere.
-static vector<S2Point> Reflect(const vector<S2Point>& pts) {
+static vector<S2Point> Reflect(absl::Span<const S2Point> pts) {
   vector<S2Point> negative_pts;
   for (const auto& p : pts) {
     negative_pts.push_back(-p);

--- a/src/s2/s2memory_tracker.cc
+++ b/src/s2/s2memory_tracker.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <utility>
 
+#include "absl/strings/str_format.h"
 #include "s2/s2error.h"
 
 void S2MemoryTracker::SetError(S2Error error) {
@@ -28,9 +29,9 @@ void S2MemoryTracker::SetError(S2Error error) {
 
 // Not inline in order to avoid code bloat.
 void S2MemoryTracker::SetLimitExceededError() {
-  error_.Init(S2Error::RESOURCE_EXHAUSTED,
-              "Memory limit exceeded (tracked usage %d bytes, limit %d bytes)",
-              usage_bytes_, limit_bytes_);
+  error_ = S2Error::ResourceExhausted(absl::StrFormat(
+      "Memory limit exceeded (tracked usage %d bytes, limit %d bytes)",
+      usage_bytes_, limit_bytes_));
 }
 
 bool S2MemoryTracker::Client::TallyTemp(int64_t delta_bytes) {

--- a/src/s2/s2memory_tracker.h
+++ b/src/s2/s2memory_tracker.h
@@ -177,7 +177,7 @@ class S2MemoryTracker {
   // Resets usage() and max_usage() to zero and clears any error.  Leaves all
   // other parameters unchanged.
   void Reset() {
-    error_.Clear();
+    error_ = S2Error::Ok();
     usage_bytes_ = max_usage_bytes_ = alloc_bytes_ = 0;
     callback_alloc_limit_bytes_ = callback_alloc_delta_bytes_;
   }
@@ -360,7 +360,7 @@ template <typename... Args>
 void S2MemoryTracker::SetError(S2Error::Code code,
                                const absl::FormatSpec<Args...>& format,
                                const Args&... args) {
-  error_.Init(code, format, args...);
+  error_ = S2Error(code, absl::StrFormat(format, args...));
 }
 
 inline bool S2MemoryTracker::Tally(int64_t delta_bytes) {

--- a/src/s2/s2metrics.h
+++ b/src/s2/s2metrics.h
@@ -171,7 +171,7 @@ int S2::Metric<dim>::GetLevelForMaxValue(double value) const {
   // rounding up.  ilogb() returns the exponent corresponding to a fraction in
   // the range [1,2).
   int level = ilogb(value / deriv_);
-  level = std::max(0, std::min(S2::kMaxCellLevel, -(level >> (dim - 1))));
+  level = std::clamp(-(level >> (dim - 1)), 0, S2::kMaxCellLevel);
   ABSL_DCHECK(level == S2::kMaxCellLevel || GetValue(level) <= value);
   ABSL_DCHECK(level == 0 || GetValue(level - 1) > value);
   return level;
@@ -184,7 +184,7 @@ int S2::Metric<dim>::GetLevelForMinValue(double value) const {
   // This code is equivalent to computing a floating-point "level" value and
   // rounding down.
   int level = ilogb(deriv_ / value);
-  level = std::max(0, std::min(S2::kMaxCellLevel, level >> (dim - 1)));
+  level = std::clamp(level >> (dim - 1), 0, S2::kMaxCellLevel);
   ABSL_DCHECK(level == 0 || GetValue(level) >= value);
   ABSL_DCHECK(level == kMaxCellLevel || GetValue(level + 1) < value);
   return level;

--- a/src/s2/s2metrics_test.cc
+++ b/src/s2/s2metrics_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2metrics.h"
 
-#include <cmath>
-
 #include <algorithm>
+#include <cmath>
 
 #include <gtest/gtest.h>
 #include "s2/s2coords.h"
@@ -117,7 +116,7 @@ TEST(S2, Metrics) {
     if (level >= S2::kMaxCellLevel + 3) width = 0;
 
     // Check boundary cases (exactly equal to a threshold value).
-    int expected_level = std::max(0, std::min(S2::kMaxCellLevel, level));
+    int expected_level = std::clamp(level, 0, S2::kMaxCellLevel);
     EXPECT_EQ(S2::kMinWidth.GetLevelForMaxValue(width), expected_level);
     EXPECT_EQ(S2::kMinWidth.GetLevelForMinValue(width), expected_level);
     EXPECT_EQ(S2::kMinWidth.GetClosestLevel(width), expected_level);

--- a/src/s2/s2min_distance_targets.cc
+++ b/src/s2/s2min_distance_targets.cc
@@ -18,7 +18,6 @@
 #include "s2/s2min_distance_targets.h"
 
 #include <cmath>
-
 #include <memory>
 #include <utility>
 

--- a/src/s2/s2min_distance_targets_test.cc
+++ b/src/s2/s2min_distance_targets_test.cc
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 #include "absl/container/btree_set.h"
+#include "absl/types/span.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1chord_angle.h"
 #include "s2/s2cell.h"
@@ -163,7 +164,7 @@ vector<int> GetContainingShapes(S2MinDistanceTarget* target,
 
 // Given two sorted vectors "x" and "y", returns true if x is a subset of y
 // and x.size() == x_size.
-bool IsSubsetOfSize(const vector<int>& x, const vector<int>& y,
+bool IsSubsetOfSize(absl::Span<const int> x, absl::Span<const int> y,
                     int x_size) {
   if (x.size() != x_size) return false;
   return std::includes(y.begin(), y.end(), x.begin(), x.end());

--- a/src/s2/s2padded_cell.cc
+++ b/src/s2/s2padded_cell.cc
@@ -20,8 +20,9 @@
 #include <algorithm>
 #include <cfloat>
 
+#include "absl/base/optimization.h"
 #include "absl/log/absl_check.h"
-#include "s2/util/bits/bits.h"
+#include "absl/numeric/bits.h"
 #include "s2/r1interval.h"
 #include "s2/r2rect.h"
 #include "s2/s2cell_id.h"
@@ -160,8 +161,9 @@ S2CellId S2PaddedCell::ShrinkToFit(const R2Rect& rect) const {
   // and then choose the cell level that includes both of these endpoints.  So
   // if both pairs of endpoints are equal we choose kMaxLevel; if they differ
   // only at bit 0, we choose (kMaxLevel - 1), and so on.
-  int level_msb = ((ij_xor[0] | ij_xor[1]) << 1) + 1;
-  int level = S2CellId::kMaxLevel - Bits::FindMSBSetNonZero(level_msb);
+  unsigned int level_msb = ((ij_xor[0] | ij_xor[1]) << 1) + 1;
+  ABSL_ASSUME(level_msb != 0);
+  int level = S2CellId::kMaxLevel - (absl::bit_width(level_msb) - 1);
   if (level <= level_) return id();
   return S2CellId::FromFaceIJ(id().face(), ij_min[0], ij_min[1]).parent(level);
 }

--- a/src/s2/s2point.h
+++ b/src/s2/s2point.h
@@ -77,7 +77,7 @@ class S2Point : public Vector3_d {
   // Initialize S2Point from a Decoder instance.
   bool Init(Decoder* decoder, S2Error& error) {
     if (decoder->avail() < sizeof(S2Point)) {
-      error.Init(S2Error::DATA_LOSS, "Not enough data to decode S2Point");
+      error = S2Error::DataLoss("Not enough data to decode S2Point");
       return false;
     }
 

--- a/src/s2/s2point_compression.h
+++ b/src/s2/s2point_compression.h
@@ -52,8 +52,6 @@
 #include "s2/s1angle.h"
 #include "s2/s2point.h"
 
-class Decoder;
-class Encoder;
 
 // The XYZ and face,si,ti coordinates of an S2Point and, if this point is equal
 // to the center of an S2Cell, the level of this cell (-1 otherwise).

--- a/src/s2/s2point_compression_test.cc
+++ b/src/s2/s2point_compression_test.cc
@@ -56,8 +56,7 @@ S2Point SnapPointToLevel(const S2Point& point, int level) {
   return S2CellId(point).parent(level).ToPoint();
 }
 
-vector<S2Point> SnapPointsToLevel(const vector<S2Point>& points,
-                                  int level) {
+vector<S2Point> SnapPointsToLevel(absl::Span<const S2Point> points, int level) {
   vector<S2Point> snapped_points(points.size());
   for (int i = 0; i < points.size(); ++i) {
     snapped_points[i] = SnapPointToLevel(points[i], level);

--- a/src/s2/s2point_index.h
+++ b/src/s2/s2point_index.h
@@ -19,7 +19,6 @@
 #define S2_S2POINT_INDEX_H_
 
 #include <cstddef>
-
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/src/s2/s2point_region.h
+++ b/src/s2/s2point_region.h
@@ -30,8 +30,6 @@
 #include "s2/s2region.h"
 #include "s2/util/coding/coder.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2Cell;
 class S2LatLngRect;
@@ -65,11 +63,11 @@ class S2PointRegion final : public S2Region {
   //
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
-  void Encode(Encoder* const encoder) const;
+  void Encode(Encoder* encoder) const;
 
   // Decodes an S2Point encoded with Encode().  Returns true on success.
   // (Returns false if the encoded point is not unit length.)
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
  private:
   S2Point point_;

--- a/src/s2/s2point_test.cc
+++ b/src/s2/s2point_test.cc
@@ -29,6 +29,7 @@
 #include "absl/hash/hash.h"
 #include "absl/log/log_streamer.h"
 #include "absl/random/random.h"
+#include "absl/strings/str_format.h"
 #include "s2/s2coder_testing.h"
 #include "s2/s2error.h"
 #include "s2/s2random.h"

--- a/src/s2/s2point_vector_shape.h
+++ b/src/s2/s2point_vector_shape.h
@@ -25,6 +25,7 @@
 #include "s2/util/coding/coder.h"
 #include "s2/encoded_s2point_vector.h"
 #include "s2/s2coder.h"
+#include "s2/s2error.h"
 #include "s2/s2point.h"
 #include "s2/s2shape.h"
 
@@ -72,6 +73,19 @@ class S2PointVectorShape : public S2Shape {
     if (!points.Init(decoder)) return false;
     points_ = points.Decode();
     return true;
+  }
+
+  // Decodes an S2PointVectorShape, returning true on success.  If any errors
+  // are encountered during decoding, the S2Error is set and false is returned.
+  //
+  // This error checking may incur slightly more overhead than the plain Init()
+  // method above, but promises that no fatal decoding conditions will occur in
+  // tests.
+  bool Init(Decoder* decoder, S2Error& error) {
+    s2coding::EncodedS2PointVector points;
+    if (!points.Init(decoder, error)) return false;
+    points_ = points.Decode(error);
+    return error.ok();
   }
 
   // S2Shape interface.

--- a/src/s2/s2pointutil.cc
+++ b/src/s2/s2pointutil.cc
@@ -59,7 +59,7 @@ S2Point Ortho(const S2Point& a) {
 #endif
 }
 
-S2Point Rotate(const S2Point& p, const S2Point& axis, S1Angle angle) {
+S2Point Rotate(const S2Point& p, const S2Point& axis, const S1Angle angle) {
   ABSL_DCHECK(IsUnitLength(p));
   ABSL_DCHECK(IsUnitLength(axis));
   // Let M be the plane through P that is perpendicular to "axis", and let
@@ -72,7 +72,8 @@ S2Point Rotate(const S2Point& p, const S2Point& axis, S1Angle angle) {
   S2Point dy = axis.CrossProd(p);
   // Mathematically the result is unit length, but normalization is necessary
   // to ensure that numerical errors don't accumulate.
-  return (cos(angle) * dx + sin(angle) * dy + center).Normalize();
+  const S1Angle::SinCosPair a = angle.SinCos();
+  return (a.cos * dx + a.sin * dy + center).Normalize();
 }
 
 Matrix3x3_d GetFrame(const S2Point& z) {

--- a/src/s2/s2pointutil_test.cc
+++ b/src/s2/s2pointutil_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2pointutil.h"
 
 #include <cmath>
-
 #include <string>
 
 #include <gtest/gtest.h>

--- a/src/s2/s2polygon.h
+++ b/src/s2/s2polygon.h
@@ -50,8 +50,6 @@
 #include "s2/s2shape_index.h"
 #include "s2/util/coding/coder.h"
 
-class Decoder;
-class Encoder;
 class S1Angle;
 class S2Cap;
 class S2Cell;
@@ -663,7 +661,7 @@ class S2Polygon final : public S2Region {
   bool Contains(const S2Cell& cell) const override;
   bool MayIntersect(const S2Cell& cell) const override;
 
-  // The point 'p' does not need to be normalized.
+  // The point 'p' must be normalized.
   bool Contains(const S2Point& p) const override;
 
   // Appends a serialized representation of the S2Polygon to "encoder".
@@ -693,7 +691,7 @@ class S2Polygon final : public S2Region {
   void EncodeUncompressed(Encoder* encoder) const;
 
   // Decodes a polygon encoded with Encode().  Returns true on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   // Wrapper class for indexing a polygon (see S2ShapeIndex).  Once this
   // object is inserted into an S2ShapeIndex it is owned by that index, and
@@ -820,9 +818,6 @@ class S2Polygon final : public S2Region {
   // Deletes the contents of the loops_ vector and resets the polygon state.
   void ClearLoops();
 
-  // Return true if there is an error in the loop nesting hierarchy.
-  bool FindLoopNestingError(S2Error* error) const;
-
   // A map from each loop to its immediate children with respect to nesting.
   // This map is built during initialization of multi-loop polygons to
   // determine which are shells and which are holes, and then discarded.
@@ -864,7 +859,7 @@ class S2Polygon final : public S2Region {
 
   // Decode a polygon encoded with EncodeUncompressed().  Used by the Decode
   // method above.
-  bool DecodeUncompressed(Decoder* const decoder);
+  bool DecodeUncompressed(Decoder* decoder);
 
   // Encode the polygon's vertices using about 4 bytes / vertex plus 24 bytes /
   // unsnapped vertex. All the loop vertices must be converted first to the

--- a/src/s2/s2polygon_test.cc
+++ b/src/s2/s2polygon_test.cc
@@ -1031,7 +1031,7 @@ TEST(S2Polygon, LoopPointers) {
 }
 
 static vector<unique_ptr<S2Loop>> MakeLoops(
-    const vector<vector<S2Point>>& loop_vertices) {
+    absl::Span<const vector<S2Point>> loop_vertices) {
   vector<unique_ptr<S2Loop>> result;
   for (const auto& vertices : loop_vertices) {
     result.emplace_back(new S2Loop(vertices));
@@ -1662,7 +1662,7 @@ TEST_F(S2PolygonTestBase, PolylineIntersection) {
     PolylineIntersectionSharedEdgeTest(*cross1_side_hole_, v + 1, -1);
   }
 
-  // See comments in TestOperations about the vlue of this constant.
+  // See comments in TestOperations about the value of this constant.
   static const S1Angle kMaxError = S1Angle::Radians(1e-4);
 
   // This duplicates some of the tests in TestOperations by
@@ -1716,7 +1716,7 @@ TEST_F(S2PolygonTestBase, PolylineIntersection) {
 }
 
 static void CheckCoveringIsConservative(const S2Polygon& polygon,
-                                        const vector<S2CellId>& cells) {
+                                        absl::Span<const S2CellId> cells) {
   // Check that Contains(S2Cell) and MayIntersect(S2Cell) are implemented
   // conservatively, by comparing against the Contains/Intersect result with
   // the "cell polygon" defined by the four cell vertices.  Please note that
@@ -2849,8 +2849,8 @@ TEST_F(S2PolygonSimplifierTest, EdgesOverlap) {
 // Creates a polygon from loops specified as a comma separated list of u:v
 // coordinates relative to a cell. The loop "0:0, 1:0, 1:1, 0:1" is
 // counter-clockwise.
-unique_ptr<S2Polygon> MakeCellPolygon(
-    const S2Cell& cell, const vector<string_view>& strs) {
+unique_ptr<S2Polygon> MakeCellPolygon(const S2Cell& cell,
+                                      absl::Span<const string_view> strs) {
   vector<unique_ptr<S2Loop>> loops;
   for (auto str : strs) {
     vector<S2LatLng> points = s2textformat::ParseLatLngsOrDie(str);

--- a/src/s2/s2polyline.cc
+++ b/src/s2/s2polyline.cc
@@ -17,11 +17,10 @@
 
 #include "s2/s2polyline.h"
 
-#include <cstddef>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
@@ -32,6 +31,7 @@
 #include "absl/flags/flag.h"
 #include "absl/log/absl_check.h"
 #include "absl/log/absl_log.h"
+#include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "absl/utility/utility.h"
 
@@ -171,20 +171,23 @@ bool S2Polyline::FindValidationError(S2Error* error) const {
   // All vertices must be unit length.
   for (int i = 0; i < num_vertices(); ++i) {
     if (!S2::IsUnitLength(vertex(i))) {
-      error->Init(S2Error::NOT_UNIT_LENGTH, "Vertex %d is not unit length", i);
+      *error = S2Error(S2Error::NOT_UNIT_LENGTH,
+                       absl::StrFormat("Vertex %d is not unit length", i));
       return true;
     }
   }
   // Adjacent vertices must not be identical or antipodal.
   for (int i = 1; i < num_vertices(); ++i) {
     if (vertex(i - 1) == vertex(i)) {
-      error->Init(S2Error::DUPLICATE_VERTICES,
-                  "Vertices %d and %d are identical", i - 1, i);
+      *error = S2Error(
+          S2Error::DUPLICATE_VERTICES,
+          absl::StrFormat("Vertices %d and %d are identical", i - 1, i));
       return true;
     }
     if (vertex(i - 1) == -vertex(i)) {
-      error->Init(S2Error::ANTIPODAL_VERTICES,
-                  "Vertices %d and %d are antipodal", i - 1, i);
+      *error = S2Error(
+          S2Error::ANTIPODAL_VERTICES,
+          absl::StrFormat("Vertices %d and %d are antipodal", i - 1, i));
       return true;
     }
   }

--- a/src/s2/s2polyline.h
+++ b/src/s2/s2polyline.h
@@ -18,9 +18,8 @@
 #ifndef S2_S2POLYLINE_H_
 #define S2_S2POLYLINE_H_
 
-#include <cstddef>
-
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -44,8 +43,6 @@
 #include "s2/s2shape.h"
 #include "s2/util/coding/coder.h"
 
-class Decoder;
-class Encoder;
 class S1Angle;
 class S2Cap;
 class S2Cell;
@@ -324,7 +321,7 @@ class S2Polyline final : public S2Region {
 
   // Decodes an S2Polyline encoded with any of Encode*() methods. Returns true
   // on success.
-  bool Decode(Decoder* const decoder);
+  bool Decode(Decoder* decoder);
 
   // Wrapper class for indexing a polyline (see S2ShapeIndex).  Once this
   // object is inserted into an S2ShapeIndex it is owned by that index, and
@@ -433,7 +430,7 @@ class S2Polyline final : public S2Region {
 
   // Decode a polyline encoded with EncodeUncompressed(). Used by the Decode
   // method above.
-  bool DecodeUncompressed(Decoder* const decoder);
+  bool DecodeUncompressed(Decoder* decoder);
 
   // Decodes a polyline encoded with EncodeCompressed(). Used by the Decode
   // method above.

--- a/src/s2/s2polyline_alignment.cc
+++ b/src/s2/s2polyline_alignment.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/s2point.h"
 #include "s2/s2polyline.h"
 #include "s2/s2polyline_alignment_internal.h"
@@ -348,7 +349,7 @@ VertexAlignment GetApproxVertexAlignment(const S2Polyline& a,
 // alignments. Specifically, because cost_fn(a, b) = cost_fn(b, a), and
 // cost_fn(a, a) = 0, we can compute only the lower triangle of cost matrix
 // and then mirror it across the diagonal to save on cost_fn invocations.
-int GetMedoidPolyline(const vector<unique_ptr<S2Polyline>>& polylines,
+int GetMedoidPolyline(absl::Span<const unique_ptr<S2Polyline>> polylines,
                       const MedoidOptions options) {
   const int num_polylines = polylines.size();
   const bool approx = options.approx();

--- a/src/s2/s2polyline_alignment.h
+++ b/src/s2/s2polyline_alignment.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/types/span.h"
 #include "s2/s2polyline.h"
 
 // This library provides code to compute vertex alignments between S2Polylines.
@@ -183,7 +184,7 @@ class MedoidOptions {
   bool approx_ = true;
 };
 
-int GetMedoidPolyline(const std::vector<std::unique_ptr<S2Polyline>>& polylines,
+int GetMedoidPolyline(absl::Span<const std::unique_ptr<S2Polyline>> polylines,
                       const MedoidOptions options);
 
 // GetConsensusPolyline allocates and returns a new "consensus" polyline from a

--- a/src/s2/s2polyline_alignment_test.cc
+++ b/src/s2/s2polyline_alignment_test.cc
@@ -15,9 +15,8 @@
 
 #include "s2/s2polyline_alignment.h"
 
-#include <cmath>
-
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/s2/s2polyline_simplifier.cc
+++ b/src/s2/s2polyline_simplifier.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2polyline_simplifier.h"
 
-#include <cmath>
-
 #include <cfloat>
+#include <cmath>
 #include <vector>
 
 #include "absl/log/absl_check.h"

--- a/src/s2/s2polyline_test.cc
+++ b/src/s2/s2polyline_test.cc
@@ -377,7 +377,7 @@ TEST(S2Polyline, SpaceUsedNonEmptyPolyline)  {
   EXPECT_GT(line->SpaceUsed(), 3 * sizeof(S2Point));
 }
 
-static string JoinInts(const vector<int>& ints) {
+static string JoinInts(absl::Span<const int> ints) {
   string result;
   int n = ints.size();
   for (int i = 0; i + 1 < n; ++i) {

--- a/src/s2/s2predicates_test.cc
+++ b/src/s2/s2predicates_test.cc
@@ -38,6 +38,7 @@
 #include "absl/random/random.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 #include "s2/base/commandlineflags.h"
 #include "s2/s1angle.h"
@@ -176,7 +177,7 @@ class SignTest : public testing::Test {
   // Given a set of points with no duplicates, first remove "origin" from
   // "points" (if it exists) and then sort the remaining points in CCW order
   // around "origin" putting the result in "sorted".
-  static void SortCCW(const vector<S2Point>& points, const S2Point& origin,
+  static void SortCCW(absl::Span<const S2Point> points, const S2Point& origin,
                       vector<S2Point>* sorted) {
     // Make a copy of the points with "origin" removed.
     sorted->clear();
@@ -192,7 +193,7 @@ class SignTest : public testing::Test {
   // index "start" of a point A, count the number of CCW triangles OAB over
   // all sorted points B not equal to A.  Also check that the results of the
   // CCW tests are consistent with the hypothesis that the points are sorted.
-  static int CountCCW(const vector<S2Point>& sorted, const S2Point& origin,
+  static int CountCCW(absl::Span<const S2Point> sorted, const S2Point& origin,
                       int start) {
     int num_ccw = 0;
     int last_sign = 1;
@@ -402,7 +403,7 @@ class StableSignTest : public testing::Test {
     absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
         "STABLE_SIGN_TEST_FAILURE_RATE",
         absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
-    constexpr int kIters = 1000;
+    constexpr int kIters = 10000;
     int failure_count = 0;
     double m = tan(S2Testing::KmToAngle(km).radians());
     for (int iter = 0; iter < kIters; ++iter) {

--- a/src/s2/s2projections.cc
+++ b/src/s2/s2projections.cc
@@ -33,11 +33,13 @@ R2Point Projection::WrapDestination(const R2Point& a, const R2Point& b) const {
   double x = b.x(), y = b.y();
   // The code below ensures that "b" is unmodified unless wrapping is required.
   if (wrap.x() > 0 && fabs(x - a.x()) > 0.5 * wrap.x()) {
-    x = a.x() + remainder(x - a.x(), wrap.x());
+    x -= std::round((x - a.x()) / wrap.x()) * wrap.x();
   }
+
   if (wrap.y() > 0 && fabs(y - a.y()) > 0.5 * wrap.y()) {
-    y = a.y() + remainder(y - a.y(), wrap.y());
+    y -= std::round((y - a.y()) / wrap.y()) * wrap.y();
   }
+
   return R2Point(x, y);
 }
 

--- a/src/s2/s2r2rect.h
+++ b/src/s2/s2r2rect.h
@@ -30,8 +30,6 @@
 #include "s2/s2point.h"
 #include "s2/s2region.h"
 
-class Decoder;
-class Encoder;
 class R1Interval;
 class S2Cap;
 class S2Cell;

--- a/src/s2/s2random.cc
+++ b/src/s2/s2random.cc
@@ -23,7 +23,7 @@
 #include "absl/random/distributions.h"
 #include "s2/s2cap.h"
 #include "s2/s2cell_id.h"
-#include "s2/s2edge_distances.h"
+#include "s2/s2edge_crossings.h"
 #include "s2/s2latlng_rect.h"
 #include "s2/s2point.h"
 #include "s2/util/math/matrix3x3.h"
@@ -66,8 +66,8 @@ Matrix3x3_d Frame(absl::BitGenRef bitgen) {
 
 void FrameAt(absl::BitGenRef bitgen, const S2Point& z,  //
              S2Point& x, S2Point& y) {
-  x = z.CrossProd(Point(bitgen)).Normalize();
-  y = z.CrossProd(x).Normalize();
+  x = S2::RobustCrossProd(z, Point(bitgen)).Normalize();
+  y = S2::RobustCrossProd(z, x).Normalize();
 }
 
 Matrix3x3_d FrameAt(absl::BitGenRef bitgen, const S2Point& z) {

--- a/src/s2/s2region.h
+++ b/src/s2/s2region.h
@@ -24,8 +24,6 @@
 #include "s2/s1angle.h"
 #include "s2/s2point.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2Cell;
 class S2CellId;
@@ -114,7 +112,7 @@ class S2Region {
   // REQUIRES: "encoder" uses the default constructor, so that its buffer
   //           can be enlarged as necessary by calling Ensure(int).
   //
-  // void Encode(Encoder* const encoder) const;
+  // void Encode(Encoder* encoder) const;
 
   // Decodes an S2Region encoded with Encode().  Note that this method
   // requires that an S2Region object of the appropriate concrete type has
@@ -128,7 +126,7 @@ class S2Region {
   //
   // Returns true on success.
   //
-  // bool Decode(Decoder* const decoder);
+  // bool Decode(Decoder* decoder);
 
  protected:
   S2Region() = default;

--- a/src/s2/s2region_coverer_test.cc
+++ b/src/s2/s2region_coverer_test.cc
@@ -17,9 +17,8 @@
 
 #include "s2/s2region_coverer.h"
 
-#include <climits>
-
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -38,10 +37,10 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
+#include "absl/types/span.h"
 
 #include "s2/base/commandlineflags.h"
 #include "s2/base/log_severity.h"
-#include "s2/base/types.h"
 #include "s2/s1angle.h"
 #include "s2/s1chord_angle.h"
 #include "s2/s2cap.h"
@@ -353,7 +352,7 @@ TEST(GetFastCovering, HugeFixedLevelCovering) {
   EXPECT_GE(covering.size(), 1 << 16);
 }
 
-bool IsCanonical(const vector<string>& input_str,
+bool IsCanonical(absl::Span<const string> input_str,
                  const S2RegionCoverer::Options& options) {
   vector<S2CellId> input;
   for (const auto& str : input_str) {
@@ -430,8 +429,8 @@ TEST(IsCanonical, Normalized) {
        "1/1130", "1/1131", "1/1132", "1/1133"}, options));
 }
 
-void TestCanonicalizeCovering(const vector<string>& input_str,
-                              const vector<string>& expected_str,
+void TestCanonicalizeCovering(absl::Span<const string> input_str,
+                              absl::Span<const string> expected_str,
                               const S2RegionCoverer::Options& options,
                               const bool test_cell_union = true) {
   vector<S2CellId> actual, expected;

--- a/src/s2/s2region_intersection.h
+++ b/src/s2/s2region_intersection.h
@@ -26,8 +26,6 @@
 #include "s2/s2point.h"
 #include "s2/s2region.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2Cell;
 class S2LatLngRect;

--- a/src/s2/s2region_sharder.cc
+++ b/src/s2/s2region_sharder.cc
@@ -16,7 +16,6 @@
 #include "s2/s2region_sharder.h"
 
 #include <cstdint>
-
 #include <utility>
 #include <vector>
 

--- a/src/s2/s2region_sharder_test.cc
+++ b/src/s2/s2region_sharder_test.cc
@@ -19,6 +19,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/types/span.h"
 #include "s2/s2cell_id.h"
 #include "s2/s2cell_index.h"
 #include "s2/s2cell_union.h"
@@ -29,7 +30,7 @@ using std::vector;
 
 class S2RegionSharderTest : public ::testing::Test {
  public:
-  S2CellIndex IndexFromCoverings(const vector<S2CellUnion>& coverings) {
+  S2CellIndex IndexFromCoverings(absl::Span<const S2CellUnion> coverings) {
     S2CellIndex index;
     for (int i = 0; i < coverings.size(); ++i) {
       index.Add(coverings[i], i);

--- a/src/s2/s2region_test.cc
+++ b/src/s2/s2region_test.cc
@@ -17,7 +17,6 @@
 #include "s2/s2region.h"
 
 #include <cstddef>
-
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/s2/s2region_union.h
+++ b/src/s2/s2region_union.h
@@ -27,8 +27,6 @@
 #include "s2/s2point.h"
 #include "s2/s2region.h"
 
-class Decoder;
-class Encoder;
 class S2Cap;
 class S2Cell;
 class S2LatLngRect;
@@ -55,7 +53,6 @@ class S2RegionUnion final : public S2Region {
   // Create a region representing the union of the given regions.
   explicit S2RegionUnion(std::vector<std::unique_ptr<S2Region>> regions);
 
-  // Use {} instead of = default to work around gcc bug.
   ~S2RegionUnion() override = default;
 
   // Initialize region by taking ownership of the given regions.

--- a/src/s2/s2shape.h
+++ b/src/s2/s2shape.h
@@ -109,7 +109,8 @@ class S2Shape {
   struct Chain {
     int32_t start, length;
     Chain() = default;
-    Chain(int32_t _start, int32_t _length) : start(_start), length(_length) {}
+    constexpr Chain(int32_t _start, int32_t _length)
+        : start(_start), length(_length) {}
 
     friend bool operator==(const Chain& x, const Chain& y) {
       return x.start == y.start && x.length == y.length;

--- a/src/s2/s2shape_index.h
+++ b/src/s2/s2shape_index.h
@@ -102,7 +102,7 @@ class S2ClippedShape {
   friend class S2Stats;
 
   // Internal methods are documented with their definition.
-  void Init(int32_t shape_id, int32_t num_edges);
+  void Init(int32_t shape_id, uint32_t num_edges);
   void Destruct();
   bool is_inline() const;
   void set_contains_center(bool contains_center);
@@ -549,7 +549,7 @@ inline int S2ClippedShape::edge(int i) const {
 }
 
 // Initialize an S2ClippedShape to hold the given number of edges.
-inline void S2ClippedShape::Init(int32_t shape_id, int32_t num_edges) {
+inline void S2ClippedShape::Init(int32_t shape_id, uint32_t num_edges) {
   shape_id_ = shape_id;
   num_edges_ = num_edges;
   contains_center_ = false;

--- a/src/s2/s2shape_index_measures_test.cc
+++ b/src/s2/s2shape_index_measures_test.cc
@@ -22,7 +22,6 @@
 #include "s2/s2shape_index_measures.h"
 
 #include <cmath>
-
 #include <memory>
 #include <string>
 

--- a/src/s2/s2shape_measures_test.cc
+++ b/src/s2/s2shape_measures_test.cc
@@ -22,7 +22,6 @@
 #include "s2/s2shape_measures.h"
 
 #include <cmath>
-
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/s2/s2shape_nesting_query.h
+++ b/src/s2/s2shape_nesting_query.h
@@ -17,7 +17,6 @@
 #ifndef S2_S2SHAPE_NESTING_QUERY_H_
 #define S2_S2SHAPE_NESTING_QUERY_H_
 
-#include <climits>
 #include <cstdint>
 #include <vector>
 
@@ -105,11 +104,6 @@ class S2ShapeNestingQuery {
         relation.AddHole(chain);
       }
       return relation;
-    }
-
-    // Builds a `ChainRelation` that's a hole with given parent.
-    static ChainRelation MakeHole(int32_t parent) {
-      return ChainRelation(parent);
     }
 
     explicit ChainRelation(int32_t parent = -1) : parent_(parent) {}

--- a/src/s2/s2shapeutil_build_polygon_boundaries.cc
+++ b/src/s2/s2shapeutil_build_polygon_boundaries.cc
@@ -23,6 +23,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2contains_point_query.h"
 #include "s2/s2pointutil.h"
@@ -34,7 +35,7 @@ using std::vector;
 
 namespace s2shapeutil {
 
-void BuildPolygonBoundaries(const vector<vector<S2Shape*>>& components,
+void BuildPolygonBoundaries(absl::Span<const vector<S2Shape*>> components,
                             vector<vector<S2Shape*>>* polygons) {
   polygons->clear();
   if (components.empty()) return;

--- a/src/s2/s2shapeutil_build_polygon_boundaries.h
+++ b/src/s2/s2shapeutil_build_polygon_boundaries.h
@@ -20,6 +20,7 @@
 
 #include <vector>
 
+#include "absl/types/span.h"
 #include "s2/s2shape.h"
 #include "s2/s2shape_index.h"
 
@@ -58,9 +59,8 @@ namespace s2shapeutil {
 // the collection of loops that form its boundary.  This function does not
 // actually construct any S2Shapes; it simply identifies the loops that belong
 // to each polygon.
-void BuildPolygonBoundaries(
-    const std::vector<std::vector<S2Shape*>>& components,
-    std::vector<std::vector<S2Shape*>>* polygons);
+void BuildPolygonBoundaries(absl::Span<const std::vector<S2Shape*>> components,
+                            std::vector<std::vector<S2Shape*>>* polygons);
 
 }  // namespace s2shapeutil
 

--- a/src/s2/s2shapeutil_coding.cc
+++ b/src/s2/s2shapeutil_coding.cc
@@ -160,7 +160,7 @@ TaggedShapeFactory::TaggedShapeFactory(const ShapeDecoder& shape_decoder,
     : shape_decoder_(shape_decoder) {
   if (!encoded_shapes_.Init(decoder)) {
     encoded_shapes_.Clear();
-    error.Init(S2Error::DATA_LOSS, "Corrupted encoded shapes.");
+    error = S2Error::DataLoss("Corrupted encoded shapes.");
   }
 }
 

--- a/src/s2/s2shapeutil_contains_brute_force_test.cc
+++ b/src/s2/s2shapeutil_contains_brute_force_test.cc
@@ -36,13 +36,15 @@ namespace s2shapeutil {
 
 TEST(ContainsBruteForce, NoInterior) {
   // Defines a polyline that almost entirely encloses the point 0:0.
-  auto polyline = MakeLaxPolylineOrDie("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
+  // Note, however, that -1e-9 was originally -1e9, and this seems to pass
+  // with almost any value, so it's not clear what's being tested here.
+  auto polyline = MakeLaxPolylineOrDie("0:0, 0:1, 1:-1, -1:-1, -1e-9:1");
   EXPECT_FALSE(ContainsBruteForce(*polyline, MakePointOrDie("0:0")));
 }
 
 TEST(ContainsBruteForce, ContainsReferencePoint) {
   // Checks that ContainsBruteForce agrees with GetReferencePoint.
-  auto polygon = MakeLaxPolygonOrDie("0:0, 0:1, 1:-1, -1:-1, -1e9:1");
+  auto polygon = MakeLaxPolygonOrDie("0:0, 0:1, 1:-1, -1:-1, -1e-9:1");
   auto ref = polygon->GetReferencePoint();
   EXPECT_EQ(ref.contained, ContainsBruteForce(*polygon, ref.point));
 }

--- a/src/s2/s2shapeutil_conversion.cc
+++ b/src/s2/s2shapeutil_conversion.cc
@@ -65,8 +65,11 @@ unique_ptr<S2Polygon> ShapeToS2Polygon(const S2Shape& poly) {
     loops.push_back(make_unique<S2Loop>(vertices));
   }
   auto output_poly = make_unique<S2Polygon>();
-  output_poly->InitOriented(std::move(loops));
-
+  if (loops.size() == 1) {
+    output_poly->Init(std::move(loops[0]));
+  } else {
+    output_poly->InitOriented(std::move(loops));
+  }
   return output_poly;
 }
 

--- a/src/s2/s2shapeutil_conversion_test.cc
+++ b/src/s2/s2shapeutil_conversion_test.cc
@@ -78,7 +78,7 @@ TEST(S2ShapeConversionUtilTest, ClosedLineToS2Polyline) {
 
 // Creates a (lax) polygon shape from the provided loops, and ensures that the
 // S2Polygon produced by ShapeToS2Polygon represents the same polygon.
-void VerifyShapeToS2Polygon(const vector<S2LaxPolygonShape::Loop>& loops,
+void VerifyShapeToS2Polygon(absl::Span<const S2LaxPolygonShape::Loop> loops,
                             int expected_num_loops, int expected_num_vertices) {
   S2LaxPolygonShape lax_polygon(loops);
   unique_ptr<S2Polygon> polygon = ShapeToS2Polygon(lax_polygon);

--- a/src/s2/s2shapeutil_edge_iterator_test.cc
+++ b/src/s2/s2shapeutil_edge_iterator_test.cc
@@ -23,6 +23,7 @@
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s2shape.h"
 #include "s2/s2shape_index.h"
+#include "s2/s2shapeutil_shape_edge_id.h"
 #include "s2/s2text_format.h"
 
 namespace s2shapeutil {
@@ -49,9 +50,20 @@ void Verify(const S2ShapeIndex* index) {
   vector<S2Shape::Edge> expected = GetEdges(index);
 
   int i = 0;
-  for (EdgeIterator it(index); !it.Done(); it.Next(), ++i) {
+  int shape_id = -1;
+  int edge_id = -1;
+  for (EdgeIterator it(index); !it.Done(); it.Next(), ++edge_id, ++i) {
+    // The iterator visits the edges of each shape in order.  When we see a new
+    // shape id, reset the edge_id count.
+    if (it.shape_id() != shape_id) {
+      shape_id = it.shape_id();
+      edge_id = 0;
+    }
+
     ASSERT_TRUE(i < expected.size());
     EXPECT_EQ(expected[i], it.edge());
+    EXPECT_EQ(it.edge_id(), edge_id);
+    EXPECT_EQ(it.shape_edge_id(), ShapeEdgeId(shape_id, edge_id));
   }
 }
 

--- a/src/s2/s2shapeutil_shape_edge_id.h
+++ b/src/s2/s2shapeutil_shape_edge_id.h
@@ -19,7 +19,6 @@
 #define S2_S2SHAPEUTIL_SHAPE_EDGE_ID_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <iostream>
 #include <ostream>

--- a/src/s2/s2text_format_test.cc
+++ b/src/s2/s2text_format_test.cc
@@ -16,7 +16,6 @@
 #include "s2/s2text_format.h"
 
 #include <cmath>
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -146,10 +145,10 @@ TEST(ToString, MinimalDigitsDoubleConstants) {
   // number of digits.
   for (int iter = 0; iter < kIters; ++iter) {
     int max_digits = absl::Uniform(bitgen, 0, 11);
-    int64_t scale = MathUtil::FastInt64Round(pow(10, max_digits));
-    int64_t lat = MathUtil::FastInt64Round(
+    int64_t scale = pow(int64_t{10}, int64_t{max_digits});
+    int64_t lat = MathUtil::Round<int64_t>(
         absl::Uniform(bitgen, -90.0 * scale, 90.0 * scale));
-    int64_t lng = MathUtil::FastInt64Round(
+    int64_t lng = MathUtil::Round<int64_t>(
         absl::Uniform(bitgen, -180.0 * scale, 180.0 * scale));
     S2LatLng ll = S2LatLng::FromDegrees(lat / static_cast<double>(scale),
                                         lng / static_cast<double>(scale));

--- a/src/s2/s2validation_query.h
+++ b/src/s2/s2validation_query.h
@@ -1,0 +1,1327 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#ifndef S2_S2VALIDATION_QUERY_H_
+#define S2_S2VALIDATION_QUERY_H_
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
+#include "absl/log/absl_check.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "s2/internal/s2disjoint_set.h"
+#include "s2/internal/s2incident_edge_tracker.h"
+#include "s2/internal/s2index_cell_data.h"
+#include "s2/s2cell_id.h"
+#include "s2/s2contains_point_query.h"
+#include "s2/s2contains_vertex_query.h"
+#include "s2/s2edge_crosser.h"
+#include "s2/s2error.h"
+#include "s2/s2point.h"
+#include "s2/s2pointutil.h"
+#include "s2/s2predicates.h"
+#include "s2/s2shape.h"
+#include "s2/s2shape_index.h"
+#include "s2/s2shapeutil_edge_wrap.h"
+
+// This header defines the following queries which each have slightly different
+// correctness semantics for their particular domain.
+
+// clang-format off
+template <typename IndexType> class S2ValidQuery;
+template <typename IndexType> class S2LegacyValidQuery;
+// clang-format on
+
+// Base class for validating geometry contained in an index according to a
+// configurable model of correctness.  There are several different notions of
+// "valid" geometry that we have to address, including the basic requirements
+// for S2BooleanOperation, S2Polygon specific checks, OGC simple geometry
+// standards, and STLib's requirements.
+//
+// Classes of geometry can be thought of as sets of all shapes that have certain
+// invariants (such as interior-on-left or no-degenerate-edges).  Classes then
+// naturally build on other classes by adding more rules to further restrict the
+// allowed shapes.
+//
+// This extends-upon structure naturally lends itself to an inheritance based
+// implementation.  Beginning with the most permissive class of geometry which
+// just meets the criteria for S2BooleanOperation (S2ValidQuery), we can then
+// build subsequent classes of geometry by inheriting from and extending the
+// checks that are performed.
+//
+// Validation queries should be templated over the exact index type and can
+// overload the virtual methods in the subclass API below.
+//
+// The Validate() driver function will call these functions in this order:
+//
+//   - Start()
+//     - CheckShape()
+//     - StartCell()
+//       - StartShape()
+//         - CheckEdge()
+//       - FinishShape()
+//   - Finish()
+//
+// Hoisting the loops into the base class like this allows us to fuse all the
+// inner loops of the various queries so that we only have to iterate over
+// the index and its geometry once.
+//
+// Several protected member functions are defined to give subclasses access to
+// the data being validated:
+//
+//   const IndexType& Index();
+//     -- Returns a reference to the current index being operated on.
+//
+//   const S2IndexCellData& CurrentCell();
+//     -- Returns a reference to the decoded data for the current cell.
+//
+//   const IncidentEdgeSet& IncidentEdges();
+//     -- Returns a reference to the current incident edge set.  We promise that
+//     this set is updated with the current cell's edges before StartCell() is
+//     called.
+//
+// A query then has a `bool Validate(const IndexType& index, S2Error* error)`
+// method which validates the index and returns true if it's valid, otherwise
+// false, with the validation failure details provided through the error
+// parameter.
+//
+// This example validates an index as containing valid geometry for
+// use with S2Polygon/S2Polyline:
+//
+//   S2LegacyValidQuery<MutableS2ShapeIndex> query;
+//   if (!query.Validate(index, error)) {
+//     ...
+//   }
+//
+template <typename IndexType>
+class S2ValidationQueryBase {
+ public:
+  using IncidentEdgeSet = internal::IncidentEdgeSet;
+  using EdgeAndIdChain = typename internal::S2IndexCellData::EdgeAndIdChain;
+  using S2IndexCellData = internal::S2IndexCellData;
+
+  S2ValidationQueryBase() = default;
+  virtual ~S2ValidationQueryBase() = default;
+
+  // Validate the index by calling the hooks in the derived class.
+  bool Validate(const IndexType& index, S2Error* error);
+
+ protected:
+  using Iterator = typename IndexType::Iterator;
+
+  // Subclass API
+  // Starts the validation process; called once per query.
+  virtual bool Start(S2Error*) { return true; }
+
+  // Validates each individual shape in the index; called once per shape.
+  //
+  // A reference to the current iterator state is passed in.  The function may
+  // reposition the iterator in order to do shape checking.
+  virtual bool CheckShape(Iterator& iter, const S2Shape& shape, int shape_id,
+                          S2Error*) {
+    return true;
+  }
+
+  // Starts processing of a cell in the index; called once per cell.
+  virtual bool StartCell(S2Error*) { return true; }
+
+  // Marks start of a clipped shape; called once per clipped shape in a cell.
+  virtual bool StartShape(const S2Shape&, const S2ClippedShape&, S2Error*) {
+    return true;
+  }
+
+  // Validates a single edge of a given shape; called at least once per edge of
+  // each shape.
+  virtual bool CheckEdge(const S2Shape&, const S2ClippedShape&,
+                         const EdgeAndIdChain&, S2Error*) {
+    return true;
+  }
+
+  // Marks end of a clipped shape; called once per clipped shape in a cell.
+  virtual bool FinishShape(const S2Shape&, const S2ClippedShape&, S2Error*) {
+    return true;
+  }
+
+  // Marks end of validation; called once per query.
+  virtual bool Finish(S2Error* error) { return true; }
+
+  // Returns a reference to the index we're validating.
+  const IndexType& Index() const {
+    ABSL_DCHECK(index_ != nullptr);
+    return *index_;
+  }
+
+  // Returns current incident edge map.
+  const IncidentEdgeSet& IncidentEdges() const {
+    return incident_edge_tracker_.IncidentEdges();
+  }
+
+  // Returns a reference to the data for the current cell.
+  const S2IndexCellData& CurrentCell() const { return cell_buffer_; }
+
+ private:
+  // Disallow copying and assignment through an abstract reference.
+  S2ValidationQueryBase(const S2ValidationQueryBase&) = delete;
+  S2ValidationQueryBase& operator=(const S2ValidationQueryBase&) = delete;
+
+  // Sets the current index we're operating on, accessible through Index();
+  void SetIndex(const IndexType* index) { index_ = index; }
+
+  // Sets the current cell that we're operating on and loads its data.
+  void SetCurrentCell(const Iterator& iter) {
+    cell_buffer_.LoadCell(index_, iter.id(), &iter.cell());
+  }
+
+  S2IndexCellData cell_buffer_;
+  internal::S2IncidentEdgeTracker incident_edge_tracker_;
+  const IndexType* index_ = nullptr;
+};
+
+// This class represents the least strict class of geometry and corresponds to
+// the requirements for compatibility with S2BooleanOperation, with these
+// specific constraints:
+//
+// == General ==
+//   * Points must be unit magnitude (according to S2::IsUnitLength()).
+//   * Points must be finite (neither inf or nan).
+//   * Edges must not have antipodal vertices.
+//   * Degenerate edges of the form {A,A} are allowed by default.
+//   * Reverse-duplicate edges of the form {A,B},{B,A} are allowed by default.
+//   * Shape chains must have at least one edge, excluding the full and empty
+//     polygon shapes, which may have at most one empty chain.
+//
+// == Polygons ==
+//   * Polygon interiors must be disjoint from all other geometry.
+//     * Polygon edges thus cannot cross any other edges, including at vertices.
+//     * No geometry may test as contained in another polygon.
+//   * Polygons can never have duplicate edges even among different polygons.
+//   * Polygon edges must be connected and form a closed loop per chain.
+//   * Polygon chains must oriented so that the interior is always on the left.
+//
+// == Polylines ==
+//   * Polyline edges can cross by default.
+//   * Polylines can have duplicate edges by default.
+//
+template <typename IndexType>
+class S2ValidQuery : public S2ValidationQueryBase<IndexType> {
+ protected:
+  // Protected because options are only for subclasses to configure behavior.
+  class Options {
+   public:
+    // Types of single-vertex touches allowed between shapes.  This is
+    // configurable for each combination of dimension.  E.g. we can configure
+    // polyline-polyline (1D-1D) and polyline-polygon (1D-2D) touches
+    // separately.
+    enum TouchType {
+      kTouchNone = 0b00,      // Allow no touches between shapes.
+      kTouchInterior = 0b01,  // Interior point may touch the other shape.
+      kTouchBoundary = 0b10,  // Boundary point may touch the other shape.
+      kTouchAny = 0b11        // Allow any touches between shapes.
+    };
+
+    Options() {
+      // Default is to allow any touches between geometry.
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          set_allowed_touches(i, j, std::make_pair(kTouchAny, kTouchAny));
+        }
+      }
+    }
+
+    // Returns a TouchType with fields set indicating what types of vertex from
+    // dimension A are allowed to touch vertices from dimension B.
+    std::pair<TouchType, TouchType> allowed_touches(int dima, int dimb) const {
+      ABSL_DCHECK_GE(dima, 0);
+      ABSL_DCHECK_LE(dima, 2);
+      ABSL_DCHECK_GE(dimb, 0);
+      ABSL_DCHECK_LE(dimb, 2);
+
+      // Just get the top half of the matrix.
+      if (dima > dimb) {
+        std::swap(dima, dimb);
+      }
+
+      return allowed_touches_[dima][dimb];
+    }
+
+    // Set the allowed touches based on geometry dimension.  We require that the
+    // matrix of combinations be symmetric, so set_allowed_touches(1, 2, X, Y)
+    // and set_allowed_touches(2, 1, Y, X) are equivalent.
+    Options& set_allowed_touches(  //
+        int dima, int dimb, std::pair<TouchType, TouchType> types) {
+      ABSL_DCHECK(0 <= dima && dima <= 2);
+      ABSL_DCHECK(0 <= dimb && dimb <= 2);
+
+      // Just set the top half of the matrix.
+      if (dima > dimb) {
+        std::swap(dima, dimb);
+      }
+
+      allowed_touches_[dima][dimb] = types;
+      return *this;
+    }
+
+    // Configures whether polylines can have duplicate edges.
+    bool allow_duplicate_polyline_edges() const {
+      return allow_duplicate_polyline_edges_;
+    }
+
+    Options& set_allow_duplicate_polyline_edges(bool flag) {
+      allow_duplicate_polyline_edges_ = flag;
+      return *this;
+    }
+
+    // Configures whether polyline edges can cross.
+    bool allow_polyline_interior_crossings() const {
+      return allow_polyline_interior_crossings_;
+    }
+
+    Options& set_allow_polyline_interior_crossings(bool flag) {
+      allow_polyline_interior_crossings_ = flag;
+      return *this;
+    }
+
+    // Configures whether reverse duplicate edges are allowed.
+    bool allow_reverse_duplicates() const { return allow_reverse_duplicates_; }
+
+    Options& set_allow_reverse_duplicates(bool flag) {
+      allow_reverse_duplicates_ = flag;
+      return *this;
+    }
+
+    // Configures whether degenerate (zero-length) edges are allowed.
+    bool allow_degenerate_edges() const { return allow_degenerate_edges_; }
+
+    Options& set_allow_degenerate_edges(bool flag) {
+      allow_degenerate_edges_ = flag;
+      return *this;
+    }
+
+   private:
+    bool allow_degenerate_edges_ = true;
+    bool allow_duplicate_polyline_edges_ = true;
+    bool allow_reverse_duplicates_ = true;
+    bool allow_polyline_interior_crossings_ = true;
+
+    std::pair<TouchType, TouchType> allowed_touches_[3][3];
+  };
+
+  const Options& options() const { return options_; }
+  Options& mutable_options() { return options_; }
+
+  // We have to include unqualified names manually due to template inheritance.
+  using Base = S2ValidationQueryBase<IndexType>;
+  using Base::CurrentCell;
+  using Base::IncidentEdges;
+  using Base::Index;
+  using typename Base::EdgeAndIdChain;
+  using typename Base::Iterator;
+  using typename Base::S2IndexCellData;
+
+  bool CheckShape(Iterator& iter, const S2Shape& shape, int shape_id,
+                  S2Error*) override;
+  bool StartCell(S2Error*) override;
+  bool CheckEdge(const S2Shape& shape, const S2ClippedShape& clipped,
+                 const EdgeAndIdChain& edge, S2Error*) override;
+  bool Finish(S2Error* error) override;
+
+ private:
+  // Returns true if the given S2Point is valid, meaning none of its components
+  // are inf or NaN.
+  static inline bool ValidPoint(const S2Point& p) {
+    return std::isfinite(p.x()) && std::isfinite(p.y()) && std::isfinite(p.z());
+  }
+
+  // Checks that a point is fully outside any polygons.
+  //
+  // Returns false if a point is not interior to any polygons, true otherwise
+  // with error populated.
+  bool PointContained(S2CellId, int shape_id, const S2Point&, S2Error*);
+
+  // Checks if any edge in the current cell is a duplicate (or reverse
+  // duplicate).
+  bool CheckForDuplicateEdges(S2Error* error) const;
+
+  // Checks if any edges in the current cell have an interior crossing.
+  bool CheckForInteriorCrossings(S2Error* error) const;
+
+  // Checks that a given chain of a polygon is oriented properly relative to one
+  // cell center in the index.  We only need to check one center because we
+  // assume that the transition between cell indices is consistent, thus we just
+  // need to make sure that the interior state isn't flipped.
+  //
+  // Returns false when the chain isn't properly oriented with S2Error set with
+  // the details, true otherwise.
+  //
+  // REQUIRES: Shape must be two dimensional.
+  // REQUIRES: Chain must be closed.
+  // REQUIRES: Chain edges must be connected (no gaps).
+  // REQUIRES: Chain must have at least three distinct points (cover some area).
+  bool CheckChainOrientation(  //
+      Iterator&, const S2Shape&, int shape_id, int chain_id, S2Error*);
+
+  // Information on one vertex of an edge, including whether it's on the
+  // boundary of its shape.  This is used by CheckTouchesAreValid() when we need
+  // to check that vertex touches are valid.
+  struct TestVertex {
+    S2Point vertex;
+    int32_t edge_id;
+    int32_t shape_id;
+    int32_t dim;
+    bool on_boundary;
+  };
+  std::vector<TestVertex> test_vertices_;
+
+  // Checks the shapes in the current cell to ensure that any touch points are
+  // allowed under the configured semantics.
+  //
+  // Returns false if any vertices touch at an invalid point with the error
+  // value set, true otherwise.
+  bool CheckTouchesAreValid(S2Error*);
+
+  Options options_;
+};
+
+//////////////////   Utility Implementation   ////////////////////
+
+// Sorts a container of S2Shape::Edges in counter-clockwise order around an
+// origin point.  By itself, ordering this way is ambiguous in terms of the
+// starting point, so we take an edge to form a reference point to form a total
+// ordering.
+//
+// Reverse duplicate edges are ordered so that the one with origin as v0 comes
+// before the other.
+//
+// The edges and first edge must all contain origin as one of their vertices.
+//
+// Can sort any container with elements that are convertible to an S2Shape::Edge
+// reference.  Both the origin point and first edge are taken by value so that
+// it's safe to call using elements of the container for those values.
+//
+// Takes a Container to the start and end of the container.  std::sort requires
+// random iterators and thus so do we.
+template <typename Container>
+void SortEdgesCcw(S2Point origin, S2Shape::Edge first, Container& data) {
+  ABSL_DCHECK(first.v0 == origin || first.v1 == origin);
+  const S2Point& first_vertex = (first.v0 == origin) ? first.v1 : first.v0;
+  ABSL_DCHECK(first_vertex != origin);
+
+  absl::c_sort(  //
+      data,      //
+      [&](const S2Shape::Edge& a, const S2Shape::Edge& b) {
+        ABSL_DCHECK(a.v0 == origin || a.v1 == origin);
+        ABSL_DCHECK(b.v0 == origin || b.v1 == origin);
+
+        // `OrderedCCW` will return `true` if `a == b`, which will violate the
+        // irreflexivity requirement of a strict weak ordering.
+        if (a == b) {
+          return false;
+        }
+
+        // Order reverse duplicates so that the one with edge.v0 ==
+        // origin is first.
+        if (a == b.Reversed()) {
+          return a.v0 == origin;
+        }
+
+        if (a == first || b == first) {
+          // If either edge is the first edge, compare so that the
+          // first edge always comes first in the sorted output.
+          return a == first;
+        }
+
+        // Otherwise check orientation of vertices.
+        S2Point apnt = (a.v0 == origin) ? a.v1 : a.v0;
+        S2Point bpnt = (b.v0 == origin) ? b.v1 : b.v0;
+        return s2pred::OrderedCCW(first_vertex, apnt, bpnt, origin);
+      });
+}
+
+template <typename IndexType>
+bool S2ValidationQueryBase<IndexType>::Validate(const IndexType& index,
+                                                S2Error* error) {
+  SetIndex(&index);
+  incident_edge_tracker_.Reset();
+  cell_buffer_.Reset();
+
+  if (!Start(error)) {
+    return false;
+  }
+
+  // Run basic checks on individual shapes in the index.
+  Iterator iter(&index, S2ShapeIndex::BEGIN);
+  for (int shape_id = 0; shape_id < index.num_shape_ids(); ++shape_id) {
+    const S2Shape* shape = index.shape(shape_id);
+    if (shape != nullptr) {
+      if (!CheckShape(iter, *shape, shape_id, error)) {
+        return false;
+      }
+    }
+  }
+
+  for (iter.Begin(); !iter.done(); iter.Next()) {
+    SetCurrentCell(iter);
+
+    // Add two dimensional shape edges to the incident edge tracker to support
+    // checks for things like crossing polygon chains and split interiors.
+    for (const S2ClippedShape& clipped : CurrentCell().clipped_shapes()) {
+      const int shape_id = clipped.shape_id();
+      const S2Shape& shape = CurrentCell().shape(clipped);
+      if (shape.dimension() < 2) {
+        continue;
+      }
+
+      incident_edge_tracker_.StartShape(shape_id);
+      for (const auto& edge : CurrentCell().shape_edges(shape_id)) {
+        incident_edge_tracker_.AddEdge(edge.id, edge);
+      }
+      incident_edge_tracker_.FinishShape();
+    }
+
+    // Now notify that we're starting this cell.
+    if (!StartCell(error)) {
+      return false;
+    }
+
+    // Iterate the shapes and edges of the cell.
+    for (const S2ClippedShape& clipped : CurrentCell().clipped_shapes()) {
+      const int shape_id = clipped.shape_id();
+      const S2Shape& shape = CurrentCell().shape(clipped);
+      if (!StartShape(shape, clipped, error)) {
+        return false;
+      }
+
+      for (const auto& edge : CurrentCell().shape_edges(shape_id)) {
+        if (!CheckEdge(shape, clipped, edge, error)) {
+          return false;
+        }
+      }
+
+      if (!FinishShape(shape, clipped, error)) {
+        return false;
+      }
+    }
+  }
+
+  // Run any final checks and finish validation
+  return Finish(error);
+}
+
+// This class represents a semantic class of geometry that's compatible with the
+// requirements of the S2Polygon and S2Polyline IsValid() methods.  It extends
+// the S2ValidQuery requirements, specifically:
+//
+// == General ==
+//   * Degenerate edges of the form {A,A} are not allowed.
+//   * All the shapes in an S2ShapeIndex must be the same dimensionality.
+//   * Duplicate vertices in a chain are not allowed.
+//     I.e. a chain cannot touch itself even at one point.
+//   * Different chains may touch, but only in such a way they don't create
+//     duplicate edges.
+//
+template <typename IndexType>
+class S2LegacyValidQuery final : public S2ValidQuery<IndexType> {
+ public:
+  S2LegacyValidQuery();
+
+ protected:
+  // We have to include unqualified names manually due to template inheritance.
+  using Base = S2ValidQuery<IndexType>;
+  using Base::CurrentCell;
+  using Base::IncidentEdges;
+  using Base::Index;
+  using typename Base::EdgeAndIdChain;
+  using typename Base::Iterator;
+  using typename Base::S2IndexCellData;
+
+  bool Start(S2Error*) final;
+  bool CheckShape(Iterator&, const S2Shape& shape, int shape_id,
+                  S2Error*) final;
+  bool StartCell(S2Error*) final;
+  bool CheckEdge(const S2Shape& shape, const S2ClippedShape& clipped,
+                 const EdgeAndIdChain& edge, S2Error*) override;
+
+ private:
+  // Tuple of (shape, chain, vertex) for detecting duplicate vertices in the
+  // same chain.
+  struct ShapeChainVertex {
+    // Constructor just to twiddle order of fields.
+    ShapeChainVertex(int shape, int chain, S2Point vertex)
+        : vertex(vertex), chain(chain), shape(shape) {}
+
+    S2Point vertex;
+    int chain;
+    int shape;
+
+    // Makes type hashable for use in Abseil containers.
+    template <typename H>
+    friend H AbslHashValue(H h, const ShapeChainVertex& a) {
+      return H::combine(std::move(h), a.vertex, a.shape, a.chain);
+    }
+  };
+};
+
+//////////////////   S2ValidQuery Implementation   ////////////////////
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckShape(Iterator& iter, const S2Shape& shape,
+                                         int shape_id, S2Error* error) {
+  // Verify that shape isn't outright lying to us about its dimension.
+  const int dim = shape.dimension();
+  if (dim < 0 || dim > 2) {
+    *error = S2Error(
+        S2Error::INVALID_DIMENSION,
+        absl::StrFormat("Shape %d has invalid dimension: %d", shape_id, dim));
+    return false;
+  }
+
+  absl::InlinedVector<int, 4> chains_to_check;
+  for (int chain_id = 0; chain_id < shape.num_chains(); ++chain_id) {
+    const S2Shape::Chain& chain = shape.chain(chain_id);
+
+    // Check that the first and last edges in a polygon chain connect to close
+    // the chain.  This is true even for degenerate chains with one edge that's
+    // a point, or two edges that are reverse duplicates.  Both are considered
+    // closed.
+    if (dim == 2 && chain.length > 0) {
+      int edge_id = chain.start;
+      int prev_id = s2shapeutil::PrevEdgeWrap(shape, edge_id);
+
+      if (shape.edge(prev_id).v1 != shape.edge(edge_id).v0) {
+        *error = S2Error(S2Error::LOOP_NOT_ENOUGH_VERTICES,
+                         absl::StrFormat("Chain %d of shape %d isn't closed",
+                                         chain_id, shape_id));
+        return false;
+      }
+    }
+
+    for (int offset = 0; offset < chain.length; ++offset) {
+      const S2Shape::Edge& edge = shape.chain_edge(chain_id, offset);
+
+      // Check that coordinates aren't inf/nan.
+      if (!ValidPoint(edge.v0) || !ValidPoint(edge.v1)) {
+        *error = S2Error(
+            S2Error::INVALID_VERTEX,
+            absl::StrFormat("Shape %d has invalid coordinates", shape_id));
+        return false;
+      }
+
+      // Check that vertices are unit length.
+      if (!S2::IsUnitLength(edge.v0) || !S2::IsUnitLength(edge.v1)) {
+        *error = S2Error(
+            S2Error::NOT_UNIT_LENGTH,
+            absl::StrFormat("Shape %d has non-unit length vertices", shape_id));
+        return false;
+      }
+
+      // (Optional) check polyline and polygon edges for degeneracy.
+      if (dim > 0 && !options().allow_degenerate_edges()) {
+        if (edge.IsDegenerate()) {
+          *error = S2Error(
+              S2Error::DUPLICATE_VERTICES,
+              absl::StrFormat("Shape %d: chain %d, edge %d is degenerate",
+                              shape_id, chain_id, chain.start + offset));
+          return false;
+        }
+      }
+
+      // Check that edge doesn't have antipodal vertices.
+      if (edge.v0 == -edge.v1) {
+        *error =
+            S2Error(S2Error::ANTIPODAL_VERTICES,
+                    absl::StrFormat("Shape %d has adjacent antipodal vertices",
+                                    shape_id));
+        return false;
+      }
+
+      // Check that chain edges are connected for polylines and polygons.
+      if (dim > 0 && chain.length >= 2 && offset > 0) {
+        const S2Shape::Edge last = shape.chain_edge(chain_id, offset - 1);
+        if (last.v1 != edge.v0) {
+          *error =
+              S2Error(S2Error::NOT_CONTINUOUS,
+                      absl::StrFormat("Chain %d of shape %d has neighboring "
+                                      "edges that don't connect.",
+                                      chain_id, shape_id));
+          return false;
+        }
+      }
+    }
+
+    // The rest of the checks are for non-empty polygon chains only.
+    if (dim != 2 || chain.length == 0) {
+      continue;
+    }
+
+    // We need at least two distinct points in a chain before we can check its
+    // orientation vs the cell center.  Scan until we find a vertex different
+    // than the first.
+    int unique_count = 1;
+    const S2Point first = shape.chain_edge(chain_id, 0).v0;
+    for (const S2Point& vertex : shape.vertices(chain_id)) {
+      if (vertex != first) {
+        ++unique_count;
+        break;
+      }
+    }
+
+    // Only a single unique point. A degenerate edge will never test as a vertex
+    // crossing (because 3 out of 4 vertices to S2::VertexCrossing() would be
+    // equal making it false), so they can't toggle interior state and we can
+    // ignore them.
+    if (unique_count == 1) {
+      continue;
+    }
+
+    chains_to_check.emplace_back(chain_id);
+  }
+
+  // Check the selected chain to verify chain orientation.
+  for (int chain_id : chains_to_check) {
+    if (!CheckChainOrientation(iter, shape, shape_id, chain_id, error)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckForDuplicateEdges(S2Error* error) const {
+  int dim0 = options().allow_duplicate_polyline_edges() ? 2 : 1;
+  int dim1 = 2;
+
+  // This is O(N^2) but cells don't have many edges in them and benchmarks show
+  // this to be faster than trying to sort the whole array ahead of time.
+  absl::Span<const EdgeAndIdChain> edges =
+      CurrentCell().dim_range_edges(dim0, dim1);
+  int num_edges = edges.size();
+  for (int i = 0; i < num_edges; ++i) {
+    for (int j = i + 1; j < num_edges; ++j) {
+      bool duplicate = (edges[i] == edges[j]);
+
+      if (!options().allow_reverse_duplicates()) {
+        duplicate |= (edges[i].Reversed() == edges[j]);
+      }
+
+      if (duplicate) {
+        *error = S2Error(S2Error::OVERLAPPING_GEOMETRY,
+                         "One or more duplicate polygon edges detected");
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckForInteriorCrossings(S2Error* error) const {
+  // Get all the polyline and polygon edges.
+  absl::Span<const EdgeAndIdChain> edges = CurrentCell().dim_range_edges(1, 2);
+
+  // If we're allowing polyline edges to cross polyline edges, then we only have
+  // to check against polygon edges.
+  size_t check_start = 0;
+  if (options().allow_polyline_interior_crossings()) {
+    check_start = CurrentCell().dim_edges(1).size();
+  }
+
+  // This can happen when we're allowing polyline crossings and only have
+  // polylines, there's nothing to do.
+  if (check_start >= edges.size()) {
+    return true;
+  }
+
+  const size_t num_edges = edges.size();
+  for (size_t i = 0; i + 1 < num_edges; ++i) {
+    // We never have to check against edges at a lower index, because if we
+    // intersect them, we'll have already checked that at this point.
+    size_t j = std::max(check_start, i + 1);
+
+    // We can skip adjacent edges.
+    if (edges[i].v1 == edges[j].v0) {
+      if (++j >= num_edges) {
+        break;
+      }
+    }
+
+    S2EdgeCrosser crosser(&edges[i].v0, &edges[i].v1);
+    for (; j < num_edges; ++j) {
+      if (crosser.c() == nullptr || *crosser.c() != edges[j].v0) {
+        crosser.RestartAt(&edges[j].v0);
+      }
+
+      if (crosser.CrossingSign(&edges[j].v1) > 0) {
+        *error =
+            S2Error(S2Error::OVERLAPPING_GEOMETRY,
+                    absl::StrFormat("Chain %d edge %d crosses chain %d edge %d",
+                                    edges[i].chain, edges[i].offset,
+                                    edges[j].chain, edges[j].offset));
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Returns true if a vertex (0 or 1) of an edge of a polyline is a boundary
+// point or not.  This is only true if the vertex is either the start or end
+// point of a chain and the chain is open.  Returns false otherwise.
+//
+// REQUIRES: vertex == 0 or vertex == 1
+inline bool PolylineVertexIsBoundaryPoint(
+    const S2Shape& shape, const internal::S2IndexCellData::EdgeAndIdChain& edge,
+    int vertex) {
+  ABSL_DCHECK(vertex == 0 || vertex == 1);
+
+  if (edge.offset == 0) {
+    return s2shapeutil::PrevEdgeWrap(shape, edge.id) == -1 && vertex == 0;
+  } else if (edge.offset == shape.chain(edge.chain).length - 1) {
+    return s2shapeutil::NextEdgeWrap(shape, edge.id) == -1 && vertex == 1;
+  }
+
+  return false;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckTouchesAreValid(S2Error* error) {
+  using TouchType = typename Options::TouchType;
+
+  const auto kAny = Options::kTouchAny;
+
+  bool need_dim[3] = {true, true, true};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      bool any_allowed =
+          (options().allowed_touches(i, j) == std::make_pair(kAny, kAny));
+      need_dim[i] &= !any_allowed;
+    }
+  }
+
+  // If all touches are allowed, then we don't have to check, easy.
+  if (!need_dim[0] && !need_dim[1] && !need_dim[2]) {
+    return true;
+  }
+
+  // Gather unique vertices from each dimension that needs to be checked.
+  test_vertices_.clear();
+  for (const S2ClippedShape& clipped : CurrentCell().clipped_shapes()) {
+    const int shape_id = clipped.shape_id();
+    const S2Shape& shape = *Index().shape(shape_id);
+    const int dim = shape.dimension();
+
+    // Skip if we're not checking this dimension.
+    if (!need_dim[dim]) {
+      continue;
+    }
+
+    for (const EdgeAndIdChain& edge : CurrentCell().shape_edges(shape_id)) {
+      // For polylines, we have to handle the start and ending edges specially,
+      // since we can have open chains that have boundary points.
+      if (dim == 1) {
+        bool on_boundary = PolylineVertexIsBoundaryPoint(shape, edge, 0);
+        test_vertices_.push_back(
+            {edge.v0, edge.id, shape_id, dim, on_boundary});
+
+        // Check vertex 1 too only if it's a boundary point, otherwise we would
+        // test v1 twice after we grab v0 of the next edge.
+        on_boundary = PolylineVertexIsBoundaryPoint(shape, edge, 1);
+        if (on_boundary) {
+          test_vertices_.push_back({edge.v1, edge.id, shape_id, dim, true});
+        }
+      } else {
+        // All polygon vertices are on the boundary, all point vertices are not.
+        test_vertices_.push_back({edge.v0, edge.id, shape_id, dim, dim == 2});
+      }
+    }
+  }
+
+  // For each test vertex, scan over the other shapes and verify that any vertex
+  // touches are allowed under the current semantics.
+  for (const TestVertex& testpnt : test_vertices_) {
+    for (const S2ClippedShape& clipped : CurrentCell().clipped_shapes()) {
+      const int shape_id = clipped.shape_id();
+      const S2Shape& shape = *Index().shape(shape_id);
+      const int dim = shape.dimension();
+
+      for (const EdgeAndIdChain& edge : CurrentCell().shape_edges(shape_id)) {
+        // Don't compare an edge against itself.
+        if (testpnt.shape_id == shape_id && testpnt.edge_id == edge.id) {
+          continue;
+        }
+
+        // Figure out which (if any) vertex of this edge we touched.
+        int vertidx = -1;
+        if (testpnt.vertex == edge.v0) vertidx = 0;
+        if (testpnt.vertex == edge.v1) vertidx = 1;
+        if (vertidx < 0) {
+          continue;
+        }
+
+        // Closed polylines are always allowed, so if we get a hit on the same
+        // shape and it's a polyline, check that it's not from the closure.
+        if (testpnt.shape_id == shape_id && dim == 1) {
+          if (vertidx == 0 &&
+              s2shapeutil::PrevEdgeWrap(shape, edge.id) == testpnt.edge_id) {
+            continue;
+          }
+
+          if (vertidx == 1 &&
+              s2shapeutil::NextEdgeWrap(shape, edge.id) == testpnt.edge_id) {
+            continue;
+          }
+        }
+
+        // Points vertices are always interior, Polygon vertices are always
+        // boundary, and it may be either for polylines.
+        bool on_boundary = (dim == 2);
+        if (dim == 1) {
+          on_boundary = PolylineVertexIsBoundaryPoint(shape, edge, vertidx);
+        }
+
+        TouchType typea = Options::kTouchInterior;
+        if (testpnt.on_boundary) {
+          typea = Options::kTouchBoundary;
+        }
+
+        TouchType typeb = Options::kTouchInterior;
+        if (on_boundary) {
+          typeb = Options::kTouchBoundary;
+        }
+
+        using TouchPair = std::pair<TouchType, TouchType>;
+        TouchPair allowed = options().allowed_touches(testpnt.dim, dim);
+
+        // Returns true if both touches match the given allowed touches.
+        const auto PermittedTouches = [](TouchPair allowed, TouchType typea,
+                                         TouchType typeb) {
+          return (allowed.first & typea) && (allowed.second & typeb);
+        };
+
+        // We require that touches be symmetric, so that the touch is invalid
+        // only if it's invalid from A->B and B->A.  This lets us support
+        // behavior such as requiring that one or the other point be an interior
+        // point.
+        if (!PermittedTouches(allowed, typea, typeb) &&
+            !PermittedTouches(allowed, typeb, typea)) {
+          *error = S2Error(S2Error::OVERLAPPING_GEOMETRY,
+                           "Index has geometry with invalid vertex touches.");
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::StartCell(S2Error* error) {
+  if (!CheckForDuplicateEdges(error) || !CheckForInteriorCrossings(error)) {
+    return false;
+  }
+
+  if (!CheckTouchesAreValid(error)) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::PointContained(S2CellId cell_id, int shape_id,
+                                             const S2Point& point,
+                                             S2Error* error) {
+  const S2IndexCellData& cell = CurrentCell();
+  for (const S2ClippedShape& clipped : cell.clipped_shapes()) {
+    if (clipped.shape_id() == shape_id) {
+      continue;
+    }
+
+    const S2Shape& shape = *Index().shape(clipped.shape_id());
+
+    // Only check for containment in polygons.
+    if (shape.dimension() != 2) {
+      continue;
+    }
+
+    if (cell.ShapeContains(clipped, point)) {
+      *error = S2Error(
+          S2Error::OVERLAPPING_GEOMETRY,
+          absl::StrFormat(
+              "Shape %d has one or more edges contained in another shape.",
+              shape_id));
+      return true;
+    }
+  }
+
+  return false;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckChainOrientation(Iterator& iter,
+                                                    const S2Shape& shape,
+                                                    int shape_id, int chain_id,
+                                                    S2Error* error) {
+  const S2Shape::Chain& chain = shape.chain(chain_id);
+
+  // Given that:
+  //  1. Edges in the chain are connected continuously.
+  //  2. The chain is closed.
+  //  3. The chain at least two distinct points.
+  //
+  // Then we can test whether the chain is oriented properly relative to the
+  // cell center by testing one edge of the chain for proper orientation.
+
+  S2ContainsVertexQuery query;
+  for (int offset = 0; offset < chain.length; ++offset) {
+    const S2Point& vertex = shape.chain_edge(chain_id, offset).v0;
+    query.Init(vertex);
+
+    // Seek to the cell containing vertex and get the clipped shape.
+    if (!iter.Locate(vertex)) {
+      *error = S2Error::DataLoss("Shape vertex was not indexed");
+      return false;
+    }
+    const S2Point& center = iter.id().ToPoint();
+
+    const S2ClippedShape* clipped = iter.cell().find_clipped(shape_id);
+    ABSL_DCHECK_NE(clipped, nullptr);
+
+    // Compute winding number and vertex sign at the same time.
+    int winding = clipped->contains_center();
+    S2CopyingEdgeCrosser crosser(center, vertex);
+
+    for (int i = 0; i < clipped->num_edges(); ++i) {
+      const S2Shape::Edge& edge = shape.edge(clipped->edge(i));
+
+      // Tally up the total change in winding number from center to vertex.
+      winding += crosser.SignedEdgeOrVertexCrossing(edge.v0, edge.v1);
+
+      // Include any edges incident on vertex in the contains vertex query.
+      if (edge.IncidentOn(vertex)) {
+        if (vertex == edge.v0) {
+          query.AddEdge(edge.v1, +1);
+        } else {
+          query.AddEdge(edge.v0, -1);
+        }
+      }
+    }
+
+    bool duplicates = query.DuplicateEdges();
+    int sign = 0;
+
+    // If we have a sign of zero on the vertex, all the edges incident on it
+    // were reverse duplicates and we can't use it to test orientation, continue
+    // trying to find another vertex.
+    if (!duplicates) {
+      sign = query.ContainsSign();
+      if (sign == 0) {
+        continue;
+      }
+    }
+
+    // The sign bit obtained by crossing edges should be consistent with the
+    // sign produced by the S2ContainsVertexQuery.
+    if (duplicates || winding != (sign < 0 ? 0 : 1)) {
+      *error = S2Error(
+          S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS,
+          absl::StrFormat(
+              "Shape %d has one or more edges with interior on the right.",
+              shape_id));
+      return false;
+    }
+    return true;
+  }
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::CheckEdge(const S2Shape& shape,
+                                        const S2ClippedShape& clipped,
+                                        const EdgeAndIdChain& edge,
+                                        S2Error* error) {
+  const S2IndexCellData& cell = CurrentCell();
+  const int dim = shape.dimension();
+
+  // For points, we can check that they're not contained in any other polygons
+  // locally within the cell by crossing edges to the cell center.
+  if (dim == 0 &&
+      PointContained(cell.id(), clipped.shape_id(), edge.v0, error)) {
+    return false;
+  }
+
+  // Edge is OK
+  return true;
+}
+
+// Checks that edges of the given shape incident on vertex are ordered such that
+// the incident chains do not cross.
+//
+// We can check this by looking at all the incident edges and making sure that,
+// for each incoming edge, as we move counter-clockwise around the vertex, we
+// encounter matching pairs of incoming/outgoing edges for each chain.
+//
+// Returns true if chains do not cross at the vertex, false otherwise.
+inline bool CheckVertexCrossings(const S2Point& vertex, const S2Shape& shape,
+                                 int shape_id,
+                                 const absl::flat_hash_set<int32_t>& edge_ids,
+                                 S2Error* error) {
+  // Extend S2Shape::Edge to wrap an edge with its chain, id and previous id.
+  struct EdgeWithInfo : public S2Shape::Edge {
+    EdgeWithInfo(S2Shape::Edge edge, int id, int chain, int prev, int sign)
+        : S2Shape::Edge(edge), id(id), chain(chain), prev(prev), sign(sign) {}
+
+    int id;
+    int chain;
+    int prev;
+    int sign;  // +1 for incoming and -1 for outgoing edges.
+  };
+
+  // Aggregate edges of the current shape and sort them CCW around the vertex.
+  absl::InlinedVector<EdgeWithInfo, 6> edges;
+  for (int32_t edge_id : edge_ids) {
+    S2Shape::ChainPosition pos = shape.chain_position(edge_id);
+    const S2Shape::Edge& edge = shape.edge(edge_id);
+    edges.push_back({
+        edge,                                       //
+        edge_id,                                    //
+        pos.chain_id,                               //
+        s2shapeutil::PrevEdgeWrap(shape, edge_id),  //
+        edge.v0 == vertex ? -1 : +1,                //
+    });
+  }
+  SortEdgesCcw(vertex, edges[0], edges);
+
+  // Mapping from chain_id => count.  We'll scan through and sum the signs on
+  // the edges for each chain.  When we reach the incoming edge the sums should
+  // be zero for every chain.
+  absl::flat_hash_map<int, int> chain_sums;
+  chain_sums.reserve(16);
+
+  for (size_t i = 0; i < edges.size(); ++i) {
+    const EdgeWithInfo& curr = edges[i];
+
+    // Skip forward to next outgoing edge.
+    if (curr.sign > 0) {
+      continue;
+    }
+
+    // Scan until we find our incoming edge and tally chain counts.
+    chain_sums.clear();
+    size_t j;
+    for (j = 1; j < edges.size(); ++j) {
+      const EdgeWithInfo& edge = edges[(i + j) % edges.size()];
+      if (curr.chain == edge.chain && curr.prev == edge.id) {
+        for (const auto& sum : chain_sums) {
+          if (sum.second != 0) {
+            *error = S2Error(
+                S2Error::OVERLAPPING_GEOMETRY,
+                absl::StrFormat(
+                    "Shape %d has one or more chains that cross at a vertex",
+                    shape_id));
+            return false;
+          }
+        }
+        break;
+      }
+
+      chain_sums[edge.chain] += edge.sign;
+    }
+
+    // If we went all the way around and didn't find an incoming edge, then
+    // the geometry must be malformed, and thus isn't valid.
+    if (j == edges.size()) {
+      *error = S2Error(S2Error::INVALID_VERTEX,
+                       "Outgoing edge with no incoming edge");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename IndexType>
+bool S2ValidQuery<IndexType>::Finish(S2Error* error) {
+  // We've checked edges having interiors on the right, and for crossings at
+  // interior points.  The only case left is to check for chains that cross at a
+  // vertex.
+  for (const auto& item : IncidentEdges()) {
+    const S2Shape& shape = *Index().shape(item.first.shape_id);
+    if (shape.dimension() == 2) {
+      if (!CheckVertexCrossings(item.first.vertex, shape, item.first.shape_id,
+                                item.second, error)) {
+        return false;
+      }
+    }
+  }
+
+  // If we get to this point we know that polygon edges don't cross any other
+  // edges and that edges are properly oriented with the interior on the left.
+  //
+  // Since edges don't cross, any given chain must be entirely inside or outside
+  // any other polygons.  Thus, to determine that polygon interiors are
+  // disjoint, we only have to check one vertex of each chain in each shape for
+  // containment.
+  //
+  // We use the OPEN containment model because we check elsewhere if the vertex
+  // lands on another vertex.
+  S2ContainsPointQueryOptions options;
+  options.set_vertex_model(S2VertexModel::OPEN);
+
+  S2ContainsPointQuery<IndexType> query(&Index(), options);
+  for (int shape_id = 0; shape_id < Index().num_shape_ids(); ++shape_id) {
+    const S2Shape* shape = Index().shape(shape_id);
+    if (shape == nullptr || shape->dimension() == 0) {
+      continue;
+    }
+
+    for (int chain = 0; chain < shape->num_chains(); ++chain) {
+      if (shape->chain(chain).length < 1) {
+        continue;
+      }
+
+      S2Point vertex = shape->chain_edge(chain, 0).v0;
+      if (query.Contains(vertex)) {
+        *error = S2Error(
+            S2Error::OVERLAPPING_GEOMETRY,
+            absl::StrFormat(
+                "Shape %d has one or more edges contained in another shape.",
+                shape_id));
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+//////////////////   S2LegacyValidQuery Implementation   ////////////////////
+
+template <typename IndexType>
+S2LegacyValidQuery<IndexType>::S2LegacyValidQuery() : Base() {
+  // Don't allow degenerate or reverse duplicates edges for legacy semantics.
+  Base::mutable_options().set_allow_degenerate_edges(false);
+  Base::mutable_options().set_allow_reverse_duplicates(false);
+}
+
+template <typename IndexType>
+bool S2LegacyValidQuery<IndexType>::Start(S2Error* error) {
+  if (!Base::Start(error)) {
+    return false;
+  }
+
+  // We can't mix dimensions under legacy semantics.
+  int dim = -1;
+  for (const S2Shape* shape : Index()) {
+    if (dim < 0) {
+      dim = shape->dimension();
+    }
+
+    if (dim != shape->dimension()) {
+      *error = S2Error(
+          S2Error::INVALID_DIMENSION,
+          "Mixed dimensional geometry is invalid for legacy semantics.");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename IndexType>
+bool S2LegacyValidQuery<IndexType>::CheckShape(Iterator& iter,
+                                               const S2Shape& shape,
+                                               int shape_id, S2Error* error) {
+  // Count the number of empty chains.  Non-empty chains must have at least
+  // three vertices.
+  if (shape.dimension() == 2) {
+    bool has_empty_loops = false;
+    for (const S2Shape::Chain& chain : shape.chains()) {
+      if (chain.length == 0) {
+        has_empty_loops = true;
+      } else if (chain.length < 3) {
+        *error = S2Error(
+            S2Error::LOOP_NOT_ENOUGH_VERTICES,
+            absl::StrFormat(
+                "Shape %d has a non-empty chain with less than three edges.",
+                shape_id));
+        return false;
+      }
+    }
+
+    if (has_empty_loops && shape.num_chains() > 1) {
+      *error = S2Error(
+          S2Error::POLYGON_EMPTY_LOOP,
+          absl::StrFormat("Shape %d has too many empty chains", shape_id));
+      return false;
+    }
+  }
+
+  if (!Base::CheckShape(iter, shape, shape_id, error)) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename IndexType>
+bool S2LegacyValidQuery<IndexType>::StartCell(S2Error* error) {
+  // Check for duplicate vertices within a chain.
+  const S2IndexCellData& cell = CurrentCell();
+  for (const S2ClippedShape& clipped : cell.clipped_shapes()) {
+    absl::Span<const EdgeAndIdChain> edges =
+        cell.shape_edges(clipped.shape_id());
+
+    for (size_t i = 0; i < edges.size(); ++i) {
+      for (size_t j = i + 1; j < edges.size(); ++j) {
+        if (edges[j].chain != edges[i].chain) {
+          continue;
+        }
+
+        if (edges[j].v0 == edges[i].v0) {
+          *error = S2Error(
+              S2Error::DUPLICATE_VERTICES,
+              absl::StrFormat("Chain %d of shape %d has duplicate vertices",
+                              edges[i].chain, clipped.shape_id()));
+          return false;
+        }
+      }
+    }
+  }
+
+  return Base::StartCell(error);
+}
+
+template <typename IndexType>
+bool S2LegacyValidQuery<IndexType>::CheckEdge(const S2Shape& shape,
+                                              const S2ClippedShape& clipped,
+                                              const EdgeAndIdChain& edge,
+                                              S2Error* error) {
+  if (!Base::CheckEdge(shape, clipped, edge, error)) {
+    return false;
+  }
+  return true;
+}
+
+#endif  // S2_S2VALIDATION_QUERY_H_

--- a/src/s2/s2validation_query_test.cc
+++ b/src/s2/s2validation_query_test.cc
@@ -1,0 +1,912 @@
+// Copyright 2022 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#include "s2/s2validation_query.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/algorithm/container.h"
+#include "absl/flags/flag.h"
+#include "absl/log/absl_check.h"
+#include "absl/log/log_streamer.h"
+#include "absl/random/bit_gen_ref.h"
+#include "absl/random/random.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "s2/util/coding/coder.h"
+#include "s2/mutable_s2shape_index.h"
+#include "s2/s2debug.h"
+#include "s2/s2error.h"
+#include "s2/s2fractal.h"
+#include "s2/s2latlng.h"
+#include "s2/s2lax_polygon_shape.h"
+#include "s2/s2point.h"
+#include "s2/s2random.h"
+#include "s2/s2shape.h"
+#include "s2/s2shapeutil_coding.h"
+#include "s2/s2testing.h"
+#include "s2/s2text_format.h"
+
+namespace {
+
+using ::absl::StrCat;
+using ::absl::string_view;
+using ::std::make_unique;
+using ::std::string;
+using ::std::unique_ptr;
+using ::std::vector;
+using ::testing::Contains;
+using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+
+// Converts latitude/longitude in radians to an S2Point
+S2Point LatLngToPoint(double lat, double lng) {
+  return S2LatLng::FromRadians(lat, lng).ToPoint();
+}
+
+// Diamond shaped pattern of points around (0,0).
+const S2Point kDiamondPoints[] = {S2LatLng::FromDegrees(+1.0, +0.0).ToPoint(),
+                                  S2LatLng::FromDegrees(-1.0, +0.0).ToPoint(),
+                                  S2LatLng::FromDegrees(+0.0, -1.0).ToPoint(),
+                                  S2LatLng::FromDegrees(+0.0, +1.0).ToPoint()};
+
+// An S2Shape subclass with one chain that's open.
+class OpenShape : public S2Shape {
+ public:
+  int dimension() const final { return 2; }
+
+  int num_edges() const final { return 3; }
+  Edge chain_edge(int, int id) const final { return edge(id); }
+  Edge edge(int id) const final {
+    ABSL_CHECK_GE(id, 0);
+    ABSL_CHECK_LT(id, 3);
+
+    switch (id) {
+      case 0:
+        return Edge(kDiamondPoints[0], kDiamondPoints[1]);
+      case 1:
+        return Edge(kDiamondPoints[1], kDiamondPoints[2]);
+      case 2:
+        return Edge(kDiamondPoints[2], kDiamondPoints[3]);
+      default:
+        ABSL_CHECK(false);
+    }
+  }
+
+  int num_chains() const final { return 1; }
+  Chain chain(int) const final { return {1, num_edges()}; }
+
+  ReferencePoint GetReferencePoint() const final {
+    return {S2Point(1, 0, 0), true};
+  }
+  ChainPosition chain_position(int id) const final { return {0, id}; }
+  TypeTag type_tag() const final { return 1; }
+};
+
+// An S2Shape subclass returning an invalid dimension value.
+class BadDimensionShape : public S2Shape {
+ public:
+  int dimension() const final { return 42; }
+  int num_edges() const final { return 0; }
+  Edge edge(int) const final { return {}; }
+  Edge chain_edge(int, int) const final { return {}; }
+  Chain chain(int) const final { return {}; }
+  int num_chains() const final { return 1; }
+  ChainPosition chain_position(int) const final { return {}; }
+  ReferencePoint GetReferencePoint() const final {
+    return {S2Point(1, 0, 0), true};
+  }
+  TypeTag type_tag() const final { return 1; }
+};
+
+// An S2Shape subclass returning a chain that's too short.
+class BadChainLengthShape : public S2Shape {
+ public:
+  int dimension() const final { return 2; }
+  int num_edges() const final { return 2; }
+
+  Edge edge(int id) const final {
+    ABSL_CHECK_GE(id, 0);
+    ABSL_CHECK_LT(id, 2);
+
+    switch (id) {
+      case 0:
+        return Edge(kDiamondPoints[0], kDiamondPoints[1]);
+      case 1:
+        return Edge(kDiamondPoints[1], kDiamondPoints[2]);
+      default:
+        ABSL_CHECK(false);
+    }
+  }
+
+  Edge chain_edge(int, int) const final { return {}; }
+  int num_chains() const final { return 1; }
+  Chain chain(int) const final { return {0, num_edges()}; }
+  ChainPosition chain_position(int) const final { return {}; }
+  ReferencePoint GetReferencePoint() const final {
+    return {S2Point(1, 0, 0), true};
+  }
+  TypeTag type_tag() const final { return 1; }
+};
+
+// Returns num evenly spaced edges all sharing a common center point.
+vector<S2Shape::Edge> CcwEdgesAbout(S2Point center, int num = 10) {
+  vector<S2Shape::Edge> edges;
+  for (int i = 0; i < num; ++i) {
+    double angle = 2 * M_PI / num * i;
+    edges.emplace_back(center, LatLngToPoint(std::sin(angle), std::cos(angle)));
+  }
+  return edges;
+}
+
+// Builds a "quilt" test shape which is a series of rings that stretch from the
+// south to north pole and form a grid where every vertex has at least two
+// chains incident on it.
+std::unique_ptr<S2LaxPolygonShape> MakeQuilt() {
+  // Defines a grid where points are separated by 15 degrees in longitude and 30
+  // degrees in latitude.  The integral indices for x thus range from [0, 24)
+  // and y ranges from [0, 13].  X values are automatically wrapped into range.
+  const auto GridPoint = [](int x, int y) {
+    constexpr double kLatDelta = 15;  // degrees;
+    constexpr double kLonDelta = 15;  // degrees;
+
+    ABSL_DCHECK(0 <= y && y <= 12);
+    ABSL_DCHECK_LE(0, x);
+    x %= 24;
+
+    // Return exact polar points to avoid numerical issues.
+    if (y == 0) return S2Point(0, 0, -1);
+    if (y == 12) return S2Point(0, 0, +1);
+
+    return S2LatLng::FromDegrees(-90 + kLatDelta * y, -180 + kLonDelta * x)
+        .ToPoint();
+  };
+
+  // Now build loops that touch at every-other point.  This will give us a
+  // diamond quilt pattern where every vertex has two chains incident on it.
+  std::vector<std::vector<S2Point>> loops;
+
+  for (int x = 0; x < 24; x += 2) {
+    for (int y = 0; y < 12; y += 2) {
+      std::vector<S2Point> loop;
+      loop.emplace_back(GridPoint(x + 0, y + 1));
+      loop.emplace_back(GridPoint(x + 1, y + 2));
+      loop.emplace_back(GridPoint(x + 2, y + 1));
+      loop.emplace_back(GridPoint(x + 1, y + 0));
+      loops.emplace_back(std::move(loop));
+    }
+  }
+  return std::make_unique<S2LaxPolygonShape>(std::move(loops));
+}
+
+TEST(SortEdgesCcw, SortsEdges) {
+  const S2Point kOrigin = LatLngToPoint(0.0, 0.0);
+  constexpr int kNumEdges = 10;
+
+  // Generate edges in order around the origin.
+  vector<S2Shape::Edge> sorted = CcwEdgesAbout(kOrigin, kNumEdges);
+
+  absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
+      "SORT_EDGES_CCW_SORTS_EDGES",
+      absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
+  for (int i = 0; i < kNumEdges; ++i) {
+    // Shift sorted edges by one.
+    absl::c_rotate(sorted, sorted.begin() + 1);
+
+    // Randomize the edges.
+    vector<S2Shape::Edge> shuffled = sorted;
+    absl::c_shuffle(shuffled, bitgen);
+
+    // Sorting about the first edge should always give back the sorted array.
+    SortEdgesCcw(kOrigin, sorted[0], shuffled);
+    EXPECT_THAT(shuffled, Eq(sorted));
+  }
+}
+
+TEST(SortEdgesCcw, SortsEdgesFlipped) {
+  const S2Point kOrigin = LatLngToPoint(0.0, 0.0);
+  constexpr int kNumEdges = 10;
+
+  // Generate edges in order around the origin.
+  vector<S2Shape::Edge> sorted = CcwEdgesAbout(kOrigin, kNumEdges);
+
+  // Flip the orientation of some of the edges.  This only changes their
+  // direction, not their ordering around the vertex.
+  sorted[3] = sorted[3].Reversed();
+  sorted[8] = sorted[8].Reversed();
+
+  absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
+      "SORT_EDGES_CCW_SORTS_EDGES_FLIPPED",
+      absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
+  for (int i = 0; i < kNumEdges; ++i) {
+    // Shift sorted edges by one.
+    absl::c_rotate(sorted, sorted.begin() + 1);
+
+    // randomize the edges.
+    vector<S2Shape::Edge> shuffled = sorted;
+    absl::c_shuffle(shuffled, bitgen);
+
+    // Sorting about the first edge should always give back the sorted array.
+    SortEdgesCcw(kOrigin, sorted[0], shuffled);
+    EXPECT_THAT(shuffled, Eq(sorted));
+  }
+}
+
+TEST(SortEdgesCcw, StartEdgeAlwaysFirst) {
+  const S2Point kOrigin = LatLngToPoint(0.0, 0.0);
+  constexpr int kNumEdges = 10;
+
+  // Generate edges in order around the origin.
+  vector<S2Shape::Edge> sorted = CcwEdgesAbout(kOrigin, kNumEdges);
+
+  absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
+      "SORT_EDGES_CCW_START_EDGE_ALWAYS_FIRST",
+      absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
+  for (int i = 0; i < kNumEdges; ++i) {
+    // Randomize the edges.
+    vector<S2Shape::Edge> shuffled = sorted;
+    absl::c_shuffle(shuffled, bitgen);
+
+    // The reference edge we sort around should always come out first.
+    SortEdgesCcw(kOrigin, sorted[i], shuffled);
+    EXPECT_THAT(shuffled[0], Eq(sorted[i]));
+  }
+}
+
+TEST(SortEdgesCcw, ReverseDuplicatesOrdered) {
+  const S2Point kOrigin = LatLngToPoint(0.0, 0.0);
+  constexpr int kNumEdges = 10;
+
+  // Generate edges in order around the origin.
+  vector<S2Shape::Edge> sorted = CcwEdgesAbout(kOrigin, kNumEdges);
+
+  // Insert two reverse duplicate edges.
+  sorted.insert(sorted.begin() + 8, sorted[8].Reversed());
+  sorted.insert(sorted.begin() + 3, sorted[3].Reversed());
+
+  // Randomize the edges.
+  absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
+      "SORT_EDGES_CCW_REVERSE_DUPLICATES_ORDERED",
+      absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
+  vector<S2Shape::Edge> shuffled = sorted;
+  absl::c_shuffle(shuffled, bitgen);
+
+  // After sorting, the reverse duplicates should be right after their sibling.
+  SortEdgesCcw(kOrigin, sorted[4], shuffled);
+
+  S2Point common = sorted[4].v0;
+  EXPECT_THAT(shuffled[0], Eq(shuffled[1].Reversed()));
+  EXPECT_THAT(shuffled[0].v0, Eq(common));
+  EXPECT_THAT(shuffled[6], Eq(shuffled[7].Reversed()));
+  EXPECT_THAT(shuffled[6].v0, Eq(common));
+}
+
+// Common logic to test across various validation queries.
+template <typename QueryType>
+class ValidationQueryTest : public ::testing::Test {
+  using IndexPtr = unique_ptr<MutableS2ShapeIndex>;
+
+ protected:
+  // Checks that a particular shape is valid.
+  void ExpectShapeValid(unique_ptr<S2Shape> shape) {
+    MutableS2ShapeIndex index;
+    index.Add(std::move(shape));
+
+    S2Error error;
+    EXPECT_THAT(query_.Validate(index, &error), IsTrue());
+    EXPECT_THAT(error.code(), Eq(S2Error::OK));
+  }
+
+  // Checks that a particular S2ShapeIndex fails to validate, and that the error
+  // matches one of the given codes.
+  void ExpectIndexInvalid(const MutableS2ShapeIndex& index,
+                          absl::Span<const S2Error::Code> codes = {}) {
+    S2Error error;
+    EXPECT_THAT(query_.Validate(index, &error), IsFalse());
+    if (!codes.empty()) {
+      EXPECT_THAT(codes, Contains(error.code()));
+    }
+  }
+
+  // Checks that a particular shape fails to validate, and that the error
+  // matches the given code.
+  void ExpectShapeInvalid(unique_ptr<S2Shape> shape,
+                          absl::Span<const S2Error::Code> codes = {}) {
+    MutableS2ShapeIndex index;
+    index.Add(std::move(shape));
+    ExpectIndexInvalid(index, codes);
+  }
+
+  void ExpectShapeInvalid(unique_ptr<S2Shape> shape, S2Error::Code code) {
+    ExpectShapeInvalid(std::move(shape), std::vector<S2Error::Code>{code});
+  }
+
+  // Checks that the given geometry string validates.
+  void ExpectGeometryValid(string_view geometry) {
+    IndexPtr index = s2textformat::MakeIndexOrDie(geometry);
+    S2Error error;
+    EXPECT_THAT(query_.Validate(*index, &error), IsTrue()) << error;
+    EXPECT_THAT(error.code(), Eq(S2Error::OK));
+  }
+
+  // Checks that the given geometry string does not validate, and that the given
+  // error code is returned.
+  void ExpectGeometryInvalid(string_view geometry, S2Error::Code code) {
+    IndexPtr index = s2textformat::MakeIndexOrDie(geometry);
+    S2Error error;
+    EXPECT_THAT(query_.Validate(*index, &error), IsFalse());
+    EXPECT_THAT(error.code(), Eq(code));
+  }
+
+  // Create "num_loops" nested regular loops around a common center point.  All
+  // loops have the same number of vertices (at least "min_vertices").
+  // Furthermore, the vertices at the same index position are collinear with the
+  // common center point of all the loops.  The loop radii decrease
+  // exponentially in order to prevent accidental loop crossings when one of the
+  // loops is modified.
+  void AddConcentricLoops(  //
+      absl::BitGenRef bitgen, int num_loops, int min_vertices) {
+    ABSL_DCHECK_LE(num_loops, 10);  // Because radii decrease exponentially.
+    S2Point center = s2random::Point(bitgen);
+    int num_vertices = min_vertices + absl::Uniform(bitgen, 0, 10);
+    for (int i = 0; i < num_loops; ++i) {
+      S1Angle radius = S1Angle::Degrees(80 * pow(0.1, i));
+      loops_.emplace_back(  //
+          S2Testing::MakeRegularPoints(center, radius, num_vertices));
+    }
+  }
+
+  // Creates and returns a new polygon from the given loops.
+  S2Polygon MakePolygon(absl::BitGenRef bitgen) {
+    std::vector<std::unique_ptr<S2Loop>> loops;
+    for (const auto& loop : loops_) {
+      loops.push_back(make_unique<S2Loop>(loop, S2Debug::DISABLE));
+    }
+
+    absl::c_shuffle(loops, bitgen);
+    S2Polygon polygon;
+    polygon.set_s2debug_override(S2Debug::DISABLE);
+    polygon.InitNested(std::move(loops));
+    return polygon;
+  }
+
+  std::vector<std::vector<S2Point>> loops_;
+
+ private:
+  QueryType query_;
+};
+
+// Define test suite for all validation queries.
+template <typename IndexType>
+using AllValidationQueries = ValidationQueryTest<IndexType>;
+
+using AllQueryTypes = ::testing::Types<  //
+    S2ValidQuery<S2ShapeIndex>,          //
+    S2LegacyValidQuery<S2ShapeIndex>     //
+  >;
+TYPED_TEST_SUITE(AllValidationQueries, AllQueryTypes);
+
+TYPED_TEST(AllValidationQueries, BasicGeometryOk) {
+  // Basic polygon should be valid.
+  this->ExpectGeometryValid("## 1:0, 0:-1, -1:0, 0:1");
+
+  // Basic polyline should be valid.
+  this->ExpectGeometryValid("# 0:0, 1:0, 0:-1, -1:0, 0:1 #");
+
+  // Basic multipoint should be valid.
+  this->ExpectGeometryValid("0:0 | 1:0 | 0:-1 | -1:0 | 0:1 ##");
+
+  // Basic polygon with a hole should be valid.
+  this->ExpectGeometryValid(      //
+      "## 2:0, 0:-2, -2:0, 0:2;"  //
+      "   0:1, -1:0, 0:-1, 1:0;"  //
+  );
+
+  // Polygon with improperly oriented hole should fail.
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   1:0, 0:-1, -1:0, 0:1;",                      //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+}
+
+TYPED_TEST(AllValidationQueries, EmptyGeometryOk) {
+  this->ExpectGeometryValid("##");
+}
+
+TYPED_TEST(AllValidationQueries, FullGeometryOk) {
+  this->ExpectGeometryValid("## full");
+}
+
+TYPED_TEST(AllValidationQueries, InteriorOnRightRegression) {
+  // Found via fuzzing, this should not test as invalid.  The root cause was
+  // that we weren't clearing the incident edge list before gathering edges,
+  // causing a duplicate edge to appear and give us the wrong interior state.
+  this->ExpectGeometryValid(  //
+      "## 0:4, 3:128, 4:2, 0:0");
+}
+
+TYPED_TEST(AllValidationQueries, TangentPolygonsOk) {
+  // Two polygons touching at one vertex should be valid.
+  this->ExpectGeometryValid(     //
+      "## 1:0, 0:-1, -1:0, 0:1"  //
+      "|  0:1, -1:2,  0:3, 1:2"  //
+  );
+}
+
+TYPED_TEST(AllValidationQueries, AntipodalEdgeFails) {
+  // We need to specify the points instead of using MakeIndexOrDie to ensure
+  // they're exactly opposite sign to be antipodal.
+  const vector<vector<S2Point>> kPoints = {{S2Point(M_SQRT1_2, M_SQRT1_2, 0),
+                                            S2Point(0, 1, 0), S2Point(-1, 0, 0),
+                                            S2Point(1, 0, 0)}};
+
+  this->ExpectShapeInvalid(make_unique<S2LaxPolygonShape>(kPoints),
+                           S2Error::ANTIPODAL_VERTICES);
+}
+
+TYPED_TEST(AllValidationQueries, BadlyDimensionedFails) {
+  this->ExpectShapeInvalid(make_unique<BadDimensionShape>(),
+                           S2Error::INVALID_DIMENSION);
+}
+
+TYPED_TEST(AllValidationQueries, OpenChainFails) {
+  this->ExpectShapeInvalid(make_unique<OpenShape>(),
+                           S2Error::LOOP_NOT_ENOUGH_VERTICES);
+}
+
+TYPED_TEST(AllValidationQueries, DuplicatePolygonEdgesFail) {
+  // Two polygons sharing an edge is invalid.
+  this->ExpectGeometryInvalid(   //
+      "## 2:0, 0:-2, -2:0, 0:2"  //
+      " | 2:0, 0:-2,  0:0",      //
+      S2Error::OVERLAPPING_GEOMETRY);
+}
+
+TYPED_TEST(AllValidationQueries, ChainsTouchingOk) {
+  // Polygon with a hole with chains touching at a point should be valid.
+  this->ExpectGeometryValid(      //
+      "## 2:0, 0:-2, -2:0, 0:2;"  //
+      "   0:2, -1:0, 0:-1, 1:0;"  //
+  );
+
+  this->ExpectGeometryValid(      //
+      "## 2:0, 0:-2, -2:0, 0:2;"  //
+      "   0:1, -2:0, 0:-1, 1:0;"  //
+  );
+
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0,  0:-2, -2:0, 0:2;"                      //
+      "   1:0,  0:-2, -1:0, 0:2;",                     //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+}
+
+TYPED_TEST(AllValidationQueries, NestedShellsFail) {
+  // Polygon with improperly oriented hole should fail
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   1:0, 0:-1, -1:0, 0:1",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+
+  // Even if they're touching.
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   2:0, 0:-1, -1:0, 0:1",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   2:0, 0:-1, -2:0, 0:1",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   1:0, 0:-2, -1:0, 0:1",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   1:0, 0:-1, -2:0, 0:1",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+
+  this->ExpectGeometryInvalid(                         //
+      "## 2:0, 0:-2, -2:0, 0:2;"                       //
+      "   1:0, 0:-1, -1:0, 0:2",                       //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS  //
+  );
+}
+
+TYPED_TEST(AllValidationQueries, ChainsCannotCross) {
+  // Polygon chains crossing is an error, regardless of orientation.
+  this->ExpectGeometryInvalid(     //
+      "## 3:0, 0:-3, -3:0, 0:+3;"  //
+      "   3:2, 0:-1, -3:2, 0:+5",  //
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS);
+
+  this->ExpectGeometryInvalid(      //
+      "## 0:3, 3:0,   0:-3, -3:0;"  //
+      "   3:2, 0:+5, -3:2,  0:-1",  //
+      S2Error::OVERLAPPING_GEOMETRY);
+
+  // Crossing at a vertex isn't allowed either.  This test vector is carefully
+  // constructed to avoid triggering the interior-on-the-right check.
+  this->ExpectGeometryInvalid(                        //
+      "## 0:-6, -6:0, 0:6, 6:0 ;"                     //
+      "   0:0,   3:0, 6:0, 6:3, 6:6, 3:6, 0:6, 0:3",  //
+      S2Error::OVERLAPPING_GEOMETRY);
+}
+
+TYPED_TEST(AllValidationQueries, ShellInHoleFails) {
+  this->ExpectGeometryInvalid(  //
+      "## 0:0, 10:10, 10:0; 5:21, 8:21, 6:23",
+      S2Error::POLYGON_INCONSISTENT_LOOP_ORIENTATIONS);
+}
+
+TYPED_TEST(AllValidationQueries, LoopsCrossing) {
+  // None of the validation semantics allow loops to cross.
+  static constexpr int kIters = 100;
+
+  absl::BitGen bitgen(S2Testing::MakeTaggedSeedSeq(
+      "LOOPS_CROSSING",
+      absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
+
+  for (int iter = 0; iter < kIters; ++iter) {
+    this->AddConcentricLoops(bitgen, 2, 4 /*min_vertices*/);
+
+    // Grab the two loops that were just added.
+    std::vector<S2Point>& loop0 = this->loops_[this->loops_.size() - 2];
+    std::vector<S2Point>& loop1 = this->loops_[this->loops_.size() - 1];
+
+    // Both loops have the same number of vertices, and vertices at the same
+    // index position are collinear with the center point, so we can create a
+    // crossing by simply exchanging two vertices at the same index position.
+    int n = loop0.size();
+    int i = absl::Uniform(bitgen, 0, n);
+    std::swap(loop0[i], loop1[i]);
+    if (absl::Bernoulli(bitgen, 0.5)) {
+      // By copy the two adjacent vertices from one loop to the other, we can
+      // ensure that the crossings happen at vertices rather than edges.
+      loop0[(i + 1) % n] = loop1[(i + 1) % n];
+      loop0[(i + n - 1) % n] = loop1[(i + n - 1) % n];
+    }
+
+    S2Polygon polygon = this->MakePolygon(bitgen);
+
+    // Don't check the error code, just that the polygon is invalid.  There's
+    // several different types of invalidity that can result from crossing loops
+    // this way.
+    this->ExpectShapeInvalid(std::make_unique<S2Polygon::Shape>(&polygon));
+  }
+}
+
+TYPED_TEST(AllValidationQueries, IndexWithUnindexVerticesFails) {
+  // This was found by fuzz testing.  It contains a chain vertex that's not
+  // actually indexed, so checking chain orientations will fail, which we should
+  // catch.
+  const std::string data(
+      "\010\212\005\001\002Y\000\010\177\210[\226\001\020\002\003\004\215\026)"
+      "!\373\362\362\341\257?\013\212t\250\343\304\000\210\363\213~\032:\306?"
+      "\027\034\201\214\213\203\357?\000\000\000p\341\000\000\000\211s\013~"
+      "\032:\306?[j\260}\330d\357?\320\246\303os$\306?"
+      "\002\201\302\270\000O\266?\242\025\030\264\323\340\357\002\201\302\270("
+      "\326O\266?\000\000\000\000\000\000$\000\000\027?\211s\013]]]~\032:\306?"
+      "\000\000\000\000\000\000\000\000\014\000\003\006("
+      "\340\010\020\010\001\020",
+      147);
+
+  S2Error error;
+  Decoder decoder(data.data(), data.size());
+
+  MutableS2ShapeIndex index;
+  EXPECT_TRUE(index.Init(&decoder,
+                         s2shapeutil::FullDecodeShapeFactory(&decoder, error)));
+  EXPECT_TRUE(error.ok()) << error.message();
+  this->ExpectIndexInvalid(index, {S2Error::DATA_LOSS});
+}
+
+TYPED_TEST(AllValidationQueries, OutgoingEdgeButNoIncomingEdge) {
+  // This was found by fuzz testing.  It contains a vertex with an outgoing edge
+  // but no corresponding incoming edge.
+  const std::string data(
+      "\010\212\005\001\002Y\000\010\177\020\000\001\020\000M\004\215\026)!"
+      "\373\010\357?\364\013\212t\250\343\305?\211s\013~\032:\306?"
+      "\027\034\201\214\213\203\357?\205\000\000\000\000\000\000\000\211s\013~"
+      "\032:\306?[j\260}\330d\357?\320\246\303os$\306?"
+      "\002\201\302\270\326O\266?\242\025\030\264\323\340\357?"
+      "\002\201\302\270\326O\266?\000\000\000\000\003 "
+      "\000\000\027\034\201\214\213\203\357?\211s\013~\032:\306?"
+      "\377\000\363\000\336\000\000\000\014\000\003\006("
+      "\340\010\020\010\001\014\020\264",
+      149);
+
+  S2Error error;
+  Decoder decoder(data.data(), data.size());
+
+  MutableS2ShapeIndex index;
+  EXPECT_TRUE(index.Init(&decoder,
+                         s2shapeutil::FullDecodeShapeFactory(&decoder, error)));
+  EXPECT_TRUE(error.ok()) << error.message();
+  this->ExpectIndexInvalid(index, {S2Error::INVALID_VERTEX});
+}
+
+TYPED_TEST(AllValidationQueries, InvalidChainNearChain) {
+  // This was found by fuzz testing.  It contains a cell with a chain that has
+  // valid points but also a chain with unnormalized points, which would fail
+  // if we didn't defer chain orientation checks.
+  const std::string data(
+      "\010\212\005\001\002Y\000\010\177\020\000\001\020\002\003\004\215\026)!"
+      "\373\010\357?\364\013\212t\250\343\305?\211s\013~\032:\306?"
+      "\027\034\201\214\213\203\357?\000\000\000\000\000\000\000\000\211s\013~"
+      "\032:\306?[j\260~\330d\357?\320\246\303os$\306?"
+      "\002\201\302\270\326O\266?\242\025\030\264\323\340\357?"
+      "\002\201\302\270\326O\266?"
+      "\000\000\000\000\000\000\000\000\027\034\201\214\213\203\357?\211s\013~"
+      "\032:\306?\000\000\000\000\000\000\000\000\014\000\003\006("
+      "\340\010\020\010\001\020",
+      147);
+
+  S2Error error;
+  Decoder decoder(data.data(), data.size());
+
+  MutableS2ShapeIndex index;
+  EXPECT_TRUE(index.Init(&decoder,
+                         s2shapeutil::FullDecodeShapeFactory(&decoder, error)));
+  EXPECT_TRUE(error.ok()) << error.message();
+  this->ExpectIndexInvalid(index, {S2Error::NOT_UNIT_LENGTH});
+}
+
+//////////////////   Multidimensional Query Tests   ////////////////////
+
+// Define test suite for validation queries that allow multidimensional geometry
+template <typename IndexType>
+using MultiDimensionalQueries = ValidationQueryTest<IndexType>;
+
+using MultiDimensionalTypes = ::testing::Types<  //
+    S2ValidQuery<MutableS2ShapeIndex>            //
+    >;
+
+TYPED_TEST_SUITE(MultiDimensionalQueries, MultiDimensionalTypes);
+
+TYPED_TEST(MultiDimensionalQueries, BasicGeometryOk) {
+  // Basic multi-dimensional geometry should be valid;
+  this->ExpectGeometryValid(    //
+      "  3:0| 0:-3| -3:0| 0:3"  //
+      "# 2:0, 0:-2, -2:0, 0:2"  //
+      "# 1:0, 0:-1, -1:0, 0:1"  //
+  );
+}
+
+TYPED_TEST(MultiDimensionalQueries, ContainedGeometryFails) {
+  // Point contained in polygon is invalid.
+  this->ExpectGeometryInvalid("0:0 ## 2:0, 0:-2, -2:0, 0:2",
+                              S2Error::OVERLAPPING_GEOMETRY);
+
+  // Polyline contained in polygon is invalid.
+  this->ExpectGeometryInvalid("# 0:-1, 0:1 # 2:0, 0:-2, -2:0, 0:2",
+                              S2Error::OVERLAPPING_GEOMETRY);
+
+  // Polygon contained in polygon is invalid.
+  this->ExpectGeometryInvalid(       //
+      "## 2:0, 0:-2, -2:0, 0:2"      //
+      " | 1:0, 0:-1, -1:0, 0:1",     //
+      S2Error::OVERLAPPING_GEOMETRY  //
+  );
+
+  // Either end of a polyline contained in a polygon is invalid.
+  this->ExpectGeometryInvalid("# 0:-3, 0:1 # 2:0, 0:-2, -2:0, 0:2",
+                              S2Error::OVERLAPPING_GEOMETRY);
+  this->ExpectGeometryInvalid("# 0:-1, 0:3 # 2:0, 0:-2, -2:0, 0:2",
+                              S2Error::OVERLAPPING_GEOMETRY);
+
+  // Polyline edges crossing are fine though.
+  this->ExpectGeometryValid("# 0:-1, 0:1 | 1:0, -1:0 #");
+}
+
+//////////////////   S2ValidQuery Tests   ////////////////////
+
+// Define test suite for s2valid validation query only.
+template <typename IndexType>
+using S2ValidTest = ValidationQueryTest<IndexType>;
+
+TYPED_TEST_SUITE(S2ValidTest,
+                 ::testing::Types<S2ValidQuery<MutableS2ShapeIndex>>);
+
+TYPED_TEST(S2ValidTest, QuiltIsValid) { this->ExpectShapeValid(MakeQuilt()); }
+
+TYPED_TEST(S2ValidTest, DegenerateRingsAllowed) {
+  // Point loops with a single edge should be allowed.
+  this->ExpectGeometryValid("## 0:0");
+
+  // Degenerate loops with a sibling edge pair should be allowed.
+  this->ExpectGeometryValid("## 0:0, 1:1");
+}
+
+TYPED_TEST(S2ValidTest, SplitInteriorsOk) {
+  // Chains touching at two points (splitting interior), should be fine.
+  this->ExpectGeometryValid(       //
+      "## 3:0, 0:-3, -3:0, 0:+3;"  //
+      "   3:0, 0:+1, -3:0, 0:-1"   //
+  );
+}
+
+TYPED_TEST(S2ValidTest, PolylineEdgesCrossSemanticsOk) {
+  // Interior crossings between polylines are ok.
+  this->ExpectGeometryValid(         //
+      "# 0:0, 1:1, 0:2, 1:3, 0:4 "   //
+      "| 1:0, 0:1, 1:2, 0:3, 1:4 #"  //
+  );
+
+  // Vertex crossings between polylines are ok.
+  this->ExpectGeometryValid(                             //
+      "# 0:0, 1:1, 2:2, 1:3, 0:4, 1:5, 2:6, 1:7, 0:8"    //
+      "| 2:0, 1:1, 0:2, 1:3, 2:4, 1:5, 0:6, 1:7, 2:8 #"  //
+  );
+
+  // Interior crossings within a polyline are ok.
+  this->ExpectGeometryValid(                                  //
+      "# 0:0, 1:1, 0:2, 1:3, 0:4, 1:4, 0:3, 1:2, 0:1, 1:0 #"  //
+  );
+
+  // Vertex crossings within a polyline are ok.
+  this->ExpectGeometryValid(                             //
+      "# 0:0, 1:1, 2:2, 1:3, 0:4, 1:5, 2:6, 1:7, 0:8,"   //
+      "  2:0, 1:1, 0:2, 1:3, 2:4, 1:5, 0:6, 1:7, 2:8 #"  //
+  );
+
+  // A closed loop that touches at the endpoints is ok.
+  this->ExpectGeometryValid(         //
+      "# 2:1, 1:0, 0:1, 1:2, 2:1 #"  //
+  );
+
+  // Two polylines touching at endpoints is also OK;
+  this->ExpectGeometryValid(  //
+      "# 0:0, 1:1, 0:2"       //
+      "| 1:3, 0:4, 1:5 #"     //
+  );
+}
+
+TYPED_TEST(S2ValidTest, ReverseDuplicateOnCenterWorks) {
+  // A pair of reverse duplicate edges touching the cell center should work.
+  this->ExpectGeometryValid(      //
+      "## 2:0, 0:-2, -2:0, 0:2;"  //
+      "   0:0, 1:1");
+}
+
+TYPED_TEST(S2ValidTest, PolygonOnCentersWorks) {
+  // Draw a nested-diamond polygon using 8 cells straddling the equator/prime
+  // meridian.  The chain orientation check will have to fall back to a brute
+  // force check but these should still work.
+  const vector<vector<S2Point>> kPoints = {
+      {
+          S2Cell(S2CellId::FromToken("0ec")).GetCenter(),
+          S2Cell(S2CellId::FromToken("044")).GetCenter(),
+          S2Cell(S2CellId::FromToken("1bc")).GetCenter(),
+          S2Cell(S2CellId::FromToken("114")).GetCenter(),
+      },
+      {
+          S2Cell(S2CellId::FromToken("104")).GetCenter(),
+          S2Cell(S2CellId::FromToken("1ac")).GetCenter(),
+          S2Cell(S2CellId::FromToken("054")).GetCenter(),
+          S2Cell(S2CellId::FromToken("0fc")).GetCenter(),
+      }};
+
+  this->ExpectShapeValid(make_unique<S2LaxPolygonShape>(kPoints));
+}
+
+TYPED_TEST(S2ValidTest, DegeneratePolygonOnCentersworks) {
+  // Now to be really rude and test a polygon consisting of nothing but
+  // reverse-duplicate pairs between cell centers.
+  const vector<vector<S2Point>> kPoints = {{
+      S2Cell(S2CellId::FromToken("0ec")).GetCenter(),
+      S2Cell(S2CellId::FromToken("044")).GetCenter(),
+      S2Cell(S2CellId::FromToken("1bc")).GetCenter(),
+      S2Cell(S2CellId::FromToken("114")).GetCenter(),
+      S2Cell(S2CellId::FromToken("1bc")).GetCenter(),
+      S2Cell(S2CellId::FromToken("044")).GetCenter(),
+  }};
+
+  this->ExpectShapeValid(make_unique<S2LaxPolygonShape>(kPoints));
+
+  // Same thing but the polygon just goes out at a diagonal and back.
+  const std::string tokens[] = {"1004", "1014", "1044", "1054", "1104", "1114"};
+
+  vector<vector<S2Point>> loops;
+  vector<S2Point> loop;
+  for (int i = 0; i < 6; ++i) {
+    loop.push_back(S2Cell(S2CellId::FromToken(tokens[i])).GetCenter());
+  }
+
+  for (int i = 4; i > 0; --i) {
+    loop.push_back(S2Cell(S2CellId::FromToken(tokens[i])).GetCenter());
+  }
+  loops.push_back(std::move(loop));
+
+  this->ExpectShapeValid(make_unique<S2LaxPolygonShape>(loops));
+}
+
+//////////////////   S2LegacyValid Tests   ////////////////////
+
+// Define test suite for legacy validation query only.
+template <typename IndexType>
+using S2LegacyValidTest = ValidationQueryTest<IndexType>;
+
+TYPED_TEST_SUITE(S2LegacyValidTest,                                         //
+                 ::testing::Types<S2LegacyValidQuery<MutableS2ShapeIndex>>  //
+);
+
+TYPED_TEST(S2LegacyValidTest, QuiltIsNotValid) {
+  // The quilt has reverse duplicate edges near the poles.
+  this->ExpectShapeInvalid(MakeQuilt(), S2Error::OVERLAPPING_GEOMETRY);
+}
+
+TYPED_TEST(S2LegacyValidTest, MultiDimensionalFails) {
+  // Multi-dimensional geometry shouldn't be allowed.
+  this->ExpectGeometryInvalid(    //
+      "  3:0| 0:-3| -3:0| 0:3"    //
+      "# 2:0, 0:-2, -2:0, 0:2"    //
+      "# 1:0, 0:-1, -1:0, 0:1",   //
+      S2Error::INVALID_DIMENSION  //
+  );
+}
+
+TYPED_TEST(S2LegacyValidTest, SplitInteriorsOk) {
+  // Chains touching at two points (splitting interior), should be fine.
+  this->ExpectGeometryValid(       //
+      "## 3:0, 0:-3, -3:0, 0:+3;"  //
+      "   3:0, 0:+1, -3:0, 0:-1"   //
+  );
+}
+
+TYPED_TEST(S2LegacyValidTest, SelfTouchingLoopFails) {
+  // A loop that touches itself should fail.
+  this->ExpectGeometryInvalid("## 2:0, 0:-2, -2:0, -1:1, 0:-2, 1:1",
+                              S2Error::DUPLICATE_VERTICES);
+}
+
+TYPED_TEST(S2LegacyValidTest, DegenerateEdgesFail) {
+  // A degenerate polygon edge should fail.
+  this->ExpectGeometryInvalid("## 2:0, 2:0, 0:-2, -2:0, 0:-2",
+                              S2Error::DUPLICATE_VERTICES);
+
+  // A degenerate polyline edge should fail.
+  this->ExpectGeometryInvalid("# 0:0, 0:0, 1:1, 2:2 #",
+                              S2Error::DUPLICATE_VERTICES);
+}
+
+TYPED_TEST(S2LegacyValidTest, ShortChainsFail) {
+  const S2Error::Code kCode = S2Error::LOOP_NOT_ENOUGH_VERTICES;
+
+  // A polygon chain with one or two edges should fail.
+  this->ExpectGeometryInvalid("## 0:0", kCode);
+  this->ExpectGeometryInvalid("## 0:0, 1:1", kCode);
+}
+
+}  // namespace

--- a/src/s2/s2winding_operation.cc
+++ b/src/s2/s2winding_operation.cc
@@ -25,6 +25,7 @@
 
 #include "absl/base/optimization.h"
 #include "absl/log/absl_check.h"
+#include "absl/types/span.h"
 #include "s2/id_set_lexicon.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1angle.h"
@@ -206,8 +207,8 @@ class WindingLayer : public S2Builder::Layer {
  private:
   bool ComputeBoundary(const Graph& g, WindingOracle* oracle, S2Error* error);
   EdgeId GetContainingLoopEdge(VertexId v, EdgeId start, const Graph& g,
-                               const vector<EdgeId>& left_turn_map,
-                               const vector<EdgeId>& sibling_map) const;
+                               absl::Span<const EdgeId> left_turn_map,
+                               absl::Span<const EdgeId> sibling_map) const;
   bool MatchesRule(int winding) const;
   bool MatchesDegeneracy(int winding, int winding_minus, int winding_plus)
       const;
@@ -387,8 +388,8 @@ bool WindingLayer::ComputeBoundary(const Graph& g, WindingOracle* oracle,
 // that contains "v" with respect to the usual semi-open boundary rules.
 EdgeId WindingLayer::GetContainingLoopEdge(
     VertexId v, EdgeId start, const Graph& g,
-    const vector<EdgeId>& left_turn_map,
-    const vector<EdgeId>& sibling_map) const {
+    absl::Span<const EdgeId> left_turn_map,
+    absl::Span<const EdgeId> sibling_map) const {
   // If the given edge is degenerate, this is an isolated vertex.
   ABSL_DCHECK_EQ(g.edge(start).second, v);
   if (g.edge(start).first == v) return start;

--- a/src/s2/s2winding_operation_test.cc
+++ b/src/s2/s2winding_operation_test.cc
@@ -18,7 +18,6 @@
 #include "s2/s2winding_operation.h"
 
 #include <cmath>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,6 +31,7 @@
 #include "absl/random/random.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "s2/mutable_s2shape_index.h"
 #include "s2/s1angle.h"
 #include "s2/s2boolean_operation.h"
@@ -72,7 +72,7 @@ namespace {
 // distinguish empty from full polygons, and we don't need its ability to
 // match edge multiplicities here.)
 void ExpectWindingResult(const S2WindingOperation::Options& options,
-                         const vector<string>& loop_strs,
+                         absl::Span<const string> loop_strs,
                          string_view ref_point_str, int ref_winding,
                          S2WindingOperation::WindingRule rule,
                          string_view expected_str) {

--- a/src/s2/sequence_lexicon.h
+++ b/src/s2/sequence_lexicon.h
@@ -18,9 +18,8 @@
 #ifndef S2_SEQUENCE_LEXICON_H_
 #define S2_SEQUENCE_LEXICON_H_
 
-#include <cstddef>
-
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iterator>

--- a/src/s2/util/bits/bits.h
+++ b/src/s2/util/bits/bits.h
@@ -24,18 +24,6 @@
 // Use namespace because this used to be a static class.
 namespace Bits {
 
-inline int FindLSBSetNonZero(uint32_t n) {
-  // TODO: Investigate whether ABSL_ASSUME is needed at all, or if clang
-  // and gcc can prove the argument is non-zero where these are used.
-  ABSL_ASSUME(n != 0);
-  return absl::countr_zero(n);
-}
-
-inline int FindLSBSetNonZero64(uint64_t n) {
-  ABSL_ASSUME(n != 0);
-  return absl::countr_zero(n);
-}
-
 inline int Log2FloorNonZero(uint32_t n) {
   ABSL_ASSUME(n != 0);
   return absl::bit_width(n) - 1;
@@ -45,9 +33,6 @@ inline int Log2FloorNonZero64(uint64_t n) {
   ABSL_ASSUME(n != 0);
   return absl::bit_width(n) - 1;
 }
-
-inline int FindMSBSetNonZero(uint32_t n) { return Log2FloorNonZero(n); }
-inline int FindMSBSetNonZero64(uint64_t n) { return Log2FloorNonZero64(n); }
 
 inline int Log2Ceiling(uint32_t n) {
   int floor = absl::bit_width(n) - 1;

--- a/src/s2/util/coding/BUILD
+++ b/src/s2/util/coding/BUILD
@@ -16,6 +16,7 @@ cc_library(
         "//s2/base:casts",
         "//s2/base:types",
         "//s2/base:logging",
+        "//s2/base:malloc_extension",
         "//s2/base:port",
         "//s2/util/bits",
         "//s2/util/endian",

--- a/src/s2/util/coding/coder.cc
+++ b/src/s2/util/coding/coder.cc
@@ -18,15 +18,16 @@
 
 #include "s2/util/coding/coder.h"
 
-#include <cassert>
-
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <tuple>
 #include <utility>
 
 #include "absl/log/absl_check.h"
+#include "absl/utility/utility.h"
 
+#include "s2/base/malloc_extension.h"
 #include "s2/base/types.h"
 
 Encoder::Encoder(Encoder&& other)
@@ -55,12 +56,12 @@ int Encoder::varint32_length(uint32_t v) { return Varint::Length32(v); }
 int Encoder::varint64_length(uint64_t v) { return Varint::Length64(v); }
 
 std::pair<unsigned char*, size_t> Encoder::NewBuffer(size_t size) {
-  auto* p = std::allocator<unsigned char>().allocate(size);
-  return {p, size};
+  auto res = __size_returning_new(size);
+  return {static_cast<unsigned char*>(res.p), res.n};
 }
 
 void Encoder::DeleteBuffer(unsigned char* buf, size_t size) {
-  std::allocator<unsigned char>().deallocate(buf, size);
+  base::sized_delete(buf, size);
 }
 
 void Encoder::EnsureSlowPath(size_t N) {

--- a/src/s2/util/gtl/BUILD
+++ b/src/s2/util/gtl/BUILD
@@ -3,4 +3,7 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "gtl",
     hdrs = glob(["*.h"]),
+    deps = [
+        "//s2/base:malloc_extension",
+    ],
 )

--- a/src/s2/util/gtl/compact_array.h
+++ b/src/s2/util/gtl/compact_array.h
@@ -56,8 +56,7 @@
 #include "absl/log/absl_log.h"
 #include "absl/meta/type_traits.h"
 
-#include "s2/base/port.h"
-#include "s2/base/types.h"
+#include "s2/base/malloc_extension.h"
 #include "s2/util/bits/bits.h"
 #include "s2/util/gtl/container_logging.h"
 
@@ -74,7 +73,6 @@ class compact_array_base {
   // kMaxSize is the maximum size this array can grow.
   static const int kMaxSize = (1 << kSizeNumBits) - 1;
 
-#ifdef IS_LITTLE_ENDIAN
   uint32_t size_ : kSizeNumBits;          // number of valid items in the array
   uint32_t capacity_ : kCapacityNumBits;  // allocated array size
   uint32_t is_exponent_ : 1;              // whether capacity_ is an exponent
@@ -83,12 +81,6 @@ class compact_array_base {
   // other data structures. We reserved the DO_NOT_USE (32nd bit in
   // little endian format) to be used as a tag.
   uint32_t DO_NOT_USE : 1;
-#else
-  uint32_t DO_NOT_USE : 1;
-  uint32_t is_exponent_ : 1;
-  uint32_t capacity_ : kCapacityNumBits;
-  uint32_t size_ : kSizeNumBits;
-#endif
 
   // Opportunistically consider allowing inlined elements.
 #if defined(_LP64) && defined(__GNUC__)
@@ -396,7 +388,11 @@ class compact_array_base {
   void reallocate(size_type n) {
     size_type old_capacity = capacity();
     if (n <= old_capacity) return;
-    set_capacity(n);
+    size_type new_n = n;
+    if (new_n > kInlined) {
+      new_n = nallocx(n * sizeof(T), 0) / sizeof(T);
+    }
+    set_capacity(new_n);
     if (MayBeInlined()) {
       if (!IsInlined() && n <= kInlined) {
         SetInlined();

--- a/src/s2/util/gtl/dense_hash_set.h
+++ b/src/s2/util/gtl/dense_hash_set.h
@@ -185,11 +185,6 @@ class dense_hash_set {
       "absl::flat_hash_set.")
   local_iterator begin(size_type i) const { return rep.begin(i); }
 
-  ABSL_DEPRECATED(
-      "This method is slated for removal.  Please migrate to "
-      "absl::flat_hash_set.")
-  local_iterator end(size_type i) const { return rep.end(i); }
-
   // Accessor functions
   allocator_type get_allocator() const { return rep.get_allocator(); }
   hasher hash_funct() const { return rep.hash_funct(); }

--- a/src/s2/util/gtl/densehashtable.h
+++ b/src/s2/util/gtl/densehashtable.h
@@ -1009,11 +1009,6 @@ class dense_hashtable {
            "Using the deleted key as a regular key");
   }
 
-  template <class K>
-  std::pair<size_type, size_type> find_position(const K& key) const {
-    return find_position_using_hash(hash(key), key);
-  }
-
   // Returns a pair of positions: 1st where the object is, 2nd where
   // it would go if you wanted to insert it.  1st is ILLEGAL_BUCKET
   // if object is not found; 2nd is ILLEGAL_BUCKET if it is.

--- a/src/s2/util/math/mathutil.h
+++ b/src/s2/util/math/mathutil.h
@@ -24,9 +24,6 @@
 #include <cstdint>
 #include <type_traits>
 
-#include "absl/log/absl_check.h"
-#include "s2/util/bits/bits.h"
-
 // Returns the sign of x:
 //   -1 if x < 0,
 //   +1 if x > 0,
@@ -165,56 +162,6 @@ class MathUtil {
 #else
     return Round<int64_t, double>(x);
 #endif  // if defined __GNUC__ && ...
-  }
-
-  // Computes v^i, where i is a non-negative integer.
-  // When T is a floating point type, this has the same semantics as pow(), but
-  // is much faster.
-  // T can also be any integral type, in which case computations will be
-  // performed in the value domain of this integral type, and overflow semantics
-  // will be those of T.
-  // You can also use any type for which operator*= is defined.
-  template <typename T>
-  static T IPow(T base, int exp) {
-    ABSL_DCHECK_GE(exp, 0);
-    uint32_t uexp = static_cast<uint32_t>(exp);
-
-    if (uexp < 16) {
-      T result = (uexp & 1) ? base : static_cast<T>(1);
-      if (uexp >= 2) {
-        base *= base;
-        if (uexp & 2) {
-          result *= base;
-        }
-        if (uexp >= 4) {
-          base *= base;
-          if (uexp & 4) {
-            result *= base;
-          }
-          if (uexp >= 8) {
-            base *= base;
-            result *= base;
-          }
-        }
-      }
-      return result;
-    }
-
-    T result = base;
-    int count = 31 ^ Bits::Log2FloorNonZero(uexp);
-
-    uexp <<= count;
-    count ^= 31;
-
-    while (count--) {
-      uexp <<= 1;
-      result *= result;
-      if (uexp >= 0x80000000) {
-        result *= base;
-      }
-    }
-
-    return result;
   }
 };
 

--- a/src/s2/value_lexicon.h
+++ b/src/s2/value_lexicon.h
@@ -19,7 +19,6 @@
 #define S2_VALUE_LEXICON_H_
 
 #include <cstddef>
-
 #include <cstdint>
 #include <functional>
 #include <limits>

--- a/src/s2/value_lexicon_test.cc
+++ b/src/s2/value_lexicon_test.cc
@@ -17,10 +17,9 @@
 
 #include "s2/value_lexicon.h"
 
-#include <cstring>
-
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <utility>
 


### PR DESCRIPTION
* Now requires abseil-cpp LTS 20240116
* S2Shape derived classes: Add decoding interface with S2Error
* S2Error: Interface is now similar to absl::Status, just with a
  different error code type.  In the future, this will probably
  be replaced by absl::Status.
* S2CellId: Made some functions constexpr
* S2DensityTree: Improved documentation of weight function
* s2edge_crossings: Fix CompareEdges for a case that never happens
* Optimize some functions using sincos() when available.
* S2Projection: Fix numerical issue
* S2Polygon uses new S2LegacyValidQuery to validate geometry.
* S2ValidationQuery: New class