### PR TITLE
test.yml: Bump macOS runners from macOS 13 to 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,14 @@ jobs:
         runs-on:
           - ubuntu-22.04
           - ubuntu-latest
-          - macos-13
-          # Can't add macos-13-xlarge due to
-          # https://github.com/zacharyburnett/setup-abseil-cpp/issues/4
+          # `large` is x86-64 and `xlarge` is AArch64.
+          # https://docs.github.com/en/actions/reference/runners/larger-runners#available-macos-larger-runners-and-labels
+          - macos-14-large
+          - macos-14-xlarge
           - macos-latest-large
-          # Disable macos-latest-xlarge due to timouts:
+          # macos-latest-xlarge may timeout.
           # https://github.com/google/s2geometry/issues/409
+          - macos-latest-xlarge
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30


### PR DESCRIPTION
macOS 13 is no longer supported.

This should have been part of 56da4f8, but was missed.