### PR TITLE
python: Require Python/SWIG if WITH_PYTHON is on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
         uses: hendrikmuhs/ccache-action@33522472633dbd32578e909b315f5ee43ba878ce # v1.2.22
         with:
           key: ${{ github.job }}-${{ matrix.runs-on }}
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install swig
       - run: mkdir build
       - run: >
           cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,10 @@ if (NOT TARGET absl::vlog_is_on)
 endif()
 
 if (WITH_PYTHON)
-    find_package(SWIG 4.0)
+    find_package(SWIG 4.0 REQUIRED)
     # Use Python3_ROOT_DIR to help find python3, if the correct location is not
     # being found by default.
-    find_package(Python3 3.10 COMPONENTS Interpreter Development.Module)
+    find_package(Python3 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
 endif()
 
 if (MSVC)
@@ -501,7 +501,7 @@ if (BUILD_EXAMPLES AND TARGET s2testing)
   add_subdirectory("doc/examples" examples)
 endif()
 
-if (SWIG_FOUND AND Python3_FOUND)
+if (WITH_PYTHON)
   add_subdirectory("src/python" python)
 endif()
 


### PR DESCRIPTION
Previously, WITH_PYTHON was only a request and failure to find Python or SWIG would silently be ignored.

Install SWIG on macOS runners.