### PR TITLE
Update to 2025-11-06 google3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ This issue may require revision of boringssl or exactfloat.
 *   A C++ compiler with C++17 support, such as
     [g++ >= 7.5](https://gcc.gnu.org/) or
     [clang >= 14.0.0](https://clang.llvm.org/)
-*   [Abseil](https://github.com/abseil/abseil-cpp) >= LTS
+*   [Abseil](https://github.com/abseil/abseil-cpp) LTS
     [`20250814`](https://github.com/abseil/abseil-cpp/releases/tag/20250814.1)
-    (standard library extensions)
+    (standard library extensions). This exact version must be used.
 *   [OpenSSL](https://github.com/openssl/openssl) (for its bignum library)
 *   [googletest testing framework >= 1.10](https://github.com/google/googletest)
     (to build tests and example programs, optional)

--- a/src/s2/encoded_uint_vector.h
+++ b/src/s2/encoded_uint_vector.h
@@ -32,7 +32,7 @@
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/util/coding/coder.h"
 #include "s2/util/coding/varint.h"
-#include "s2/util/gtl/unaligned.h"
+#include "s2/util/endian/endian.h"
 
 namespace s2coding {
 
@@ -175,17 +175,15 @@ inline T GetUintWithLength(const char* ptr, int length) {
   // following page in the address space is unmapped.)
 
   if (length & sizeof(T)) {
-    // If we care about big-endian, we need to use `LittleEndian::Load*()` here.
-    static_assert(absl::endian::native == absl::endian::little);
-    return gtl::UnalignedLoad<T>(ptr);
+    return LittleEndian::Load<T>(ptr);
   }
   T x = 0;
   ptr += length;
   if (sizeof(T) > 4 && (length & 4)) {
-    x = gtl::UnalignedLoad<uint32_t>(ptr -= sizeof(uint32_t));
+    x = LittleEndian::Load<uint32_t>(ptr -= sizeof(uint32_t));
   }
   if (sizeof(T) > 2 && (length & 2)) {
-    x = (x << 16) + gtl::UnalignedLoad<uint16_t>(ptr -= sizeof(uint16_t));
+    x = (x << 16) + LittleEndian::Load<uint16_t>(ptr -= sizeof(uint16_t));
   }
   if (sizeof(T) > 1 && (length & 1)) {
     x = (x << 8) + static_cast<uint8_t>(*--ptr);

--- a/src/s2/s2cell_iterator_join.h
+++ b/src/s2/s2cell_iterator_join.h
@@ -318,7 +318,7 @@ bool S2CellIteratorJoin<A, B>::ProcessNearby(absl::Span<const S2Cell> cells_a,
   for (const S2Cell& cell_a : cells_a) {
     nearby_cells.clear();
     for (const S2Cell& cell_b : cells_b) {
-      if (cell_a.GetDistance(cell_b) <= tolerance_) {
+      if (cell_a.IsDistanceLessOrEqual(cell_b, tolerance_)) {
         nearby_cells.emplace_back(cell_b);
       }
     }
@@ -402,7 +402,8 @@ bool S2CellIteratorJoin<A, B>::ProcessCellPairs(
     for (int i = 0; i < cells_b.size() && success; ++i) {
       S2CellId id = cells_b[i].id();
       success &= ScanCellRange(iter_b_, id, [&](const auto& iter_b) {
-        if (sub_cell_a.GetDistance(matched_cells_[idx++]) <= tolerance_) {
+        if (sub_cell_a.IsDistanceLessOrEqual(matched_cells_[idx++],
+                                             tolerance_)) {
           if (!visitor(iter_a.iterator(), iter_b.iterator())) {
             return false;
           }

--- a/src/s2/s2cell_test.cc
+++ b/src/s2/s2cell_test.cc
@@ -72,12 +72,6 @@ using std::pow;
 using std::vector;
 using ::testing::Eq;
 
-// Reflects the center point of a cell across the given boundary.
-S2Point ReflectCenter(const S2Cell& cell, int k) {
-  Vector3_d normal = cell.GetEdgeRaw(k);
-  return Matrix3x3_d::Householder(normal) * cell.GetCenter();
-}
-
 TEST(S2Cell, TestFaces) {
   flat_hash_map<S2Point, int> edge_counts;
   flat_hash_map<S2Point, int> vertex_counts;
@@ -471,6 +465,9 @@ TEST(S2Cell, RectBoundIsLargeEnough) {
 TEST(S2Cell, ConsistentWithS2CellIdFromPoint) {
   // Construct many points that are nearly on an S2Cell edge, and verify that
   // S2Cell(S2CellId(p)).Contains(p) is always true.
+  //
+  // Note this is not actually the case and this test fails 3.5% of the time.
+  // TODO(b/416457492): Fix (S2Cell(S2CellId(point)) does not contain point).
   absl::BitGen bitgen(
       S2Testing::MakeTaggedSeedSeq("CONSISTENT_WITH_S2CELL_ID_FROM_POINT",
                               absl::LogInfoStreamer(__FILE__, __LINE__).stream()));

--- a/src/s2/s2coords.cc
+++ b/src/s2/s2coords.cc
@@ -19,99 +19,22 @@
 
 #include "absl/log/absl_check.h"
 #include "absl/numeric/bits.h"
-#include "s2/s2coords_internal.h"
 #include "s2/s2point.h"
 
 namespace S2 {
-
-namespace internal {
-
-// Define the "extern" constants in s2coords_internal.h.
-
-static_assert(kSwapMask == 0x01 && kInvertMask == 0x02, "masks changed");
-
-// kIJtoPos[orientation][ij] -> pos
-const int kIJtoPos[4][4] = {
-  // (0,0) (0,1) (1,0) (1,1)
-  {     0,    1,    3,    2  },  // canonical order
-  {     0,    3,    1,    2  },  // axes swapped
-  {     2,    3,    1,    0  },  // bits inverted
-  {     2,    1,    3,    0  },  // swapped & inverted
-};
-
-// kPosToIJ[orientation][pos] -> ij
-const int kPosToIJ[4][4] = {
-  // 0  1  2  3
-  {  0, 1, 3, 2 },    // canonical order:    (0,0), (0,1), (1,1), (1,0)
-  {  0, 2, 3, 1 },    // axes swapped:       (0,0), (1,0), (1,1), (0,1)
-  {  3, 2, 0, 1 },    // bits inverted:      (1,1), (1,0), (0,0), (0,1)
-  {  3, 1, 0, 2 },    // swapped & inverted: (1,1), (0,1), (0,0), (1,0)
-};
-
-// kPosToOrientation[pos] -> orientation_modifier
-const int kPosToOrientation[4] = {
-  kSwapMask,
-  0,
-  0,
-  kInvertMask + kSwapMask,
-};
-
-const int kFaceUVWFaces[6][3][2] = {
-  { { 4, 1 }, { 5, 2 }, { 3, 0 } },
-  { { 0, 3 }, { 5, 2 }, { 4, 1 } },
-  { { 0, 3 }, { 1, 4 }, { 5, 2 } },
-  { { 2, 5 }, { 1, 4 }, { 0, 3 } },
-  { { 2, 5 }, { 3, 0 }, { 1, 4 } },
-  { { 4, 1 }, { 3, 0 }, { 2, 5 } }
-};
-
-const double kFaceUVWAxes[6][3][3] = {
-  {
-    { 0,  1,  0 },
-    { 0,  0,  1 },
-    { 1,  0,  0 }
-  },
-  {
-    {-1,  0,  0 },
-    { 0,  0,  1 },
-    { 0,  1,  0 }
-  },
-  {
-    {-1,  0,  0 },
-    { 0, -1,  0 },
-    { 0,  0,  1 }
-  },
-  {
-    { 0,  0, -1 },
-    { 0, -1,  0 },
-    {-1,  0,  0 }
-  },
-  {
-    { 0,  0, -1 },
-    { 1,  0,  0 },
-    { 0, -1,  0 }
-  },
-  {
-    { 0,  1,  0 },
-    { 1,  0,  0 },
-    { 0,  0, -1 }
-  }
-};
-
-} // namespace internal
-
-
 
 S2Point FaceXYZtoUVW(int face, const S2Point& p) {
   // The result coordinates are simply the dot products of P with the (u,v,w)
   // axes for the given face (see kFaceUVWAxes).
   switch (face) {
+    // clang-format off
     case 0:  return S2Point( p.y(),  p.z(),  p.x());
     case 1:  return S2Point(-p.x(),  p.z(),  p.y());
     case 2:  return S2Point(-p.x(), -p.y(),  p.z());
     case 3:  return S2Point(-p.z(), -p.y(), -p.x());
     case 4:  return S2Point(-p.z(),  p.x(), -p.y());
     default: return S2Point( p.y(),  p.x(), -p.z());
+    // clang-format on
   }
 }
 

--- a/src/s2/s2coords_internal.h
+++ b/src/s2/s2coords_internal.h
@@ -19,6 +19,7 @@
 #define S2_S2COORDS_INTERNAL_H_
 
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
+
 namespace S2 {
 namespace internal {
 
@@ -34,15 +35,23 @@ namespace internal {
 // 'kInvertMask' is true, then the traversal order is rotated by 180
 // degrees (i.e. the bits of i and j are inverted, or equivalently,
 // the axis directions are reversed).
-int constexpr kSwapMask = 0x01;
-int constexpr kInvertMask = 0x02;
+inline constexpr int kSwapMask = 0x01;
+inline constexpr int kInvertMask = 0x02;
 
 // kIJtoPos[orientation][ij] -> pos
 //
 // Given a cell orientation and the (i,j)-index of a subcell (0=(0,0),
 // 1=(0,1), 2=(1,0), 3=(1,1)), return the order in which this subcell is
 // visited by the Hilbert curve (a position in the range [0..3]).
-extern const int kIJtoPos[4][4];
+inline constexpr int kIJtoPos[4][4] = {
+    // clang-format off
+    // (0,0) (0,1) (1,0) (1,1)
+    {     0,    1,    3,    2  },  // canonical order
+    {     0,    3,    1,    2  },  // axes swapped
+    {     2,    3,    1,    0  },  // bits inverted
+    {     2,    1,    3,    0  },  // swapped & inverted
+    // clang-format on
+};
 
 // kPosToIJ[orientation][pos] -> ij
 //
@@ -51,7 +60,15 @@ extern const int kIJtoPos[4][4];
 // inverse of the previous table:
 //
 //   kPosToIJ[r][kIJtoPos[r][ij]] == ij
-extern const int kPosToIJ[4][4];
+inline constexpr int kPosToIJ[4][4] = {
+    // clang-format off
+    // 0  1  2  3
+    {  0, 1, 3, 2 },    // canonical order:    (0,0), (0,1), (1,1), (1,0)
+    {  0, 2, 3, 1 },    // axes swapped:       (0,0), (1,0), (1,1), (0,1)
+    {  3, 2, 0, 1 },    // bits inverted:      (1,1), (1,0), (0,0), (0,1)
+    {  3, 1, 0, 2 },    // swapped & inverted: (1,1), (0,1), (0,0), (1,0)
+    // clang-format on
+};
 
 // kPosToOrientation[pos] -> orientation_modifier
 //
@@ -59,13 +76,57 @@ extern const int kPosToIJ[4][4];
 // with the given traversal position [0..3] is related to the orientation
 // of the parent cell.  The modifier should be XOR-ed with the parent
 // orientation to obtain the curve orientation in the child.
-extern const int kPosToOrientation[4];
+inline constexpr int kPosToOrientation[4] = {
+    kSwapMask, 0, 0, kInvertMask + kSwapMask,
+};
 
 // The U,V,W axes for each face.
-extern const double kFaceUVWAxes[6][3][3];
+inline constexpr double kFaceUVWAxes[6][3][3] = {
+    // clang-format off
+    {
+      { 0,  1,  0 },
+      { 0,  0,  1 },
+      { 1,  0,  0 }
+    },
+    {
+      {-1,  0,  0 },
+      { 0,  0,  1 },
+      { 0,  1,  0 }
+    },
+    {
+      {-1,  0,  0 },
+      { 0, -1,  0 },
+      { 0,  0,  1 }
+    },
+    {
+      { 0,  0, -1 },
+      { 0, -1,  0 },
+      {-1,  0,  0 }
+    },
+    {
+      { 0,  0, -1 },
+      { 1,  0,  0 },
+      { 0, -1,  0 }
+    },
+    {
+      { 0,  1,  0 },
+      { 1,  0,  0 },
+      { 0,  0, -1 }
+    }
+    // clang-format on
+};
 
 // The precomputed neighbors of each face (see GetUVWFace).
-extern const int kFaceUVWFaces[6][3][2];
+inline constexpr int kFaceUVWFaces[6][3][2] = {
+    // clang-format off
+    { { 4, 1 }, { 5, 2 }, { 3, 0 } },
+    { { 0, 3 }, { 5, 2 }, { 4, 1 } },
+    { { 0, 3 }, { 1, 4 }, { 5, 2 } },
+    { { 2, 5 }, { 1, 4 }, { 0, 3 } },
+    { { 2, 5 }, { 3, 0 }, { 1, 4 } },
+    { { 4, 1 }, { 3, 0 }, { 2, 5 } }
+    // clang-format on
+};
 
 }  // namespace internal
 }  // namespace S2

--- a/src/s2/s2density_tree.h
+++ b/src/s2/s2density_tree.h
@@ -280,6 +280,31 @@ class S2DensityTree {
   // is not necessarily normalized.
   S2CellUnion Leaves(S2Error* absl_nonnull error) const;
 
+  // Given an input S2DensityTree, returns a "dilated" tree, i.e. a new
+  // density tree that has weight in all areas within the given distance
+  // "radius" of the spatial boundary of the leaves of the tree.
+  //
+  // Dilation is required for creating density trees for clustering data for
+  // cases like a D-Within filter join, so that clusters created from the
+  // density tree will contain all pairs of features within distance "radius"
+  // of each other.
+  //
+  // Dilation is done by adding weights to neighbors of leaves of the tree. If
+  // the radius is small relative to the area covered by the density tree, the
+  // required size of the neighboring cells could also be small, resulting in
+  // an exponential blowup in the number of cells in the tree. The
+  // 'max_level_diff' parameter prevents this by limiting the level of
+  // neighboring added cells, relative to the size of the leaf being dilated.
+  // Therefore there is a tradeoff between dilation accuracy and tree size: a
+  // higher max_level_diff will add more, smaller cells.
+  //
+  // If the dilation radius is large compared to cells in the tree, then
+  // dilation discards nodes with a cell level higher than the cell level
+  // required for dilation, and instead adds neighbors to nodes in the tree
+  // that are at the dilation cell level.
+  static S2DensityTree Dilate(const S2DensityTree& tree, S1Angle radius,
+                              int max_level_diff, S2Error* absl_nonnull error);
+
   // The decoded weight and offsets of encoded cells.
   class Cell {
    public:

--- a/src/s2/s2metrics.h
+++ b/src/s2/s2metrics.h
@@ -166,7 +166,8 @@ extern const double kMaxDiagAspect;
 
 template <int dim>
 int S2::Metric<dim>::GetLevelForMaxValue(double value) const {
-  if (value <= 0) return S2::kMaxCellLevel;
+  // Catches non-positive values, including NaN.
+  if (!(value > 0)) return S2::kMaxCellLevel;
 
   // This code is equivalent to computing a floating-point "level" value and
   // rounding up.  ilogb() returns the exponent corresponding to a fraction in
@@ -180,7 +181,8 @@ int S2::Metric<dim>::GetLevelForMaxValue(double value) const {
 
 template <int dim>
 int S2::Metric<dim>::GetLevelForMinValue(double value) const {
-  if (value <= 0) return S2::kMaxCellLevel;
+  // Catches non-positive values, including NaN.
+  if (!(value > 0)) return S2::kMaxCellLevel;
 
   // This code is equivalent to computing a floating-point "level" value and
   // rounding down.

--- a/src/s2/s2metrics_test.cc
+++ b/src/s2/s2metrics_test.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include <gtest/gtest.h>
 #include "s2/s2coords.h"
@@ -138,4 +139,21 @@ TEST(S2, Metrics) {
     EXPECT_EQ(S2::kMinArea.GetClosestLevel(1.2 * area), expected_level);
     EXPECT_EQ(S2::kMinArea.GetClosestLevel(0.8 * area), expected_level);
   }
+}
+
+TEST(S2, NaNInput) {
+  constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+  S2::LengthMetric metric_1d(1);
+  S2::AreaMetric metric_2d(1);
+
+  // The exact result is not specified and is not really important.
+  // The essential property is that we don't hit undefined behavior, so this
+  // test needs to be run with the `ubsan` enabled.
+  EXPECT_GE(metric_1d.GetLevelForMaxValue(kNaN), 0);
+  EXPECT_GE(metric_1d.GetLevelForMinValue(kNaN), 0);
+  EXPECT_GE(metric_1d.GetClosestLevel(kNaN), 0);
+
+  EXPECT_GE(metric_2d.GetLevelForMaxValue(kNaN), 0);
+  EXPECT_GE(metric_2d.GetLevelForMinValue(kNaN), 0);
+  EXPECT_GE(metric_2d.GetClosestLevel(kNaN), 0);
 }

--- a/src/s2/s2text_format.cc
+++ b/src/s2/s2text_format.cc
@@ -15,11 +15,13 @@
 
 #include "s2/s2text_format.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "absl/log/absl_check.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
@@ -73,7 +75,8 @@ vector<S2LatLng> ParseLatLngsOrDie(string_view str) {
 bool ParseLatLngs(string_view str, vector<S2LatLng>* latlngs) {
   for (const string_view lat_lng_str :
        absl::StrSplit(str, ',', absl::SkipEmpty())) {
-    const vector<string_view> lat_lng = absl::StrSplit(lat_lng_str, ':');
+    const absl::InlinedVector<string_view, 2> lat_lng =
+        absl::StrSplit(lat_lng_str, ':');
     if (lat_lng.size() != 2) return false;
     double lat, lng;
     if (!absl::SimpleAtod(lat_lng[0], &lat)) return false;
@@ -294,9 +297,8 @@ unique_ptr<MutableS2ShapeIndex> MakeIndexOrDie(string_view str) {
 }
 
 bool MakeIndex(string_view str, unique_ptr<MutableS2ShapeIndex>* index) {
-  vector<string_view> strs = absl::StrSplit(str, '#');
+  absl::InlinedVector<string_view, 3> strs = absl::StrSplit(str, '#');
   ABSL_DCHECK_EQ(3, strs.size()) << "Must contain two # characters: " << str;
-
   vector<S2Point> points;
   for (const auto& point_str : SplitString(strs[0], '|')) {
     S2Point point;

--- a/src/s2/util/endian/endian.h
+++ b/src/s2/util/endian/endian.h
@@ -58,6 +58,12 @@ class LittleEndian {
   }
 
   // Functions to do unaligned loads and stores in little-endian order.
+  template <typename T>
+  static T Load(const void* p) {
+    const char* pc = reinterpret_cast<const char*>(p);
+    return byteswap_if_big_endian(gtl::UnalignedLoad<T>(pc));
+  }
+
   static uint16_t Load16(const void* p) {
     const char* pc = reinterpret_cast<const char*>(p);
     return ToHost16(gtl::UnalignedLoad<uint16_t>(pc));

--- a/src/s2/util/math/exactfloat/exactfloat_underflow_test.cc
+++ b/src/s2/util/math/exactfloat/exactfloat_underflow_test.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 //
 
-#include <cmath>
-
 #include <gtest/gtest.h>
 #include "s2/util/math/exactfloat/exactfloat.h"
 
@@ -24,9 +22,9 @@ using ::exactfloat::ExactFloat;
 
 TEST(ExactFloatTest, Overflow) {
   // Construct an ExactFloat whose exponent is kMaxExp.
-  const int kMaxExp = exactfloat::ExactFloat::kMaxExp;
+  const int kMaxExp = ExactFloat::kMaxExp;
 
-  exactfloat::ExactFloat v = ldexp(exactfloat::ExactFloat(0.5), kMaxExp);
+  ExactFloat v = ldexp(ExactFloat(0.5), kMaxExp);
   EXPECT_FALSE(isinf(v));
   EXPECT_EQ(kMaxExp, v.exp());
 
@@ -41,16 +39,16 @@ TEST(ExactFloatTest, Overflow) {
 }
 
 TEST(ExactFloatTest, OverflowMaxExpAndPrecision) {
-  const int kMaxExp = exactfloat::ExactFloat::kMaxExp;
-  const int kMaxPrec = exactfloat::ExactFloat::kMaxPrec;
-  const int kMinExp = exactfloat::ExactFloat::kMinExp;
+  const int kMaxExp = ExactFloat::kMaxExp;
+  const int kMaxPrec = ExactFloat::kMaxPrec;
+  const int kMinExp = ExactFloat::kMinExp;
 
   // Now build an ExactFloat whose exponent and precision are both maximal (!)
-  const exactfloat::ExactFloat v =
-      ldexp(1.0 - ldexp(exactfloat::ExactFloat(1.0), -kMaxPrec), kMaxExp);
+  const ExactFloat v =
+      ldexp(1.0 - ldexp(ExactFloat(1.0), -kMaxPrec), kMaxExp);
   EXPECT_FALSE(isinf(v));
-  EXPECT_EQ(exactfloat::ExactFloat::kMaxExp, v.exp());
-  EXPECT_EQ(exactfloat::ExactFloat::kMaxPrec, v.prec());
+  EXPECT_EQ(ExactFloat::kMaxExp, v.exp());
+  EXPECT_EQ(ExactFloat::kMaxPrec, v.prec());
 
   // Try overflowing it in various ways.
   EXPECT_TRUE(
@@ -68,25 +66,25 @@ TEST(ExactFloatTest, OverflowMaxExpAndPrecision) {
 
   // Check that if kMaxExp and kMaxPrec are exceeded simultaneously, the
   // result is infinity rather than NaN.
-  exactfloat::ExactFloat a =
-      ldexp(1.0 - ldexp(exactfloat::ExactFloat(1.0), -kMaxPrec), kMaxExp);
-  exactfloat::ExactFloat b =
-      ldexp(1.0 - ldexp(exactfloat::ExactFloat(1.0), -kMaxPrec), kMaxExp - 1);
+  ExactFloat a =
+      ldexp(1.0 - ldexp(ExactFloat(1.0), -kMaxPrec), kMaxExp);
+  ExactFloat b =
+      ldexp(1.0 - ldexp(ExactFloat(1.0), -kMaxPrec), kMaxExp - 1);
   EXPECT_TRUE(isinf(a + b));
 }
 
 TEST(ExactFloatTest, Underflow) {
   // Construct an ExactFloat whose exponent is kMinExp.
-  const int kMinExp = exactfloat::ExactFloat::kMinExp;
-  const exactfloat::ExactFloat v = ldexp(exactfloat::ExactFloat(0.5), kMinExp);
+  const int kMinExp = ExactFloat::kMinExp;
+  const ExactFloat v = ldexp(ExactFloat(0.5), kMinExp);
   EXPECT_FALSE(v.is_zero());
   EXPECT_EQ(kMinExp, v.exp());
 
   // Now check that if the exponent is made smaller, it underflows.
   EXPECT_TRUE((0.5 * v).is_zero());
-  EXPECT_FALSE(exactfloat::signbit(0.5 * v));
+  EXPECT_FALSE(signbit(0.5 * v));
   EXPECT_TRUE((-0.5 * v).is_zero());
-  EXPECT_TRUE(exactfloat::signbit(-0.5 * v));
+  EXPECT_TRUE(signbit(-0.5 * v));
 
   // Check that underflowing the exponent a lot does not cause problems.
   EXPECT_TRUE((v * v).is_zero());
@@ -95,22 +93,22 @@ TEST(ExactFloatTest, Underflow) {
 // Skip this test for iOS* and Android because it times out constantly.
 #if !defined(__ANDROID__) && !defined(__APPLE__)
 TEST(ExactFloatTest, UnderflowMaxExpAndMinPrecision) {
-  const int kMinExp = exactfloat::ExactFloat::kMinExp;
-  const int kMaxPrec = exactfloat::ExactFloat::kMaxPrec;
+  const int kMinExp = ExactFloat::kMinExp;
+  const int kMaxPrec = ExactFloat::kMaxPrec;
 
   // Now build an ExactFloat whose exponent is minimal and whose precision is
   // maximal.
-  const exactfloat::ExactFloat v =
-      ldexp(1.0 - ldexp(exactfloat::ExactFloat(1.0), -kMaxPrec), kMinExp);
+  const ExactFloat v =
+      ldexp(1.0 - ldexp(ExactFloat(1.0), -kMaxPrec), kMinExp);
   EXPECT_FALSE(v.is_zero());
-  EXPECT_EQ(exactfloat::ExactFloat::kMinExp, v.exp());
-  EXPECT_EQ(exactfloat::ExactFloat::kMaxPrec, v.prec());
+  EXPECT_EQ(ExactFloat::kMinExp, v.exp());
+  EXPECT_EQ(ExactFloat::kMaxPrec, v.prec());
 
   // Try underflowing it in various ways.
-  exactfloat::ExactFloat underflow = 0.5 * v;
-  EXPECT_TRUE(underflow.is_zero() && !exactfloat::signbit(underflow));
+  ExactFloat underflow = 0.5 * v;
+  EXPECT_TRUE(underflow.is_zero() && !signbit(underflow));
   underflow = -0.5 * v;
-  EXPECT_TRUE(underflow.is_zero() && exactfloat::signbit(underflow));
+  EXPECT_TRUE(underflow.is_zero() && signbit(underflow));
 
   // Check that if kMaxPrec is exceeded, the result is NaN.
   EXPECT_TRUE(isnan(v + ldexp(ExactFloat(1.0), kMinExp + 1)));
@@ -118,9 +116,9 @@ TEST(ExactFloatTest, UnderflowMaxExpAndMinPrecision) {
   // Check that if kMinExp and kMaxPrec are exceeded simultaneously, the
   // result is zero rather than NaN.
   underflow = ldexp(v, -1);
-  EXPECT_TRUE(underflow.is_zero() && !exactfloat::signbit(underflow));
+  EXPECT_TRUE(underflow.is_zero() && !signbit(underflow));
   underflow = ldexp(-v, -1);
-  EXPECT_TRUE(underflow.is_zero() && exactfloat::signbit(underflow));
+  EXPECT_TRUE(underflow.is_zero() && signbit(underflow));
 }
 #endif
 


### PR DESCRIPTION
* Require abseil-cpp 20250814 exactly
* Remove little endian static_assert
  * Fixes https://github.com/google/s2geometry/issues/469
* S2CellId: Make lookup tables constexpr, removing runtime init
* New function: S2DensityTree::Dilate
* ExactFloat: Fix 32-bit build
  * Fixes https://github.com/google/s2geometry/issues/470