### PR TITLE
S1Angle::SinCos: Disable sincos for glibc

### DIFF
--- a/src/s2/s1angle.h
+++ b/src/s2/s1angle.h
@@ -332,7 +332,10 @@ inline S1Angle::SinCosPair S1Angle::SinCos() const {
 // TODO(b/370513151): Remove once Clang can optimize this.
 // NB: __sincos() provided by __APPLE__ is not bit-identical to sin(), cos()
 // under `--config=darwin_arm64`.
-#if defined(__GLIBC__) || defined(__ANDROID__)
+// `sincos` gives different results on Ubuntu 22.  Disable for glibc until
+// this can be narrowed down further.
+// https://github.com/google/s2geometry/issues/413
+#if defined(__ANDROID__)
   double sin_angle, cos_angle;
   sincos(radians(), &sin_angle, &cos_angle);
   return {sin_angle, cos_angle};


### PR DESCRIPTION
S1Angle.Trigonometry fails on Ubuntu 22.  Disable for all glibc targets until this can be narrowed down further.

```
/home/runner/work/s2geometry/s2geometry/src/s2/s1angle_test.cc:139: Failure
Expected equality of these values:
  sin_cos.cos
    Which is: -0.2[58](https://github.com/google/s2geometry/actions/runs/13603572823/job/38032416706?pr=412#step:8:59)81904510251996
  cos(angle)
    Which is: -0.25881904510251991

[  FAILED  ] S1Angle.Trigonometry (0 ms)
```