### PR TITLE
workflows: add windows to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,27 @@ jobs:
           # macos-latest-xlarge may timeout.
           # https://github.com/google/s2geometry/issues/409
           - macos-latest-xlarge
+          - windows-latest
+        python: ["ON"]
+        exclude:
+          - runs-on: windows-latest
+            python: "ON"
+        include:
+          - runs-on: windows-latest
+            python: "OFF"
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set NUM_CORES
+        shell: bash
         run: |
-          NUM_CORES=$(getconf _NPROCESSORS_ONLN)
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            NUM_CORES=$NUMBER_OF_PROCESSORS
+          else
+            NUM_CORES=$(getconf _NPROCESSORS_ONLN)
+          fi
           echo "NUM_CORES=$NUM_CORES" >> $GITHUB_ENV
           echo "Detected $NUM_CORES cores"
       - name: Setup ccache
@@ -46,7 +59,7 @@ jobs:
       - run: mkdir build
       - run: >
           cmake
-          -DWITH_PYTHON=yes
+          -DWITH_PYTHON=${{ matrix.python }}
           -DFETCH_ABSEIL=ON
           -DCMAKE_CXX_STANDARD=17
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
@@ -59,7 +72,10 @@ jobs:
         run: ctest --parallel ${{ env.NUM_CORES }} --output-on-failure
         working-directory: build/
   bazel:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.runs-on }}
 
     # We would like to test on the oldest and newest supported.
     # https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
@@ -82,6 +98,7 @@ jobs:
         repository-cache: true
 
     - name: Build and Test
+      shell: bash
       run: |
         bazel test \
           --keep_going \


### PR DESCRIPTION
Add Windows support to the GitHub Actions workflow for both CMake and Bazel builds.

Changes include:
- Add `windows-latest` to the `cmake` and `bazel` job matrices.
- Enable Python only for non-Windows for now.
- Add `shell: bash` to the Bazel test step to ensure multi-line command continuations work correctly on Windows runners.