### PR TITLE
README.md: Remove dead Kotlin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ The resulting wheel will be in the `dist` directory.
 
 * [Go](https://github.com/golang/geo) (Approximately 40% complete.)
 * [Java](https://github.com/google/s2-geometry-library-java)
-* [Kotlin](https://github.com/Enovea/s2-geometry-kotlin) (Complete except binary serialization)
 
 ## Disclaimer
 


### PR DESCRIPTION
The Kotlin implementation appears to be dead; the repo is a 404.

Fixes https://github.com/google/s2geometry/issues/513.