### PR TITLE
workflows: Disable macos and enable ubuntu-22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,13 @@ jobs:
     strategy:
       matrix:
         runs-on:
+          - ubuntu-22.04
           - ubuntu-latest
-          # macos-13 is an intel runner, macos-14 is apple silicon
-          - macos-13
-          - macos-latest
+          - macos-13-large
+          # Can't add macos-13-xlarge due to
+          # https://github.com/zacharyburnett/setup-abseil-cpp/issues/4
+          - macos-latest-large
+          - macos-latest-xlarge
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,14 @@ jobs:
     strategy:
       matrix:
         runs-on:
+          - ubuntu-22.04
           - ubuntu-latest
-          # macos-13 is an intel runner, macos-14 is apple silicon
           - macos-13
-          - macos-latest
+          # Can't add macos-13-xlarge due to
+          # https://github.com/zacharyburnett/setup-abseil-cpp/issues/4
+          - macos-latest-large
+          # Disable macos-latest-xlarge due to timouts:
+          # https://github.com/google/s2geometry/issues/409
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30


### PR DESCRIPTION
Disable test/macos-latest due to timeouts.
https://github.com/google/s2geometry/issues/409

Enable ubuntu-22.