### PR TITLE
python: Bump min version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,12 +84,10 @@ if (NOT TARGET absl::vlog_is_on)
 endif()
 
 if (WITH_PYTHON)
-    # Should be easy to make it work with swig3, but some args to %pythonprepend
-    # seem to be different and were changed.
     find_package(SWIG 4.0)
     # Use Python3_ROOT_DIR to help find python3, if the correct location is not
     # being found by default.
-    find_package(Python3 COMPONENTS Interpreter Development.Module)
+    find_package(Python3 3.10 COMPONENTS Interpreter Development.Module)
 endif()
 
 if (MSVC)

--- a/README.md
+++ b/README.md
@@ -197,10 +197,9 @@ or on macOS:
 ```
 sudo port install swig
 ```
-Version 4.0 is required, but it should be easy to make it work 3.0 or probably
-even 2.0.
+SWIG version 4.0 is required.
 
-Python 3 is required.
+[Python 3.10 is required](https://github.com/google/oss-policies-info/blob/main/foundational-python-support-matrix.md).
 
 ### Creating wheels
 First, make a virtual environment and install `build` into it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Tiago Brito", email = "tiago.brito@90poe.io" },
     { name = "Zachary Burnett", email = "zachary.r.burnett@gmail.com" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: POSIX",


### PR DESCRIPTION
We support all non-EOL Python versions.

* https://devguide.python.org/versions/
* https://github.com/google/oss-policies-info/blob/main/foundational-python-support-matrix.md