### PR TITLE
workflows: fix Bazel caching and flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,20 +74,22 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-    - name: Setup Bazel ${{ matrix.bazel }}
+    - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86  # v0.19.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
-        # Store build cache per workflow.
-        disk-cache: ${{ github.workflow }}
-        # Share repository cache between workflows.
+        # Share caches between workflows.
+        disk-cache: true
         repository-cache: true
+        # The Bazel workspace is in the src directory.
+        workspace-root: src
 
     - name: Build and Test
       run: |
         bazel test \
+          --config=ci \
           --keep_going \
-          --test_verbose_timeout_warnings --test_output=errors \
+          --test_verbose_timeout_warnings \
           //...
       working-directory: src

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -1,3 +1,9 @@
 # Enable Bzlmod for every Bazel command
 common --enable_bzlmod
 common --cxxopt=-std=c++20
+common --announce_rc
+
+# CI-specific flags
+common:ci --color=yes
+build:ci --show_progress_rate_limit=10
+test:ci --test_output=errors


### PR DESCRIPTION
The Bazel setup action was failing to correctly configure caching because it defaulted to the repository root, while the actual Bazel workspace is located in the `src` directory.

* Set `workspace-root: src` in the setup-bazel action to ensure cache configuration is written where Bazel can see it.
* Change `disk-cache` to `true` to use the action's default OS-aware cache key, preventing cross-platform cache poisoning.
* Fix an empty matrix variable in the setup step name.
* Introduce a `ci` configuration in `src/.bazelrc` with CI-specific flags (`--color=yes`, `--show_progress_rate_limit=10`, and `--test_output=errors`).
* Add `--announce_rc` to common flags.
* Update the GitHub Actions workflow to invoke Bazel with `--config=ci`.