### PR TITLE
python: Replace std::to_string with absl::StrCat

### DIFF
--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -63,6 +63,7 @@ pybind_library(
     srcs = ["s1interval_bindings.cc"],
     deps = [
         "//:s2",
+	 "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/src/python/s1interval_bindings.cc
+++ b/src/python/s1interval_bindings.cc
@@ -1,8 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
-#include <sstream>
-
+#include "absl/strings/str_cat.h"
 #include "s2/s1interval.h"
 
 namespace py = pybind11;
@@ -11,7 +10,7 @@ namespace {
 
 void MaybeThrowInvalidPoint(double p) {
   if (!S1Interval::IsValidPoint(p)) {
-     throw py::value_error("Invalid S1 point: " + std::to_string(p));
+     throw py::value_error(absl::StrCat("Invalid S1 point: ", p));
   }
 }
 


### PR DESCRIPTION
std::to_string depends on the locale, and absl::StrCat is faster.