### PR TITLE
Fix bignum.cc build failure on GCC 8 (x86_64)

### DIFF
--- a/src/s2/util/math/exactfloat/bignum.cc
+++ b/src/s2/util/math/exactfloat/bignum.cc
@@ -15,7 +15,7 @@
 
 #include "s2/util/math/exactfloat/bignum.h"
 
-#ifdef __x86_64__
+#if defined(__x86_64__) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 9) || defined(__ADX__))
 #include <immintrin.h>
 #endif
 
@@ -292,7 +292,7 @@ inline Bigit AddBigit(Bigit a, Bigit b, Bigit* absl_nonnull carry) {
 // Godbolt link for comparison:
 //   https://godbolt.org/z/cGnnfMbMn  (no intrinsics)
 //   https://godbolt.org/z/jnM1Y3Tjs  (intrinsics)
-#ifdef __x86_64__
+#if defined(__x86_64__) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 9) || defined(__ADX__))
   static_assert(sizeof(Bigit) == sizeof(unsigned long long));
   Bigit out;
   *carry =
@@ -311,7 +311,7 @@ inline Bigit AddBigit(Bigit a, Bigit b, Bigit* absl_nonnull carry) {
 inline Bigit SubBigit(Bigit a, Bigit b, Bigit* absl_nonnull borrow) {
   ABSL_DCHECK_LE(*borrow, Bigit(1));
   // See notes in AddBigit on why using an intrinsic is the right choice here.
-#ifdef __x86_64__
+#if defined(__x86_64__) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 9) || defined(__ADX__))
   Bigit out;
   *borrow = _subborrow_u64(static_cast<char>(*borrow), a, b,
                            reinterpret_cast<unsigned long long*>(&out));


### PR DESCRIPTION
## Description

The `_addcarry_u64` and `_subborrow_u64` intrinsics in `bignum.cc` require the ADX instruction set extension, which GCC < 9 does not enable by default on x86_64. The existing `#ifdef __x86_64__` guard is too broad, causing build failures on GCC 8.5.0 (the default compiler on Rocky Linux 8 / RHEL 8).

```
bignum.cc:299:7: error: '_addcarry_u64' was not declared in this scope
bignum.cc:316:13: error: '_subborrow_u64' was not declared in this scope
```

## Fix

Replace `#ifdef __x86_64__` with a stricter check:

```cpp
#if defined(__x86_64__) && (defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 9) || defined(__ADX__))
```

This allows the intrinsics on Clang (all versions), GCC >= 9, or any compiler with `-madx`. On older GCC, falls through to the existing portable `absl::uint128` arithmetic path with no functional change.

Fixes #568