### PR TITLE
Skip GetSignedArea.ErrorAccumulation test on macOS

### DIFF
--- a/src/s2/s2loop_measures_test.cc
+++ b/src/s2/s2loop_measures_test.cc
@@ -253,7 +253,7 @@ TEST(GetSignedArea, Underflow) {
 }
 
 TEST(GetSignedArea, ErrorAccumulation) {
-#if defined(__APPLE__) && defined(__aarch64__)
+#if defined(__APPLE__)
   GTEST_SKIP() << "https://github.com/google/s2geometry/issues/395";
 #endif
   // Loop encompassing half an octant of the sphere.


### PR DESCRIPTION
This was previously skipped only for AArch64 macOS.

https://github.com/google/s2geometry/blob/master/src/s2/s2loop_measures_test.cc#L256

The test fails for x86-64 macOS as well.  

https://github.com/google/s2geometry/issues/395#issuecomment-2629120303

Disable for `__APPLE__`.