### PR TITLE
test.yml: build with --parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,5 +40,5 @@ jobs:
       - run: mkdir build
       - run: cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=/usr/local/ -DBUILD_TESTS=OFF ..
         working-directory: build/
-      - run: sudo cmake --build . --parallel --target=install
+      - run: sudo cmake --build . --parallel 45 --target=install
         working-directory: build/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,8 @@ jobs:
       - run: mkdir build
       - run: cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_PREFIX_PATH=/usr/local/ -DGOOGLETEST_ROOT=${{ env.GOOGLETEST_ROOT }} -DGOOGLETEST_VERSION=${{ env.GOOGLETEST_VERSION }} ..
         working-directory: build/
-      - run: cmake --build . ${{ runner.os == 'macOS' && '--parallel' || '' }}
-        # building tests with `--parallel` is disabled on Linux because GitHub seems to automatically cancel the job due to resource limits(?) 
+      - run: cmake --build . --parallel 45
         working-directory: build/
       - if: always()
-        run: cmake --build . --parallel --target=test
+        run: cmake --build . --parallel 45 --target=test
         working-directory: build/


### PR DESCRIPTION
This was disabled for Linux because the jobs were getting cancelled.  It is far too slow building sequentially (8 minutes instead of 1 minutes), so try re-enabling it.