### PR TITLE
S2Cell::Contains: Increase expansion to 5/3*DBL_EPSILON

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -729,7 +729,6 @@ cc_test(
 cc_test(
     name = "s2cell_test",
     srcs = [":s2/s2cell_test.cc"],
-    flaky = True,
     deps = [
         ":s2",
         ":s2_testing_headers",

--- a/src/s2/s2cell.cc
+++ b/src/s2/s2cell.cc
@@ -310,8 +310,13 @@ bool S2Cell::Contains(const S2Point& p) const {
   //
   // is always true.  To do this, we need to account for the error when
   // converting from (u,v) coordinates to (s,t) coordinates.  At least in the
-  // case of S2_QUADRATIC_PROJECTION, the total error is at most DBL_EPSILON.
-  return uv_.Expanded(DBL_EPSILON).Contains(uv);
+  // case of S2_QUADRATIC_PROJECTION, the total error is at most
+  // (5/3) * DBL_EPSILON.
+  // See
+  // https://github.com/google/s2geometry/issues/463#issuecomment-3488383557.
+  // TODO: Expand explanation here and document error bounds on other
+  // functions.
+  return uv_.Expanded((5/3.) * DBL_EPSILON).Contains(uv);
 }
 
 void S2Cell::Encode(Encoder* const encoder) const {

--- a/src/s2/s2cell_test.cc
+++ b/src/s2/s2cell_test.cc
@@ -514,9 +514,6 @@ TEST(S2Cell, RectBoundIsLargeEnough) {
 TEST(S2Cell, ConsistentWithS2CellIdFromPoint) {
   // Construct many points that are nearly on an S2Cell edge, and verify that
   // S2Cell(S2CellId(p)).Contains(p) is always true.
-  //
-  // Note this is not actually the case and this test fails 3.5% of the time.
-  // TODO(b/416457492): Fix (S2Cell(S2CellId(point)) does not contain point).
   absl::BitGen bitgen(
       S2Testing::MakeTaggedSeedSeq("CONSISTENT_WITH_S2CELL_ID_FROM_POINT",
                               absl::LogInfoStreamer(__FILE__, __LINE__).stream()));
@@ -538,9 +535,11 @@ TEST(S2Cell, ConsistentWithS2CellIdFromPoint) {
   }
 }
 
-TEST(S2Cell, DISABLED_ConsistentWithS2CellIdFromPointExample1) {
-  // Failures can be generated for `ConsistentWithS2CellIdFromPoint` by
-  // increasing the number of iterations to 1M.  This is one such example.
+TEST(S2Cell, ConsistentWithS2CellIdFromPointExample1) {
+  // Failures could previously be generated for
+  // `ConsistentWithS2CellIdFromPoint` by increasing the number of iterations
+  // to 1M.  This is one such example.
+  // https://github.com/google/s2geometry/issues/463
   S2Point p(0.38203141040035632, 0.030196609707941954, 0.9236558700239289);
   S2Cell cell{S2CellId(p)};
   EXPECT_TRUE(cell.Contains(p)) << " point: " << p << " cell: " << cell.id();


### PR DESCRIPTION
The required expansion is 5/3*DBL_EPSILON, not DBL_EPSILON, as explained in https://github.com/google/s2geometry/issues/463#issuecomment-3488383557

The comment should be expanded, but this will at least fix the flaky test.