### PR TITLE
exactfloat: Remove BoringSSL/OpenSSL Bazel dep

### DIFF
--- a/src/s2/util/math/exactfloat/BUILD.bazel
+++ b/src/s2/util/math/exactfloat/BUILD.bazel
@@ -30,13 +30,7 @@ cc_library(
         "@abseil-cpp//absl/numeric:bits",
         "@abseil-cpp//absl/numeric:int128",
         "@abseil-cpp//absl/random:random",
-    ] + select({
-        "//:use_openssl_setting": ["@openssl//:crypto"],
-        "//conditions:default": [
-            "@abseil-cpp//absl/container:fixed_array",
-            "@boringssl//:crypto",
-        ],
-    }),
+    ],
 )
 
 cc_test(
@@ -49,9 +43,11 @@ cc_test(
         "@abseil-cpp//absl/random:bit_gen_ref",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/strings:strings",
-        "@boringssl//:crypto",
         "@googletest//:gtest_main",
-    ],
+    ] + select({
+        "//:use_openssl_setting": ["@openssl//:crypto"],
+        "//conditions:default": ["@boringssl//:crypto"],
+    }),
 )
 
 cc_test(


### PR DESCRIPTION
Only exactfloat_tests depends on these.  47eaa29 (exactfloat: Remove OpenSSL dependency (#453)) did not update these deps.