### PR TITLE
Add tag_regex for dynamic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,6 @@ namespaces = false
 "" = "src"
 
 [tool.setuptools_scm]
+# The same as the default.  See #450.
+# https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm._config.DEFAULT_TAG_REGEX
 tag_regex = "^(?:[\\w-]+-)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"


### PR DESCRIPTION
* Fix for issue #450 
* Explicitly adds the default tag regex defined in [setuptools_scm](https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm._config.DEFAULT_TAG_REGEX)
* Before fix
```sh
> python -m build --wheel "-C--global-option=build_ext" "-C--global-option=-DBUILD_TESTS=OFF;Python3_FIND_VIRTUALENV=ONLY"
...
removing build/bdist.macosx-15.0-arm64/wheel
Successfully built s2geometry-0.0.0-cp312-cp312-macosx_15_0_arm64.whl
```
* After fix
```sh
> python -m build --wheel "-C--global-option=build_ext" "-C--global-option=-DBUILD_TESTS=OFF;Python3_FIND_VIRTUALENV=ONLY"
...
removing build/bdist.macosx-15.0-arm64/wheel
Successfully built s2geometry-0.12.1.dev28+g672409037-cp312-cp312-macosx_15_0_arm64.whl
```