### PR TITLE
Fix bazel build

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -237,7 +237,6 @@ cc_library(
     ],
     deps = [
         "//s2/base:commandlineflags",
-        "//s2/base:types",
         "//s2/base:logging",
         "//s2/base:port",
         "//s2/base:spinlock",

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -11,7 +11,7 @@ cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_exten
 use_repo(cc_configure, "local_config_cc")
 
 bazel_dep(name = "boringssl", version = "0.20250514.0")
-bazel_dep(name = "abseil-cpp", version = "20250127.1")
+bazel_dep(name = "abseil-cpp", version = "20250814.1")
 bazel_dep(name = "googletest", version = "1.17.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 

--- a/src/s2/base/BUILD
+++ b/src/s2/base/BUILD
@@ -22,11 +22,6 @@ cc_library(
 )
 
 cc_library(
-    name = "types",
-    hdrs = ["types.h"],
-)
-
-cc_library(
     name = "casts",
     hdrs = ["casts.h"],
     deps = [
@@ -46,7 +41,6 @@ cc_library(
         "commandlineflags_declare.h",
     ],
     deps = [
-        ":types",
         "@abseil-cpp//absl/flags:flag",
     ],
 )
@@ -62,5 +56,8 @@ cc_library(
     name = "spinlock",
     hdrs = [
         "spinlock.h",
+    ],
+    deps = [
+        "@abseil-cpp//absl/base:core_headers",
     ],
 )

--- a/src/s2/base/spinlock.h
+++ b/src/s2/base/spinlock.h
@@ -18,7 +18,7 @@
 
 #include <atomic>
 
-#include <absl/base/thread_annotations.h>
+#include "absl/base/thread_annotations.h"
 
 class ABSL_LOCKABLE ABSL_ATTRIBUTE_WARN_UNUSED SpinLock {
  public:

--- a/src/s2/util/bits/BUILD
+++ b/src/s2/util/bits/BUILD
@@ -3,11 +3,5 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "bits",
     srcs = ["bit-interleave.cc"],
-    hdrs = [
-        "bit-interleave.h",
-        "bits.h",
-    ],
-    deps = [
-        "//s2/base:types",
-    ],
+    hdrs = ["bit-interleave.h"],
 )

--- a/src/s2/util/coding/BUILD
+++ b/src/s2/util/coding/BUILD
@@ -14,7 +14,6 @@ cc_library(
     ],
     deps = [
         "//s2/base:casts",
-        "//s2/base:types",
         "//s2/base:logging",
         "//s2/base:malloc_extension",
         "//s2/base:port",

--- a/src/s2/util/math/BUILD
+++ b/src/s2/util/math/BUILD
@@ -10,7 +10,6 @@ cc_library(
     srcs = ["mathutil.cc"],
     hdrs = ["mathutil.h"],
     deps = [
-        "//s2/base:types",
         "//s2/util/bits",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",

--- a/src/s2/util/math/exactfloat/BUILD
+++ b/src/s2/util/math/exactfloat/BUILD
@@ -5,7 +5,6 @@ cc_library(
     srcs = ["exactfloat.cc"],
     hdrs = ["exactfloat.h"],
     deps = [
-        "//s2/base:types",
         "//s2/base:port",
         "//s2/base:logging",
         "@abseil-cpp//absl/log:log",


### PR DESCRIPTION
This should have been in f80b725a8fe1, but was missed.

* Remove util/bits/bits.h from BUILD files; it has been deleted.
* Bump abseil-cpp version.
* Fix spinlock deps and includes.