### PR TITLE
workflows: Bump setup-abseil-cpp version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     steps:
-      - uses: zacharyburnett/setup-abseil-cpp@de39f445295c887839e30c864ffbbb1c0231bc83 # 1.0.5
+      - uses: zacharyburnett/setup-abseil-cpp@dfe299c5b1cad83ac96bb41461fea4296bf1a47c # Not a release, but has #423 fix.
         with:
           cmake-build-args: "-DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON -DBUILD_TESTING=off -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
           abseil-version: "20240722.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     env:
       CTEST_OUTPUT_ON_FAILURE: ON
     steps:
-      - uses: zacharyburnett/setup-abseil-cpp@de39f445295c887839e30c864ffbbb1c0231bc83 # 1.0.5
+      - uses: zacharyburnett/setup-abseil-cpp@dfe299c5b1cad83ac96bb41461fea4296bf1a47c # Not a release, but has #423 fix.
         with:
           cmake-build-args: "-DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON -DBUILD_TESTING=off -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
           abseil-version: "20240722.0"


### PR DESCRIPTION
Bump zacharyburnett/setup-abseil-cpp version to hash that includes new actions/cache version from
https://github.com/zacharyburnett/setup-abseil-cpp/pull/5.

There is no corresponding release.

Fixes #423.