### PR TITLE
pybind: Add S2LatLng bindings

### DIFF
--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -32,6 +32,7 @@ pybind_extension(
         ":s1angle_bindings",
         ":s1interval_bindings",
         ":s2point_bindings",
+        ":s2latlng_bindings",
     ],
 )
 
@@ -84,6 +85,14 @@ pybind_library(
     ],
 )
 
+pybind_library(
+    name = "s2latlng_bindings",
+    srcs = ["s2latlng_bindings.cc"],
+    deps = [
+        "//:s2",
+    ],
+)
+
 # ========================================
 # Python Tests
 # ========================================
@@ -121,5 +130,11 @@ py_test(
 py_test(
     name = "s2point_test",
     srcs = ["s2point_test.py"],
+    deps = [":s2geometry_pybind"],
+)
+
+py_test(
+    name = "s2latlng_test",
+    srcs = ["s2latlng_test.py"],
     deps = [":s2geometry_pybind"],
 )

--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -90,6 +90,7 @@ pybind_library(
     srcs = ["s2latlng_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -43,6 +43,8 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 **Invalid Values:**
 - Invalid inputs to constructions or functions raises `ValueError`.
 - Example: `S1Interval(0.0, 4.0)` raises `ValueError` because `4.0 > π`.
+- Some classes change the behavior of operations to guarantee validity.
+- Example: `S2LatLng` arithmetic operators automatically clamp the result to a valid range whereas in C++, `S2LatLng` these operators can produce invalid states.
 - Note: In C++, these conditions trigger `ABSL_DCHECK` assertions. The bindings prevent these assertions from firing by pre-validating inputs.
 - Note: Python bindings check for invalid inputs and throw C++ exceptions which are caught by
   pybind and converted to Python exceptions. Exceptions are normally prohibited by the C++

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -44,7 +44,7 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 - Invalid inputs to constructions or functions raises `ValueError`.
 - Example: `S1Interval(0.0, 4.0)` raises `ValueError` because `4.0 > π`.
 - Some classes change the behavior of operations to guarantee validity.
-- Example: `S2LatLng` arithmetic operators automatically clamp the result to a valid range whereas in C++, `S2LatLng` these operators can produce invalid states.
+- Example: `S2LatLng` arithmetic operators automatically clamp the result to a valid range whereas in C++ these operators can produce invalid states.
 - Note: In C++, these conditions trigger `ABSL_DCHECK` assertions. The bindings prevent these assertions from firing by pre-validating inputs.
 - Note: Python bindings check for invalid inputs and throw C++ exceptions which are caught by
   pybind and converted to Python exceptions. Exceptions are normally prohibited by the C++

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -29,5 +29,7 @@ PYBIND11_MODULE(s2geometry_bindings, m) {
 
   // Deps: s2point
   bind_s1angle(m);
+
+  // Deps: s1angle, s2point
   bind_s2latlng(m);
 }

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -9,6 +9,7 @@ void bind_r2rect(py::module& m);
 void bind_s1angle(py::module& m);
 void bind_s1interval(py::module& m);
 void bind_s2point(py::module& m);
+void bind_s2latlng(py::module& m);
 
 PYBIND11_MODULE(s2geometry_bindings, m) {
   m.doc() = "S2 Geometry Python bindings using pybind11";
@@ -28,4 +29,5 @@ PYBIND11_MODULE(s2geometry_bindings, m) {
 
   // Deps: s2point
   bind_s1angle(m);
+  bind_s2latlng(m);
 }

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -1,0 +1,187 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include <cmath>
+#include <sstream>
+#include <string>
+
+#include "s2/s1angle.h"
+#include "s2/s2latlng.h"
+#include "s2/s2point.h"
+
+namespace py = pybind11;
+
+namespace {
+
+void MaybeThrowNotValid(const S2LatLng& ll) {
+  if (!ll.is_valid()) {
+    std::ostringstream oss;
+    oss << "Invalid S2LatLng: " << ll
+        << " (latitude must be in [-90, 90], longitude in [-180, 180])";
+    throw py::value_error(oss.str());
+  }
+}
+
+void MaybeThrowNotFinite(double m) {
+  if (!std::isfinite(m)) {
+    throw py::value_error("Scalar must be finite, got " + std::to_string(m));
+  }
+}
+
+}  // namespace
+
+void bind_s2latlng(py::module& m) {
+  py::class_<S2LatLng>(m, "S2LatLng",
+      "Represents a point on the unit sphere as a latitude-longitude pair.\n\n"
+      "All S2LatLng values are guaranteed to be valid: latitude in [-90, 90]\n"
+      "and longitude in [-180, 180] degrees. Constructors and factory methods\n"
+      "raise ValueError for out-of-range inputs. Arithmetic operators\n"
+      "automatically normalize the result.\n\n"
+      "Note: the native C++ implementation does not normalize arithmetic\n"
+      "results and allows invalid states.\n\n"
+      "See s2/s2latlng.h for comprehensive documentation.")
+      // Constructors
+      .def(py::init<>(), "Default constructor sets latitude and longitude to zero")
+      .def(py::init([](S1Angle lat, S1Angle lng) {
+               S2LatLng ll(lat, lng);
+               MaybeThrowNotValid(ll);
+               return ll;
+           }),
+           py::arg("lat"), py::arg("lng"),
+           "Construct from latitude and longitude angles.\n\n"
+           "Raises ValueError if latitude is not in [-90, 90] or\n"
+           "longitude is not in [-180, 180] degrees.")
+      .def(py::init([](const S2Point& p) {
+               S2LatLng ll(p);
+               MaybeThrowNotValid(ll);
+               return ll;
+           }),
+           py::arg("point"),
+           "Convert a direction vector to an S2LatLng.\n\n"
+           "The vector does not need to be unit length.\n"
+           "Raises ValueError if the point has non-finite coordinates.")
+
+      // Factory methods
+      .def_static("from_radians", [](double lat_radians, double lng_radians) {
+               S2LatLng ll = S2LatLng::FromRadians(lat_radians, lng_radians);
+               MaybeThrowNotValid(ll);
+               return ll;
+           },
+           py::arg("lat_radians"), py::arg("lng_radians"),
+           "Construct from latitude and longitude in radians.\n\n"
+           "Raises ValueError if out of range.")
+      .def_static("from_degrees", [](double lat_degrees, double lng_degrees) {
+               S2LatLng ll = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
+               MaybeThrowNotValid(ll);
+               return ll;
+           },
+           py::arg("lat_degrees"), py::arg("lng_degrees"),
+           "Construct from latitude and longitude in degrees.\n\n"
+           "Raises ValueError if out of range.")
+      .def_static("from_e5", [](int32_t lat_e5, int32_t lng_e5) {
+               S2LatLng ll = S2LatLng::FromE5(lat_e5, lng_e5);
+               MaybeThrowNotValid(ll);
+               return ll;
+           },
+           py::arg("lat_e5"), py::arg("lng_e5"),
+           "Construct from latitude and longitude in E5 format.\n\n"
+           "Raises ValueError if out of range.")
+      .def_static("from_e6", [](int32_t lat_e6, int32_t lng_e6) {
+               S2LatLng ll = S2LatLng::FromE6(lat_e6, lng_e6);
+               MaybeThrowNotValid(ll);
+               return ll;
+           },
+           py::arg("lat_e6"), py::arg("lng_e6"),
+           "Construct from latitude and longitude in E6 format.\n\n"
+           "Raises ValueError if out of range.")
+      .def_static("from_e7", [](int32_t lat_e7, int32_t lng_e7) {
+               S2LatLng ll = S2LatLng::FromE7(lat_e7, lng_e7);
+               MaybeThrowNotValid(ll);
+               return ll;
+           },
+           py::arg("lat_e7"), py::arg("lng_e7"),
+           "Construct from latitude and longitude in E7 format.\n\n"
+           "Raises ValueError if out of range.")
+      .def_static("latitude", &S2LatLng::Latitude, py::arg("point"),
+                  "Return the latitude of a direction vector")
+      .def_static("longitude", &S2LatLng::Longitude, py::arg("point"),
+                  "Return the longitude of a direction vector")
+
+      // Properties
+      .def_property_readonly("lat", &S2LatLng::lat, "The latitude as an S1Angle")
+      .def_property_readonly("lng", &S2LatLng::lng,
+                             "The longitude as an S1Angle")
+      .def("coords", [](const S2LatLng& self) {
+        return py::make_tuple(self.coords().x(), self.coords().y());
+      }, "Return the (lat, lng) coordinates in radians as a tuple")
+
+      // Geometric operations
+      .def("to_point", &S2LatLng::ToPoint,
+           "Convert to the equivalent unit-length S2Point")
+      .def("get_distance", &S2LatLng::GetDistance,
+           py::arg("other"),
+           "Return the surface distance to another S2LatLng.\n\n"
+           "Uses the Haversine formula.")
+      .def("to_string_in_degrees", &S2LatLng::ToStringInDegrees,
+           "Return \"lat,lng\" in degrees, e.g. \"37.794000,-122.395000\"")
+      // Note: default value must match C++ signature in s2latlng.h
+      .def("approx_equals", [](const S2LatLng& self, const S2LatLng& o,
+                                S1Angle max_error) {
+               return self.ApproxEquals(o, max_error);
+           },
+           py::arg("other"),
+           py::arg("max_error") = S1Angle::Radians(1e-15),
+           "Return true if approximately equal to 'other'.\n\n"
+           "Note: this compares coordinates in rectangular lat/lng space.\n"
+           "For points near the poles, consider using get_distance() instead.")
+
+      // Operators
+      .def(py::self == py::self, "Return true if exactly equal")
+      .def(py::self != py::self, "Return true if not exactly equal")
+      .def(py::self < py::self,
+           "Compare by latitude first, then longitude")
+      .def(py::self > py::self,
+           "Compare by latitude first, then longitude")
+      .def(py::self <= py::self,
+           "Compare by latitude first, then longitude")
+      .def(py::self >= py::self,
+           "Compare by latitude first, then longitude")
+      .def("__add__", [](const S2LatLng& a, const S2LatLng& b) {
+        return (a + b).Normalized();
+      }, py::arg("other"),
+           "Add two S2LatLngs.\n\n"
+           "The result is automatically normalized.\n"
+           "Note: the native C++ implementation does not normalize.")
+      .def("__sub__", [](const S2LatLng& a, const S2LatLng& b) {
+        return (a - b).Normalized();
+      }, py::arg("other"),
+           "Subtract two S2LatLngs.\n\n"
+           "The result is automatically normalized.\n"
+           "Note: the native C++ implementation does not normalize.")
+      .def("__mul__", [](const S2LatLng& a, double m) {
+        MaybeThrowNotFinite(m);
+        return (a * m).Normalized();
+      }, py::arg("m"),
+           "Multiply by scalar.\n\n"
+           "The result is automatically normalized.\n"
+           "Note: the native C++ implementation does not normalize.")
+      .def("__rmul__", [](const S2LatLng& a, double m) {
+        MaybeThrowNotFinite(m);
+        return (m * a).Normalized();
+      }, py::arg("m"),
+           "Multiply by scalar (reversed operands).\n\n"
+           "The result is automatically normalized.\n"
+           "Note: the native C++ implementation does not normalize.")
+
+      // String representation
+      .def("__repr__", [](const S2LatLng& ll) {
+        std::ostringstream oss;
+        oss << "S2LatLng(" << ll << ")";
+        return oss.str();
+      })
+      .def("__str__", [](const S2LatLng& ll) {
+        std::ostringstream oss;
+        oss << ll;
+        return oss.str();
+      });
+}

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -3,8 +3,8 @@
 
 #include <cmath>
 #include <sstream>
-#include <string>
 
+#include "absl/strings/str_cat.h"
 #include "s2/s1angle.h"
 #include "s2/s2latlng.h"
 #include "s2/s2point.h"
@@ -24,7 +24,7 @@ void MaybeThrowNotValid(const S2LatLng& ll) {
 
 void MaybeThrowNotFinite(double m) {
   if (!std::isfinite(m)) {
-    throw py::value_error("Scalar must be finite, got " + std::to_string(m));
+    throw py::value_error(absl::StrCat("Scalar must be finite, got ", m));
   }
 }
 

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -69,7 +69,7 @@ void bind_s2latlng(py::module& m) {
            py::arg("lat_radians"), py::arg("lng_radians"),
            "Construct from latitude and longitude in radians.\n\n"
            "Raises ValueError if out of range.")
-      .def_static("from_radians_normalized",
+      .def_static("normalized_from_radians",
            [](double lat_radians, double lng_radians) {
                MaybeThrowNotFinite(lat_radians);
                MaybeThrowNotFinite(lng_radians);

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -15,10 +15,9 @@ namespace {
 
 void MaybeThrowNotValid(const S2LatLng& ll) {
   if (!ll.is_valid()) {
-    std::ostringstream oss;
-    oss << "Invalid S2LatLng: " << ll
-        << " (latitude must be in [-90, 90], longitude in [-180, 180])";
-    throw py::value_error(oss.str());
+    throw py::value_error(absl::StrCat(
+        "Invalid S2LatLng: (", ll.lat().degrees(), ", ", ll.lng().degrees(),
+        ") (latitude must be in [-90, 90], longitude in [-180, 180])"));
   }
 }
 
@@ -70,6 +69,18 @@ void bind_s2latlng(py::module& m) {
            py::arg("lat_radians"), py::arg("lng_radians"),
            "Construct from latitude and longitude in radians.\n\n"
            "Raises ValueError if out of range.")
+      .def_static("from_radians_normalized",
+           [](double lat_radians, double lng_radians) {
+               MaybeThrowNotFinite(lat_radians);
+               MaybeThrowNotFinite(lng_radians);
+               return S2LatLng::FromRadians(lat_radians, lng_radians)
+                   .Normalized();
+           },
+           py::arg("lat_radians"), py::arg("lng_radians"),
+           "Construct from latitude and longitude in radians, accepting any\n"
+           "finite values. Latitude is clamped to [-Pi/2, Pi/2] and longitude\n"
+           "is wrapped to [-Pi, Pi].\n\n"
+           "Raises ValueError if either value is non-finite.")
       .def_static("from_degrees", [](double lat_degrees, double lng_degrees) {
                S2LatLng ll = S2LatLng::FromDegrees(lat_degrees, lng_degrees);
                MaybeThrowNotValid(ll);
@@ -111,9 +122,8 @@ void bind_s2latlng(py::module& m) {
       .def_property_readonly("lat", &S2LatLng::lat, "The latitude as an S1Angle")
       .def_property_readonly("lng", &S2LatLng::lng,
                              "The longitude as an S1Angle")
-      .def("coords", [](const S2LatLng& self) {
-        return py::make_tuple(self.coords().x(), self.coords().y());
-      }, "Return the (lat, lng) coordinates in radians as a tuple")
+      .def_property_readonly("coords", &S2LatLng::coords,
+                             "The (lat, lng) coordinates in radians as an R2Point")
 
       // Geometric operations
       .def("to_point", &S2LatLng::ToPoint,
@@ -122,8 +132,6 @@ void bind_s2latlng(py::module& m) {
            py::arg("other"),
            "Return the surface distance to another S2LatLng.\n\n"
            "Uses the Haversine formula.")
-      .def("to_string_in_degrees", &S2LatLng::ToStringInDegrees,
-           "Return \"lat,lng\" in degrees, e.g. \"37.794000,-122.395000\"")
       // Note: default value must match C++ signature in s2latlng.h
       .def("approx_equals", [](const S2LatLng& self, const S2LatLng& o,
                                 S1Angle max_error) {
@@ -174,6 +182,8 @@ void bind_s2latlng(py::module& m) {
            "Note: the native C++ implementation does not normalize.")
 
       // String representation
+      .def("to_string_in_degrees", &S2LatLng::ToStringInDegrees,
+           "Return \"lat,lng\" in degrees, e.g. \"37.794000,-122.395000\"")
       .def("__repr__", [](const S2LatLng& ll) {
         std::ostringstream oss;
         oss << "S2LatLng(" << ll << ")";

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -12,21 +12,21 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_default_constructor(self):
         ll = s2.S2LatLng()
-        self.assertEqual(ll.lat.radians(), 0.0)
-        self.assertEqual(ll.lng.radians(), 0.0)
+        self.assertEqual(ll.lat.radians, 0.0)
+        self.assertEqual(ll.lng.radians, 0.0)
 
     def test_constructor_from_angles(self):
         lat = s2.S1Angle.from_degrees(37.0)
         lng = s2.S1Angle.from_degrees(-122.0)
         ll = s2.S2LatLng(lat, lng)
-        self.assertAlmostEqual(ll.lat.degrees(), 37.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -122.0)
+        self.assertAlmostEqual(ll.lat.degrees, 37.0)
+        self.assertAlmostEqual(ll.lng.degrees, -122.0)
 
     def test_constructor_from_angles_at_bounds(self):
         ll = s2.S2LatLng(s2.S1Angle.from_degrees(90.0),
                          s2.S1Angle.from_degrees(180.0))
-        self.assertAlmostEqual(ll.lat.degrees(), 90.0)
-        self.assertAlmostEqual(ll.lng.degrees(), 180.0)
+        self.assertAlmostEqual(ll.lat.degrees, 90.0)
+        self.assertAlmostEqual(ll.lng.degrees, 180.0)
 
     def test_constructor_from_angles_invalid_lat_raises(self):
         with self.assertRaises(ValueError) as cm:
@@ -45,8 +45,8 @@ class TestS2LatLng(unittest.TestCase):
     def test_constructor_from_point(self):
         p = s2.S2Point(1.0, 0.0, 0.0)
         ll = s2.S2LatLng(p)
-        self.assertAlmostEqual(ll.lat.degrees(), 0.0)
-        self.assertAlmostEqual(ll.lng.degrees(), 0.0)
+        self.assertAlmostEqual(ll.lat.degrees, 0.0)
+        self.assertAlmostEqual(ll.lng.degrees, 0.0)
 
     def test_constructor_from_nan_point_raises(self):
         p = s2.S2Point(float('nan'), 0.0, 0.0)
@@ -56,14 +56,14 @@ class TestS2LatLng(unittest.TestCase):
     def test_constructor_from_point_north_pole(self):
         p = s2.S2Point(0.0, 0.0, 1.0)
         ll = s2.S2LatLng(p)
-        self.assertAlmostEqual(ll.lat.degrees(), 90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 90.0)
 
     # Factory methods
 
     def test_from_radians(self):
         ll = s2.S2LatLng.from_radians(math.pi / 4, -math.pi / 2)
-        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 45.0)
+        self.assertAlmostEqual(ll.lng.degrees, -90.0)
 
     def test_from_radians_invalid_raises(self):
         with self.assertRaises(ValueError):
@@ -71,8 +71,8 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_from_degrees(self):
         ll = s2.S2LatLng.from_degrees(45.0, -90.0)
-        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 45.0)
+        self.assertAlmostEqual(ll.lng.degrees, -90.0)
 
     def test_from_degrees_invalid_raises(self):
         with self.assertRaises(ValueError):
@@ -82,8 +82,8 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_from_e5(self):
         ll = s2.S2LatLng.from_e5(4500000, -9000000)
-        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 45.0)
+        self.assertAlmostEqual(ll.lng.degrees, -90.0)
 
     def test_from_e5_invalid_raises(self):
         with self.assertRaises(ValueError):
@@ -91,8 +91,8 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_from_e6(self):
         ll = s2.S2LatLng.from_e6(45000000, -90000000)
-        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 45.0)
+        self.assertAlmostEqual(ll.lng.degrees, -90.0)
 
     def test_from_e6_invalid_raises(self):
         with self.assertRaises(ValueError):
@@ -100,8 +100,8 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_from_e7(self):
         ll = s2.S2LatLng.from_e7(450000000, -900000000)
-        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
-        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+        self.assertAlmostEqual(ll.lat.degrees, 45.0)
+        self.assertAlmostEqual(ll.lng.degrees, -90.0)
 
     def test_from_e7_invalid_raises(self):
         with self.assertRaises(ValueError):
@@ -110,12 +110,12 @@ class TestS2LatLng(unittest.TestCase):
     def test_latitude_static(self):
         p = s2.S2Point(0.0, 0.0, 1.0)
         lat = s2.S2LatLng.latitude(p)
-        self.assertAlmostEqual(lat.degrees(), 90.0)
+        self.assertAlmostEqual(lat.degrees, 90.0)
 
     def test_longitude_static(self):
         p = s2.S2Point(0.0, 1.0, 0.0)
         lng = s2.S2LatLng.longitude(p)
-        self.assertAlmostEqual(lng.degrees(), 90.0)
+        self.assertAlmostEqual(lng.degrees, 90.0)
 
     # Properties
 
@@ -157,18 +157,18 @@ class TestS2LatLng(unittest.TestCase):
         ll = s2.S2LatLng.from_degrees(37.7749, -122.4194)
         p = ll.to_point()
         ll2 = s2.S2LatLng(p)
-        self.assertAlmostEqual(ll.lat.radians(), ll2.lat.radians())
-        self.assertAlmostEqual(ll.lng.radians(), ll2.lng.radians())
+        self.assertAlmostEqual(ll.lat.radians, ll2.lat.radians)
+        self.assertAlmostEqual(ll.lng.radians, ll2.lng.radians)
 
     def test_get_distance(self):
         # Distance between two points on the equator, 90 degrees apart.
         a = s2.S2LatLng.from_degrees(0.0, 0.0)
         b = s2.S2LatLng.from_degrees(0.0, 90.0)
-        self.assertAlmostEqual(a.get_distance(b).degrees(), 90.0)
+        self.assertAlmostEqual(a.get_distance(b).degrees, 90.0)
 
     def test_get_distance_same_point(self):
         ll = s2.S2LatLng.from_degrees(37.0, -122.0)
-        self.assertAlmostEqual(ll.get_distance(ll).radians(), 0.0)
+        self.assertAlmostEqual(ll.get_distance(ll).radians, 0.0)
 
     def test_to_string_in_degrees(self):
         ll = s2.S2LatLng.from_degrees(37.794, -122.395)
@@ -220,53 +220,51 @@ class TestS2LatLng(unittest.TestCase):
         a = s2.S2LatLng.from_degrees(10.0, 20.0)
         b = s2.S2LatLng.from_degrees(30.0, 40.0)
         result = a + b
-        self.assertAlmostEqual(result.lat.degrees(), 40.0)
-        self.assertAlmostEqual(result.lng.degrees(), 60.0)
+        self.assertAlmostEqual(result.lat.degrees, 40.0)
+        self.assertAlmostEqual(result.lng.degrees, 60.0)
 
     def test_addition_normalizes(self):
         # 80 + 20 = 100 degrees latitude, should clamp to 90.
         a = s2.S2LatLng.from_degrees(80.0, 170.0)
         b = s2.S2LatLng.from_degrees(20.0, 30.0)
         result = a + b
-        self.assertAlmostEqual(result.lat.degrees(), 90.0)
+        self.assertAlmostEqual(result.lat.degrees, 90.0)
         # 170 + 30 = 200 degrees longitude, should wrap to -160.
-        self.assertAlmostEqual(result.lng.degrees(), -160.0)
+        self.assertAlmostEqual(result.lng.degrees, -160.0)
 
     def test_subtraction(self):
         a = s2.S2LatLng.from_degrees(30.0, 40.0)
         b = s2.S2LatLng.from_degrees(10.0, 20.0)
         result = a - b
-        self.assertAlmostEqual(result.lat.degrees(), 20.0)
-        self.assertAlmostEqual(result.lng.degrees(), 20.0)
+        self.assertAlmostEqual(result.lat.degrees, 20.0)
+        self.assertAlmostEqual(result.lng.degrees, 20.0)
 
     def test_subtraction_normalizes(self):
         # -80 - 20 = -100 degrees latitude, should clamp to -90.
         a = s2.S2LatLng.from_degrees(-80.0, -170.0)
         b = s2.S2LatLng.from_degrees(20.0, 30.0)
         result = a - b
-        self.assertAlmostEqual(result.lat.degrees(), -90.0)
+        self.assertAlmostEqual(result.lat.degrees, -90.0)
         # -170 - 30 = -200 degrees longitude, should wrap to 160.
-        self.assertAlmostEqual(result.lng.degrees(), 160.0)
+        self.assertAlmostEqual(result.lng.degrees, 160.0)
 
     def test_scalar_multiplication(self):
         ll = s2.S2LatLng.from_degrees(10.0, 20.0)
         result1 = ll * 2.0
         result2 = 2.0 * ll
         for result in [result1, result2]:
-            self.assertAlmostEqual(result.lat.degrees(), 20.0)
-            self.assertAlmostEqual(result.lng.degrees(), 40.0)
+            self.assertAlmostEqual(result.lat.degrees, 20.0)
+            self.assertAlmostEqual(result.lng.degrees, 40.0)
 
     def test_scalar_multiplication_inf_raises(self):
         ll = s2.S2LatLng.from_degrees(10.0, 20.0)
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ll * float('inf')
-        self.assertEqual(str(cm.exception), "Scalar must be finite, got inf")
 
     def test_scalar_multiplication_nan_raises(self):
         ll = s2.S2LatLng.from_degrees(10.0, 20.0)
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             ll * float('nan')
-        self.assertEqual(str(cm.exception), "Scalar must be finite, got nan")
 
     def test_rmul_inf_raises(self):
         ll = s2.S2LatLng.from_degrees(10.0, 20.0)
@@ -277,9 +275,9 @@ class TestS2LatLng(unittest.TestCase):
         ll = s2.S2LatLng.from_degrees(60.0, 120.0)
         result = ll * 2.0
         # 120 degrees latitude -> clamped to 90
-        self.assertAlmostEqual(result.lat.degrees(), 90.0)
+        self.assertAlmostEqual(result.lat.degrees, 90.0)
         # 240 degrees longitude -> wrapped to -120
-        self.assertAlmostEqual(result.lng.degrees(), -120.0)
+        self.assertAlmostEqual(result.lng.degrees, -120.0)
 
     # String representation
 

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -1,0 +1,300 @@
+"""Tests for S2LatLng pybind11 bindings."""
+
+import math
+import unittest
+import s2geometry_pybind as s2
+
+
+class TestS2LatLng(unittest.TestCase):
+    """Test cases for S2LatLng bindings."""
+
+    # Constructors
+
+    def test_default_constructor(self):
+        ll = s2.S2LatLng()
+        self.assertEqual(ll.lat.radians(), 0.0)
+        self.assertEqual(ll.lng.radians(), 0.0)
+
+    def test_constructor_from_angles(self):
+        lat = s2.S1Angle.from_degrees(37.0)
+        lng = s2.S1Angle.from_degrees(-122.0)
+        ll = s2.S2LatLng(lat, lng)
+        self.assertAlmostEqual(ll.lat.degrees(), 37.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -122.0)
+
+    def test_constructor_from_angles_at_bounds(self):
+        ll = s2.S2LatLng(s2.S1Angle.from_degrees(90.0),
+                         s2.S1Angle.from_degrees(180.0))
+        self.assertAlmostEqual(ll.lat.degrees(), 90.0)
+        self.assertAlmostEqual(ll.lng.degrees(), 180.0)
+
+    def test_constructor_from_angles_invalid_lat_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            s2.S2LatLng(s2.S1Angle.from_degrees(91.0),
+                        s2.S1Angle.from_degrees(0.0))
+        self.assertEqual(
+            str(cm.exception),
+            "Invalid S2LatLng: [91.0000000, 0.0000000] "
+            "(latitude must be in [-90, 90], longitude in [-180, 180])")
+
+    def test_constructor_from_angles_invalid_lng_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng(s2.S1Angle.from_degrees(0.0),
+                        s2.S1Angle.from_degrees(181.0))
+
+    def test_constructor_from_point(self):
+        p = s2.S2Point(1.0, 0.0, 0.0)
+        ll = s2.S2LatLng(p)
+        self.assertAlmostEqual(ll.lat.degrees(), 0.0)
+        self.assertAlmostEqual(ll.lng.degrees(), 0.0)
+
+    def test_constructor_from_nan_point_raises(self):
+        p = s2.S2Point(float('nan'), 0.0, 0.0)
+        with self.assertRaises(ValueError):
+            s2.S2LatLng(p)
+
+    def test_constructor_from_point_north_pole(self):
+        p = s2.S2Point(0.0, 0.0, 1.0)
+        ll = s2.S2LatLng(p)
+        self.assertAlmostEqual(ll.lat.degrees(), 90.0)
+
+    # Factory methods
+
+    def test_from_radians(self):
+        ll = s2.S2LatLng.from_radians(math.pi / 4, -math.pi / 2)
+        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+
+    def test_from_radians_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_radians(2.0, 0.0)  # lat > pi/2
+
+    def test_from_degrees(self):
+        ll = s2.S2LatLng.from_degrees(45.0, -90.0)
+        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+
+    def test_from_degrees_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_degrees(91.0, 0.0)
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_degrees(0.0, 181.0)
+
+    def test_from_e5(self):
+        ll = s2.S2LatLng.from_e5(4500000, -9000000)
+        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+
+    def test_from_e5_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_e5(9100000, 0)  # 91 degrees
+
+    def test_from_e6(self):
+        ll = s2.S2LatLng.from_e6(45000000, -90000000)
+        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+
+    def test_from_e6_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_e6(91000000, 0)  # 91 degrees
+
+    def test_from_e7(self):
+        ll = s2.S2LatLng.from_e7(450000000, -900000000)
+        self.assertAlmostEqual(ll.lat.degrees(), 45.0)
+        self.assertAlmostEqual(ll.lng.degrees(), -90.0)
+
+    def test_from_e7_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_e7(910000000, 0)  # 91 degrees
+
+    def test_latitude_static(self):
+        p = s2.S2Point(0.0, 0.0, 1.0)
+        lat = s2.S2LatLng.latitude(p)
+        self.assertAlmostEqual(lat.degrees(), 90.0)
+
+    def test_longitude_static(self):
+        p = s2.S2Point(0.0, 1.0, 0.0)
+        lng = s2.S2LatLng.longitude(p)
+        self.assertAlmostEqual(lng.degrees(), 90.0)
+
+    # Properties
+
+    def test_lat_lng_are_s1angles(self):
+        ll = s2.S2LatLng.from_degrees(37.0, -122.0)
+        self.assertIsInstance(ll.lat, s2.S1Angle)
+        self.assertIsInstance(ll.lng, s2.S1Angle)
+
+    def test_lat_lng_readonly(self):
+        ll = s2.S2LatLng.from_degrees(37.0, -122.0)
+        with self.assertRaises(AttributeError):
+            ll.lat = s2.S1Angle.from_degrees(0.0)
+        with self.assertRaises(AttributeError):
+            ll.lng = s2.S1Angle.from_degrees(0.0)
+
+    def test_coords(self):
+        ll = s2.S2LatLng.from_radians(0.5, -1.0)
+        coords = ll.coords()
+        self.assertAlmostEqual(coords[0], 0.5)
+        self.assertAlmostEqual(coords[1], -1.0)
+
+    # Geometric operations
+
+    def test_to_point(self):
+        ll = s2.S2LatLng.from_degrees(0.0, 0.0)
+        p = ll.to_point()
+        self.assertAlmostEqual(p.x, 1.0)
+        self.assertAlmostEqual(p.y, 0.0)
+        self.assertAlmostEqual(p.z, 0.0)
+
+    def test_to_point_north_pole(self):
+        ll = s2.S2LatLng.from_degrees(90.0, 0.0)
+        p = ll.to_point()
+        self.assertAlmostEqual(p.x, 0.0, places=15)
+        self.assertAlmostEqual(p.y, 0.0, places=15)
+        self.assertAlmostEqual(p.z, 1.0)
+
+    def test_to_point_roundtrip(self):
+        ll = s2.S2LatLng.from_degrees(37.7749, -122.4194)
+        p = ll.to_point()
+        ll2 = s2.S2LatLng(p)
+        self.assertAlmostEqual(ll.lat.radians(), ll2.lat.radians())
+        self.assertAlmostEqual(ll.lng.radians(), ll2.lng.radians())
+
+    def test_get_distance(self):
+        # Distance between two points on the equator, 90 degrees apart.
+        a = s2.S2LatLng.from_degrees(0.0, 0.0)
+        b = s2.S2LatLng.from_degrees(0.0, 90.0)
+        self.assertAlmostEqual(a.get_distance(b).degrees(), 90.0)
+
+    def test_get_distance_same_point(self):
+        ll = s2.S2LatLng.from_degrees(37.0, -122.0)
+        self.assertAlmostEqual(ll.get_distance(ll).radians(), 0.0)
+
+    def test_to_string_in_degrees(self):
+        ll = s2.S2LatLng.from_degrees(37.794, -122.395)
+        self.assertEqual(ll.to_string_in_degrees(), "37.794000,-122.395000")
+
+    def test_approx_equals(self):
+        a = s2.S2LatLng.from_degrees(37.0, -122.0)
+        b = s2.S2LatLng.from_degrees(37.0, -122.0)
+        self.assertTrue(a.approx_equals(b))
+
+    def test_approx_equals_within_tolerance(self):
+        a = s2.S2LatLng.from_degrees(37.0, -122.0)
+        b = s2.S2LatLng.from_degrees(37.0 + 1e-16, -122.0)
+        self.assertTrue(a.approx_equals(b))
+
+    def test_approx_equals_outside_default_tolerance(self):
+        a = s2.S2LatLng.from_degrees(37.0, -122.0)
+        b = s2.S2LatLng.from_degrees(37.1, -122.0)
+        self.assertFalse(a.approx_equals(b))
+
+    def test_approx_equals_custom_tolerance(self):
+        a = s2.S2LatLng.from_degrees(37.0, -122.0)
+        b = s2.S2LatLng.from_degrees(37.1, -122.0)
+        self.assertTrue(a.approx_equals(b, s2.S1Angle.from_degrees(0.2)))
+        self.assertFalse(a.approx_equals(b, s2.S1Angle.from_degrees(0.05)))
+
+    # Operators
+
+    def test_equality(self):
+        a = s2.S2LatLng.from_degrees(37.0, -122.0)
+        b = s2.S2LatLng.from_degrees(37.0, -122.0)
+        c = s2.S2LatLng.from_degrees(38.0, -122.0)
+        self.assertTrue(a == b)
+        self.assertTrue(a != c)
+        self.assertFalse(a != b)
+        self.assertFalse(a == c)
+
+    def test_comparison(self):
+        a = s2.S2LatLng.from_degrees(10.0, 20.0)
+        b = s2.S2LatLng.from_degrees(20.0, 10.0)
+        self.assertTrue(a < b)
+        self.assertTrue(b > a)
+        self.assertTrue(a <= b)
+        self.assertTrue(b >= a)
+        self.assertTrue(a <= a)
+        self.assertTrue(a >= a)
+
+    def test_addition(self):
+        a = s2.S2LatLng.from_degrees(10.0, 20.0)
+        b = s2.S2LatLng.from_degrees(30.0, 40.0)
+        result = a + b
+        self.assertAlmostEqual(result.lat.degrees(), 40.0)
+        self.assertAlmostEqual(result.lng.degrees(), 60.0)
+
+    def test_addition_normalizes(self):
+        # 80 + 20 = 100 degrees latitude, should clamp to 90.
+        a = s2.S2LatLng.from_degrees(80.0, 170.0)
+        b = s2.S2LatLng.from_degrees(20.0, 30.0)
+        result = a + b
+        self.assertAlmostEqual(result.lat.degrees(), 90.0)
+        # 170 + 30 = 200 degrees longitude, should wrap to -160.
+        self.assertAlmostEqual(result.lng.degrees(), -160.0)
+
+    def test_subtraction(self):
+        a = s2.S2LatLng.from_degrees(30.0, 40.0)
+        b = s2.S2LatLng.from_degrees(10.0, 20.0)
+        result = a - b
+        self.assertAlmostEqual(result.lat.degrees(), 20.0)
+        self.assertAlmostEqual(result.lng.degrees(), 20.0)
+
+    def test_subtraction_normalizes(self):
+        # -80 - 20 = -100 degrees latitude, should clamp to -90.
+        a = s2.S2LatLng.from_degrees(-80.0, -170.0)
+        b = s2.S2LatLng.from_degrees(20.0, 30.0)
+        result = a - b
+        self.assertAlmostEqual(result.lat.degrees(), -90.0)
+        # -170 - 30 = -200 degrees longitude, should wrap to 160.
+        self.assertAlmostEqual(result.lng.degrees(), 160.0)
+
+    def test_scalar_multiplication(self):
+        ll = s2.S2LatLng.from_degrees(10.0, 20.0)
+        result1 = ll * 2.0
+        result2 = 2.0 * ll
+        for result in [result1, result2]:
+            self.assertAlmostEqual(result.lat.degrees(), 20.0)
+            self.assertAlmostEqual(result.lng.degrees(), 40.0)
+
+    def test_scalar_multiplication_inf_raises(self):
+        ll = s2.S2LatLng.from_degrees(10.0, 20.0)
+        with self.assertRaises(ValueError) as cm:
+            ll * float('inf')
+        self.assertEqual(str(cm.exception), "Scalar must be finite, got inf")
+
+    def test_scalar_multiplication_nan_raises(self):
+        ll = s2.S2LatLng.from_degrees(10.0, 20.0)
+        with self.assertRaises(ValueError) as cm:
+            ll * float('nan')
+        self.assertEqual(str(cm.exception), "Scalar must be finite, got nan")
+
+    def test_rmul_inf_raises(self):
+        ll = s2.S2LatLng.from_degrees(10.0, 20.0)
+        with self.assertRaises(ValueError):
+            float('inf') * ll
+
+    def test_scalar_multiplication_normalizes(self):
+        ll = s2.S2LatLng.from_degrees(60.0, 120.0)
+        result = ll * 2.0
+        # 120 degrees latitude -> clamped to 90
+        self.assertAlmostEqual(result.lat.degrees(), 90.0)
+        # 240 degrees longitude -> wrapped to -120
+        self.assertAlmostEqual(result.lng.degrees(), -120.0)
+
+    # String representation
+
+    def test_repr(self):
+        ll = s2.S2LatLng.from_degrees(45.0, -90.0)
+        self.assertEqual(repr(ll), "S2LatLng([45.0000000, -90.0000000])")
+
+    def test_str(self):
+        ll = s2.S2LatLng.from_degrees(45.0, -90.0)
+        self.assertEqual(str(ll), "[45.0000000, -90.0000000]")
+
+    def test_repr_zero(self):
+        ll = s2.S2LatLng()
+        self.assertEqual(repr(ll), "S2LatLng([0.0000000, 0.0000000])")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -34,7 +34,7 @@ class TestS2LatLng(unittest.TestCase):
                         s2.S1Angle.from_degrees(0.0))
         self.assertEqual(
             str(cm.exception),
-            "Invalid S2LatLng: [91.0000000, 0.0000000] "
+            "Invalid S2LatLng: (91, 0) "
             "(latitude must be in [-90, 90], longitude in [-180, 180])")
 
     def test_constructor_from_angles_invalid_lng_raises(self):
@@ -68,6 +68,28 @@ class TestS2LatLng(unittest.TestCase):
     def test_from_radians_invalid_raises(self):
         with self.assertRaises(ValueError):
             s2.S2LatLng.from_radians(2.0, 0.0)  # lat > pi/2
+
+    def test_from_radians_normalized_clamps_latitude(self):
+        ll = s2.S2LatLng.from_radians_normalized(2.0, 0.0)  # lat > pi/2
+        self.assertAlmostEqual(ll.lat.radians, math.pi / 2)
+        self.assertAlmostEqual(ll.lng.radians, 0.0)
+
+    def test_from_radians_normalized_wraps_longitude(self):
+        # 3*pi/2 wraps to -pi/2
+        ll = s2.S2LatLng.from_radians_normalized(0.0, 3 * math.pi / 2)
+        self.assertAlmostEqual(ll.lat.radians, 0.0)
+        self.assertAlmostEqual(ll.lng.radians, -math.pi / 2)
+
+    def test_from_radians_normalized_in_range_is_unchanged(self):
+        ll = s2.S2LatLng.from_radians_normalized(0.5, -1.0)
+        self.assertAlmostEqual(ll.lat.radians, 0.5)
+        self.assertAlmostEqual(ll.lng.radians, -1.0)
+
+    def test_from_radians_normalized_non_finite_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_radians_normalized(float('nan'), 0.0)
+        with self.assertRaises(ValueError):
+            s2.S2LatLng.from_radians_normalized(0.0, float('inf'))
 
     def test_from_degrees(self):
         ll = s2.S2LatLng.from_degrees(45.0, -90.0)
@@ -133,9 +155,10 @@ class TestS2LatLng(unittest.TestCase):
 
     def test_coords(self):
         ll = s2.S2LatLng.from_radians(0.5, -1.0)
-        coords = ll.coords()
-        self.assertAlmostEqual(coords[0], 0.5)
-        self.assertAlmostEqual(coords[1], -1.0)
+        coords = ll.coords
+        self.assertIsInstance(coords, s2.R2Point)
+        self.assertAlmostEqual(coords.x, 0.5)
+        self.assertAlmostEqual(coords.y, -1.0)
 
     # Geometric operations
 

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -69,27 +69,27 @@ class TestS2LatLng(unittest.TestCase):
         with self.assertRaises(ValueError):
             s2.S2LatLng.from_radians(2.0, 0.0)  # lat > pi/2
 
-    def test_from_radians_normalized_clamps_latitude(self):
-        ll = s2.S2LatLng.from_radians_normalized(2.0, 0.0)  # lat > pi/2
+    def test_normalized_from_radians_clamps_latitude(self):
+        ll = s2.S2LatLng.normalized_from_radians(2.0, 0.0)  # lat > pi/2
         self.assertAlmostEqual(ll.lat.radians, math.pi / 2)
         self.assertAlmostEqual(ll.lng.radians, 0.0)
 
-    def test_from_radians_normalized_wraps_longitude(self):
+    def test_normalized_from_radians_wraps_longitude(self):
         # 3*pi/2 wraps to -pi/2
-        ll = s2.S2LatLng.from_radians_normalized(0.0, 3 * math.pi / 2)
+        ll = s2.S2LatLng.normalized_from_radians(0.0, 3 * math.pi / 2)
         self.assertAlmostEqual(ll.lat.radians, 0.0)
         self.assertAlmostEqual(ll.lng.radians, -math.pi / 2)
 
-    def test_from_radians_normalized_in_range_is_unchanged(self):
-        ll = s2.S2LatLng.from_radians_normalized(0.5, -1.0)
+    def test_normalized_from_radians_in_range_is_unchanged(self):
+        ll = s2.S2LatLng.normalized_from_radians(0.5, -1.0)
         self.assertAlmostEqual(ll.lat.radians, 0.5)
         self.assertAlmostEqual(ll.lng.radians, -1.0)
 
-    def test_from_radians_normalized_non_finite_raises(self):
+    def test_normalized_from_radians_non_finite_raises(self):
         with self.assertRaises(ValueError):
-            s2.S2LatLng.from_radians_normalized(float('nan'), 0.0)
+            s2.S2LatLng.normalized_from_radians(float('nan'), 0.0)
         with self.assertRaises(ValueError):
-            s2.S2LatLng.from_radians_normalized(0.0, float('inf'))
+            s2.S2LatLng.normalized_from_radians(0.0, float('inf'))
 
     def test_from_degrees(self):
         ll = s2.S2LatLng.from_degrees(45.0, -90.0)


### PR DESCRIPTION
Add pybind11 bindings for S2LatLng.

Supports downstream PR for S2CellId.

(Part of a series of addressing https://github.com/google/s2geometry/pull/524)