### PR TITLE
GetCommonAncestorLevel: work around bit_width return type bug

### DIFF
--- a/src/s2/s2cell_id.cc
+++ b/src/s2/s2cell_id.cc
@@ -204,7 +204,7 @@ int S2CellId::GetCommonAncestorLevel(S2CellId other) const {
   // Compute the position of the most significant bit, and then map the bit
   // position as follows:
   // {0} -> 30, {1,2} -> 29, {3,4} -> 28, ... , {59,60} -> 0, {61,62,63} -> -1.
-  return max(61 - absl::bit_width(bits), -1) >> 1;
+  return max(static_cast<int>(61 - absl::bit_width(bits)), -1) >> 1;
 }
 
 // Print the num_digits low order hex digits.

--- a/src/s2/s2cell_id.cc
+++ b/src/s2/s2cell_id.cc
@@ -204,8 +204,9 @@ int S2CellId::GetCommonAncestorLevel(S2CellId other) const {
   // Compute the position of the most significant bit, and then map the bit
   // position as follows:
   // {0} -> 30, {1,2} -> 29, {3,4} -> 28, ... , {59,60} -> 0, {61,62,63} -> -1.
-  // Work around https://github.com/abseil/abseil-cpp/issues/1890 with `static_cast`.
-  // This can be removed when we requires an abseil-cpp LTS with the fix, perhaps 2025-07.
+  // Work around https://github.com/abseil/abseil-cpp/issues/1890 with
+  // `static_cast`.  This can be removed when we require an abseil-cpp LTS
+  // with the fix, perhaps 2025-07.
   return max(61 - static_cast<int>(absl::bit_width(bits)), -1) >> 1;
 }
 

--- a/src/s2/s2cell_id.cc
+++ b/src/s2/s2cell_id.cc
@@ -204,7 +204,9 @@ int S2CellId::GetCommonAncestorLevel(S2CellId other) const {
   // Compute the position of the most significant bit, and then map the bit
   // position as follows:
   // {0} -> 30, {1,2} -> 29, {3,4} -> 28, ... , {59,60} -> 0, {61,62,63} -> -1.
-  return max(static_cast<int>(61 - absl::bit_width(bits)), -1) >> 1;
+  // Work around https://github.com/abseil/abseil-cpp/issues/1890 with `static_cast`.
+  // This can be removed when we requires an abseil-cpp LTS with the fix, perhaps 2025-07.
+  return max(61 - static_cast<int>(absl::bit_width(bits)), -1) >> 1;
 }
 
 // Print the num_digits low order hex digits.


### PR DESCRIPTION
This is meant to work around the situation when `absl::bit_width` is `unsigned long`.
```
error: no matching function for call to 'max'
[build]   return max(61 - absl::bit_width(bits), -1) >> 1;
[build]          ^~~
[build] /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/algorithmfwd.h:407:5: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned long' vs. 'int')
```

ref https://github.com/abseil/abseil-cpp/issues/1890
ref https://github.com/google/s2geometry/pull/421#discussion_r2095372420

System: Debian 12
Compiler: Clang-15 