### PR TITLE
pybind: Add S2Point bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
+build/
 MODULE.bazel.lock

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 #
 # Please keep the list sorted.
 
+Aurora Innovation
 Dan Larkin-York <dan@arangodb.com>
 Google Inc.
 Koordinates Limited

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@
 # Please keep the list sorted.
 
 Dan Larkin-York <dan@arangodb.com>
+David Eustis <deustis@aurora.tech>
 Eric Veach <ericv@google.com>
 Jesse Rosenstock <jmr@google.com>
 Julien Basch <julienbasch@google.com>

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -18,6 +18,13 @@ bazel_dep(name = "openssl", version = "3.5.4.bcr.0", dev_dependency = True)
 bazel_dep(name = "google_benchmark", version = "1.9.4", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 
+# Python configuration
+# The platforms dependency is needed for pybind_extension rules. See:
+# https://github.com/pybind/pybind11_bazel/blob/master/MODULE.bazel
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "pybind11_bazel", version = "3.0.0")
+bazel_dep(name = "rules_python", version = "1.6.3")
+
 # Extensions
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension", dev_dependency = True)
 use_repo(cc_configure, "local_config_cc")

--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -1,0 +1,49 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+package(default_visibility = ["//visibility:private"])
+
+# ========================================
+# Python Package
+# ========================================
+
+py_library(
+    name = "s2geometry_pybind",
+    srcs = ["s2geometry_pybind/__init__.py"],
+    data = [
+        ":s2geometry_bindings",
+    ],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)
+
+# ========================================
+# C++ Bindings
+# ========================================
+
+pybind_extension(
+    name = "s2geometry_bindings",
+    srcs = ["module.cc"],
+    deps = [
+        ":s2point_bindings",
+    ],
+)
+
+pybind_library(
+    name = "s2point_bindings",
+    srcs = ["s2point_bindings.cc"],
+    deps = [
+        "//:s2",
+    ],
+)
+
+# ========================================
+# Python Tests
+# ========================================
+
+py_test(
+    name = "s2point_test",
+    srcs = ["s2point_test.py"],
+    deps = [":s2geometry_pybind"],
+)

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -1,0 +1,85 @@
+# S2 Geometry Pybind11 Bindings
+
+*UNDER DEVELOPMENT*
+
+This directory contains SWIG and pybind11-based Python SDK for S2 Geometry.
+
+## Migration Strategy
+
+The S2 Geometry library is transitioning from SWIG-based bindings to pybind11-based bindings. During this migration:
+
+- **SWIG bindings** (`s2geometry`): The current production bindings, built with CMake. Use `import s2geometry` to access these.
+- **pybind11 bindings** (`s2geometry_pybind`): The new bindings under development, built with Bazel. Use `import s2geometry_pybind` to access these.
+
+Once the pybind11 bindings are feature-complete and stable, the SWIG bindings will be deprecated and the pybind11 package will be renamed to `s2geometry` to become the primary Python API.
+
+## Directory Structure
+
+```
+python/
+├── module.cc                     # Binding module entry point
+├── s2point_bindings.cc           # Bindings for S2Point (add more *_bindings.cc as needed)
+├── s2geometry_pybind/            # Dir for Python package
+│   └── __init__.py               # Package initialization
+├── s2point_test.py               # Tests for S2Point (add more *_test.py as needed)
+└── BUILD.bazel                   # Build rules for bindings, library, and tests
+```
+
+## Usage Example
+
+```python
+import s2geometry_pybind as s2
+
+p1 = s2.S2Point(1.0, 0.0, 0.0)
+p2 = s2.S2Point(0.0, 1.0, 0.0)
+sum_point = p1 + p2
+print(sum_point)
+```
+
+## Development
+
+### Building with Bazel (pybind11 bindings)
+
+Bazel can be used for development and testing of the new pybind11-based bindings.
+
+To run all tests:
+```bash
+cd src
+bazel test //python/...
+```
+
+### Building with CMake (SWIG bindings)
+
+CMake currently builds **only the SWIG-based bindings** (the legacy `s2geometry` package). The pybind11 bindings are not yet integrated into the CMake build system.
+
+For detailed CMake build instructions, dependency installation, and Python wheel creation, see the [parent directory README](../README.md#build-and-install). Key points:
+
+- Install dependencies: `sudo apt-get install cmake libssl-dev swig python3-dev`
+- Enable Python bindings with `-DWITH_PYTHON=ON` when running cmake
+- This will build the SWIG-based `s2geometry` package only
+
+Example:
+```bash
+mkdir build && cd build
+cmake -DBUILD_TESTS=yes -DWITH_PYTHON=ON -DCMAKE_PREFIX_PATH=/path/to/absl/install -DCMAKE_CXX_STANDARD=17 ..
+make -j $(nproc)
+make test ARGS="-j$(nproc)"
+sudo make install
+```
+
+To run the SWIG tests directly without cmake:
+```bash
+cd build/python
+PYTHONPATH=. python3 ../../src/python/s2geometry_test.py
+```
+
+**Note:** Once the pybind11 bindings are complete, they will be integrated into the CMake build system as a replacement for the SWIG bindings.
+
+## Extending the Bindings
+
+To add bindings for a new class:
+
+1. Create `<classname>_bindings.cc` with pybind11 bindings
+2. Update `BUILD.bazel` to add a new `pybind_library` target
+3. Update `module.cc` to call your binding function
+4. Create tests in `<classname>_test.py`

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+// Forward declarations for binding functions
+void bind_s2point(py::module& m);
+
+PYBIND11_MODULE(s2geometry_bindings, m) {
+  m.doc() = "S2 Geometry Python bindings using pybind11";
+  bind_s2point(m);
+}

--- a/src/python/s2geometry_pybind/__init__.py
+++ b/src/python/s2geometry_pybind/__init__.py
@@ -1,0 +1,3 @@
+"""S2 Geometry library Python bindings using pybind11."""
+
+from s2geometry_bindings import *

--- a/src/python/s2point_bindings.cc
+++ b/src/python/s2point_bindings.cc
@@ -1,0 +1,66 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "s2/s2point.h"
+
+namespace py = pybind11;
+
+void bind_s2point(py::module& m) {
+  py::class_<S2Point>(m, "S2Point")
+      // Constructors
+      .def(py::init<>(), "Default constructor")
+      .def(py::init<double, double, double>(),
+           py::arg("x"), py::arg("y"), py::arg("z"),
+           "Construct S2Point from x, y, z coordinates")
+
+      // Accessors
+      .def_property_readonly("x", py::overload_cast<>(&S2Point::x, py::const_),
+                             "x coordinate")
+      .def_property_readonly("y", py::overload_cast<>(&S2Point::y, py::const_),
+                             "y coordinate")
+      .def_property_readonly("z", py::overload_cast<>(&S2Point::z, py::const_),
+                             "z coordinate")
+
+      // Vector operations
+      .def("norm", &S2Point::Norm, "Return the Euclidean norm (length)")
+      .def("norm2", &S2Point::Norm2, "Return the squared Euclidean norm")
+      .def("normalize", &S2Point::Normalize, "Return a normalized copy")
+      .def("dot_prod", [](const S2Point& self, const S2Point& other) {
+        return self.DotProd(other);
+      }, py::arg("other"), "Return the dot product with another point")
+      .def("cross_prod", [](const S2Point& self, const S2Point& other) -> S2Point {
+        return self.CrossProd(other);
+      }, py::arg("other"), "Return the cross product with another point")
+      .def("angle", &S2Point::Angle, py::arg("other"),
+           "Return the angle to another point")
+
+      // Operators
+      .def(py::self + py::self, "Add two points")
+      .def(py::self - py::self, "Subtract two points")
+      .def(py::self * double(), "Multiply by scalar")
+      .def("__rmul__", [](const S2Point& self, double v) -> S2Point {
+        return self * v;
+      }, "Multiply by scalar")
+      .def(py::self / double(), "Divide by scalar")
+      .def(-py::self, "Negate point")
+      .def(py::self == py::self, "Check equality")
+      .def(py::self != py::self, "Check inequality")
+      .def(py::self += py::self, "In-place addition")
+      .def(py::self -= py::self, "In-place subtraction")
+      .def("__imul__", [](S2Point& self, double v) -> S2Point& {
+        return self *= v;
+      }, py::arg("v"), "In-place multiplication")
+      .def("__itruediv__", [](S2Point& self, double v) -> S2Point& {
+        return self /= v;
+      }, py::arg("v"), "In-place division")
+
+      // String representation
+      .def("__repr__", [](const S2Point& p) {
+        return "S2Point(" + std::to_string(p.x()) + ", " +
+               std::to_string(p.y()) + ", " + std::to_string(p.z()) + ")";
+      })
+      .def("__str__", [](const S2Point& p) {
+        return "(" + std::to_string(p.x()) + ", " +
+               std::to_string(p.y()) + ", " + std::to_string(p.z()) + ")";
+      });
+}

--- a/src/python/s2point_test.py
+++ b/src/python/s2point_test.py
@@ -1,0 +1,103 @@
+"""Tests for S2Point pybind11 bindings."""
+
+import unittest
+import s2geometry_pybind as s2
+
+
+class TestS2Point(unittest.TestCase):
+    """Test cases for S2Point bindings."""
+
+    def test_default_constructor(self):
+        p = s2.S2Point()
+        self.assertEqual(p.x, 0.0)
+        self.assertEqual(p.y, 0.0)
+        self.assertEqual(p.z, 0.0)
+
+    def test_constructor_with_coordinates(self):
+        p = s2.S2Point(1.0, 2.0, 3.0)
+        self.assertEqual(p.x, 1.0)
+        self.assertEqual(p.y, 2.0)
+        self.assertEqual(p.z, 3.0)
+
+    def test_norm(self):
+        p = s2.S2Point(3.0, 4.0, 0.0)
+        self.assertAlmostEqual(p.norm(), 5.0)
+        self.assertAlmostEqual(p.norm2(), 25.0)
+
+    def test_normalize(self):
+        p = s2.S2Point(3.0, 4.0, 0.0)
+        normalized = p.normalize()
+        self.assertAlmostEqual(normalized.norm(), 1.0)
+        self.assertAlmostEqual(normalized.x, 0.6)
+        self.assertAlmostEqual(normalized.y, 0.8)
+        self.assertAlmostEqual(normalized.z, 0.0)
+
+    def test_dot_product(self):
+        p1 = s2.S2Point(1.0, 0.0, 0.0)
+        p2 = s2.S2Point(0.0, 1.0, 0.0)
+        p3 = s2.S2Point(1.0, 0.0, 0.0)
+        self.assertAlmostEqual(p1.dot_prod(p2), 0.0)
+        self.assertAlmostEqual(p1.dot_prod(p3), 1.0)
+
+    def test_cross_product(self):
+        p1 = s2.S2Point(1.0, 0.0, 0.0)
+        p2 = s2.S2Point(0.0, 1.0, 0.0)
+        cross = p1.cross_prod(p2)
+        self.assertAlmostEqual(cross.x, 0.0)
+        self.assertAlmostEqual(cross.y, 0.0)
+        self.assertAlmostEqual(cross.z, 1.0)
+
+    def test_addition(self):
+        p1 = s2.S2Point(1.0, 2.0, 3.0)
+        p2 = s2.S2Point(4.0, 5.0, 6.0)
+        result = p1 + p2
+        self.assertAlmostEqual(result.x, 5.0)
+        self.assertAlmostEqual(result.y, 7.0)
+        self.assertAlmostEqual(result.z, 9.0)
+
+    def test_subtraction(self):
+        p1 = s2.S2Point(4.0, 5.0, 6.0)
+        p2 = s2.S2Point(1.0, 2.0, 3.0)
+        result = p1 - p2
+        self.assertAlmostEqual(result.x, 3.0)
+        self.assertAlmostEqual(result.y, 3.0)
+        self.assertAlmostEqual(result.z, 3.0)
+
+    def test_scalar_multiplication(self):
+        p = s2.S2Point(1.0, 2.0, 3.0)
+        result1 = p * 2.0
+        result2 = 2.0 * p
+        for result in [result1, result2]:
+            self.assertAlmostEqual(result.x, 2.0)
+            self.assertAlmostEqual(result.y, 4.0)
+            self.assertAlmostEqual(result.z, 6.0)
+
+    def test_scalar_division(self):
+        p = s2.S2Point(2.0, 4.0, 6.0)
+        result = p / 2.0
+        self.assertAlmostEqual(result.x, 1.0)
+        self.assertAlmostEqual(result.y, 2.0)
+        self.assertAlmostEqual(result.z, 3.0)
+
+    def test_negation(self):
+        p = s2.S2Point(1.0, -2.0, 3.0)
+        result = -p
+        self.assertAlmostEqual(result.x, -1.0)
+        self.assertAlmostEqual(result.y, 2.0)
+        self.assertAlmostEqual(result.z, -3.0)
+
+    def test_equality(self):
+        p1 = s2.S2Point(1.0, 2.0, 3.0)
+        p2 = s2.S2Point(1.0, 2.0, 3.0)
+        p3 = s2.S2Point(1.0, 2.0, 4.0)
+
+        self.assertEqual(p1, p2)
+        self.assertNotEqual(p1, p3)
+
+    def test_repr(self):
+        p = s2.S2Point(1.0, 2.0, 3.0)
+        self.assertEqual(repr(p), "S2Point(1.000000, 2.000000, 3.000000)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Initial Bazel configuration for Pybind11 and S2Point bindings.
https://github.com/google/s2geometry/issues/522

The S2 Geometry library is transitioning from SWIG-based bindings to pybind11-based bindings.

During this migration:
- **SWIG bindings** (`s2geometry`): The current production bindings, built with CMake. Use `import s2geometry` to access these.
- **pybind11 bindings** (`s2geometry_pybind`): The new bindings under development, built with Bazel. Use `import s2geometry_pybind` to access these.

Once the pybind11 bindings are feature-complete and stable, the SWIG bindings will be deprecated and the pybind11 package will be renamed to `s2geometry` to become the primary Python API.

This PR adds Bazel configuration for building and testing the bindings on the local toolchain. For distribution we'll need to generate a wheel for compatibility with different OS and python versions.