### PR TITLE
python: Use Limited API / Stable ABI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,8 @@ jobs:
       - run: mkdir build
       - run: >
           cmake
-          -DWITH_PYTHON=yes
+          -DWITH_PYTHON=ON
+          -DWITH_PYTHON_LIMITED_API=${{ matrix.runs-on != 'ubuntu-22.04' && 'ON' || 'OFF' }}
           -DFETCH_ABSEIL=ON
           -DCMAKE_CXX_STANDARD=17
           -DCMAKE_C_COMPILER_LAUNCHER=ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ option(BUILD_EXAMPLES "Build s2 documentation examples." ON)
 option(BUILD_TESTS "Build s2 unittests." ON)
 
 option(WITH_PYTHON "Add python interface" OFF)
+# Requires SWIG >= 4.2 and CMake >= 3.26.
+option(WITH_PYTHON_LIMITED_API "Use Python Limited API for SWIG" OFF)
 add_feature_info(PYTHON WITH_PYTHON "provides python interface to S2")
 
 option(S2_USE_SYSTEM_INCLUDES
@@ -84,10 +86,19 @@ if (NOT TARGET absl::vlog_is_on)
 endif()
 
 if (WITH_PYTHON)
-    find_package(SWIG 4.0 REQUIRED)
     # Use Python3_ROOT_DIR to help find python3, if the correct location is not
     # being found by default.
-    find_package(Python3 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+    if (WITH_PYTHON_LIMITED_API)
+        # Development.SABIModule requires CMake 3.26; be explicit.
+        cmake_minimum_required(VERSION 3.26)
+        find_package(Python3 3.10 COMPONENTS Interpreter Development.SABIModule REQUIRED)
+        # SWIG requires 4.2 for stable ABI support.
+        # https://www.swig.org/Doc4.2/Python.html#Python_stable_abi
+        find_package(SWIG 4.2 REQUIRED)
+    else()
+        find_package(Python3 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+        find_package(SWIG 4.0 REQUIRED)
+    endif()
 endif()
 
 if (MSVC)

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -35,7 +35,14 @@ set_property(SOURCE s2.i PROPERTY CPLUSPLUS ON)
 
 swig_add_library(s2geometry LANGUAGE python SOURCES s2.i)
 
-swig_link_libraries(s2geometry Python3::Module s2)
+if (WITH_PYTHON_LIMITED_API)
+    swig_link_libraries(s2geometry Python3::SABIModule s2)
+    # https://www.swig.org/Doc4.2/Python.html#Python_stable_abi
+    target_compile_definitions(s2geometry PRIVATE Py_LIMITED_API=0x030a0000)
+else()
+    swig_link_libraries(s2geometry Python3::Module s2)
+endif()
+
 enable_testing()
 add_test(NAME s2geometry_test COMMAND
          ${Python3_EXECUTABLE}

--- a/src/python/coder.i
+++ b/src/python/coder.i
@@ -35,9 +35,12 @@
     $1 = (void *) PyByteArray_AsString($input);
     $2 = PyByteArray_Size($input);
   } else {
+    // TODO: When Py_LIMITED_API is raised to 3.13+ (2028), replace
+    // %S/(PyObject*)Py_TYPE() with %T in PyErr_Format calls for bare type
+    // names (e.g. "int" vs "<class 'int'>").
     PyErr_Format(PyExc_TypeError,
-                 "bytes or bytearray needed, %s found",
-                 $input->ob_type->tp_name);
+                 "bytes or bytearray needed, %S found",
+                 (PyObject*)Py_TYPE($input));
     return nullptr;
   }
 };
@@ -48,7 +51,8 @@
     $2 = PyByteArray_Size($input);
   } else {
     PyErr_Format(PyExc_TypeError,
-                 "bytearray needed, %s found", $input->ob_type->tp_name);
+                 "bytearray needed, %S found",
+                 (PyObject*)Py_TYPE($input));
     return nullptr;
   }
 };
@@ -76,7 +80,8 @@
       return new Decoder(PyByteArray_AsString(obj), PyByteArray_Size(obj));
     }
     PyErr_Format(PyExc_TypeError,
-                 "bytes or bytearray needed, %s found", obj->ob_type->tp_name);
+                 "bytes or bytearray needed, %S found",
+                 (PyObject*)Py_TYPE(obj));
     return nullptr;
   }
 }


### PR DESCRIPTION
Introduce a new CMake option, `WITH_PYTHON_LIMITED_API`, to optionally build the SWIG Python bindings using the Python Limited API (Stable ABI). This allows the generated bindings to be compatible across multiple Python 3.10+ minor versions without recompilation.

When `WITH_PYTHON_LIMITED_API` is enabled:
- The build requires SWIG >= 4.2, and CMake >= 3.26.
- The `Py_LIMITED_API` macro is defined for the compiler.

When disabled (the default), the traditional Python C API is used, preserving compatibility with older toolchains (SWIG 4.0).

https://docs.python.org/3/c-api/stable.html