### PR TITLE
workflows: replace setup-abseil-cpp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,19 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     steps:
-      - uses: zacharyburnett/setup-abseil-cpp@5386866b5b554e420966aa7f31a477ad92f185d2 # Not a release, but has #423 fix.
-        with:
-          cmake-build-args: "-DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON -DBUILD_TESTING=off -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-          abseil-version: "20250814.1"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@33522472633dbd32578e909b315f5ee43ba878ce # v1.2.22
+        with:
+          key: ${{ github.job }}-${{ matrix.runs-on }}
       - run: mkdir build
       - run: >
           cmake
           -DWITH_PYTHON=yes
+          -DFETCH_ABSEIL=ON
           -DCMAKE_CXX_STANDARD=17
-          -DCMAKE_PREFIX_PATH=/usr/local/
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           ..
         working-directory: build/
       - run: cmake --build . --parallel 45

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,22 @@ add_definitions(-DABSL_MIN_LOG_LEVEL=1)
 # add_subdirectory(absl-submbodule)
 # add_subdirectory(s2-submodule)
 if (NOT TARGET absl::base)
-    find_package(absl REQUIRED)
+    option(FETCH_ABSEIL "Download and build abseil-cpp" OFF)
+    if (FETCH_ABSEIL)
+        message(STATUS "Downloading and building abseil-cpp...")
+        FetchContent_Declare(
+            absl
+            URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20250814.1.zip
+            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+        set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)
+        set(ABSL_ENABLE_INSTALL ON CACHE BOOL "" FORCE)
+        set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(absl)
+    else()
+        find_package(absl REQUIRED)
+    endif()
 endif()
 # pthreads isn't used directly, but this is still required for std::thread.
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Replace setup-abseil-cpp with ccache and FetchContent.

The setup-abseil-cpp GitHub Action has been causing test failures with cache key problems like https://github.com/google/s2geometry/issues/456. Replace it with a combination of CMake's FetchContent and ccache. This simplifies the CI workflow and provides more robust caching.

- Add a FETCH_ABSEIL option to CMakeLists.txt to optionally download and build Abseil from source (defaults to OFF).
- Update the CI workflow to enable FETCH_ABSEIL and use ccache (pinned to v1.2.22) for faster recompilations.
- Remove the dependency on the setup-abseil-cpp action and the associated CMAKE_PREFIX_PATH hardcoding in build.yml.