### PR TITLE
CMakeLists.txt: Disable benchmark tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if (BUILD_TESTS)
   )
   # Don't install benchmark when s2geometry is installed.
   set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
-  set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(benchmark)
 
   # https://google.github.io/googletest/quickstart-cmake.html#set-up-a-project


### PR DESCRIPTION
Tests from google-benchmark like reporter_output_test were accidentally being run.

Force BENCHMARK_ENABLE_TESTING to OFF instead of
BENCHMARK_ENABLE_GTEST_TESTS.  The former is the global testing switch, the latter only controls test that use GoogleTest.