### PR TITLE
pybind: Add S2CellId bindings

### DIFF
--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -33,6 +33,7 @@ pybind_extension(
         ":s1interval_bindings",
         ":s2point_bindings",
         ":s2latlng_bindings",
+        ":s2cell_id_bindings",
     ],
 )
 
@@ -94,6 +95,14 @@ pybind_library(
     ],
 )
 
+pybind_library(
+    name = "s2cell_id_bindings",
+    srcs = ["s2cell_id_bindings.cc"],
+    deps = [
+        "//:s2",
+    ],
+)
+
 # ========================================
 # Python Tests
 # ========================================
@@ -137,5 +146,11 @@ py_test(
 py_test(
     name = "s2latlng_test",
     srcs = ["s2latlng_test.py"],
+    deps = [":s2geometry_pybind"],
+)
+
+py_test(
+    name = "s2cell_id_test",
+    srcs = ["s2cell_id_test.py"],
     deps = [":s2geometry_pybind"],
 )

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -76,6 +76,10 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 - C++ functions that accept or return a vector object use a Python tuple (of length matching the vector dimension)
 - Array indexing operators (e.g., `point[0]`) are not currently supported
 
+**Iterators:**
+- Some classes support `__iter__` for traversal (e.g., `for c in S2CellId.cells(level=5):`) or expose methods that return iterables.
+- Iterables support forward iteration, `len()`, indexing, `in`, and `reversed()` unless otherwise noted.
+
 **Serialization:**
 - The C++ Encoder/Decoder serialization functions are not currently supported
 
@@ -145,10 +149,12 @@ Use the following sections to organize functions within the bindings files and t
 
 1. **Constructors** - Default constructors and constructors with parameters
 2. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
-3. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
-4. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
-5. **Geometric operations** - All other methods including conversions, computations, containment checks, set operations, normalization, and distance calculations
-6. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
-7. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
-8. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
-9. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)
+3. **Constants** - Class-level constants (e.g., `S2CellId.kMaxLevel`, `S2CellId.kNumFaces`)
+4. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
+5. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
+6. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations
+7. **Traversal** - Methods for navigating hierarchies and iterating over related cells (e.g., `parent`, `child`, `children()`, `cells()`, neighbor methods)
+8. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
+9. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
+10. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
+11. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -149,7 +149,8 @@ Use the following sections to organize functions within the bindings files and t
 4. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
 5. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
 6. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations
-7. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
-8. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
-9. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
-10. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)
+7. **Traversal** - Methods for navigating a cell hierarchy (e.g., `parent`, `child`, neighbor methods)
+8. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
+9. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
+10. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
+11. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -76,10 +76,6 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 - C++ functions that accept or return a vector object use a Python tuple (of length matching the vector dimension)
 - Array indexing operators (e.g., `point[0]`) are not currently supported
 
-**Iterators:**
-- Some classes support `__iter__` for traversal (e.g., `for c in S2CellId.cells(level=5):`) or expose methods that return iterables.
-- Iterables support forward iteration, `len()`, indexing, `in`, and `reversed()` unless otherwise noted.
-
 **Serialization:**
 - The C++ Encoder/Decoder serialization functions are not currently supported
 
@@ -153,8 +149,7 @@ Use the following sections to organize functions within the bindings files and t
 4. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
 5. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
 6. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations
-7. **Traversal** - Methods for navigating hierarchies and iterating over related cells (e.g., `parent`, `child`, `children()`, `cells()`, neighbor methods)
-8. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
-9. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
-10. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
-11. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)
+7. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
+8. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
+9. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
+10. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -144,8 +144,8 @@ To add bindings for a new class:
 Use the following sections to organize functions within the bindings files and tests. Secondarily, follow the order in which functions are declared in the C++ headers.
 
 1. **Constructors** - Default constructors and constructors with parameters
-1. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
 1. **Constants** - Class-level constants in upper snake case (e.g., `S2CellId.MAX_LEVEL`, `S2CellId.NUM_FACES`)
+1. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
 1. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
 1. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
 1. **Geometric operations** - All other methods including conversions, computations, containment checks, set operations, normalization, and distance calculations

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -149,7 +149,7 @@ Use the following sections to organize functions within the bindings files and t
 
 1. **Constructors** - Default constructors and constructors with parameters
 2. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
-3. **Constants** - Class-level constants (e.g., `S2CellId.kMaxLevel`, `S2CellId.kNumFaces`)
+3. **Constants** - Class-level constants in upper snake case (e.g., `S2CellId.MAX_LEVEL`, `S2CellId.NUM_FACES`)
 4. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
 5. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
 6. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -144,13 +144,13 @@ To add bindings for a new class:
 Use the following sections to organize functions within the bindings files and tests. Secondarily, follow the order in which functions are declared in the C++ headers.
 
 1. **Constructors** - Default constructors and constructors with parameters
-2. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
-3. **Constants** - Class-level constants in upper snake case (e.g., `S2CellId.MAX_LEVEL`, `S2CellId.NUM_FACES`)
-4. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
-5. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
-6. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations
-7. **Traversal** - Methods for navigating a cell hierarchy (e.g., `parent`, `child`, neighbor methods)
-8. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
-9. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
-10. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
-11. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)
+1. **Factory methods** - Static factory methods (e.g., `from_degrees`, `from_radians`, `zero`, `invalid`)
+1. **Constants** - Class-level constants in upper snake case (e.g., `S2CellId.MAX_LEVEL`, `S2CellId.NUM_FACES`)
+1. **Properties** - Mutable and read-only properties (e.g., coordinate accessors like `x`, `y`, `lo`, `hi`)
+1. **Predicates** - Simple boolean state checks (e.g., `is_empty`, `is_valid`, `is_full`)
+1. **Geometric operations** - Conversions, computations, containment checks, set operations, normalization, and distance calculations
+1. **Traversal** - Methods for navigating a cell hierarchy (e.g., `parent`, `child`, neighbor methods)
+1. **Vector operations** - Methods from the Vector base class (e.g., `norm`, `norm2`, `normalize`, `dot_prod`, `cross_prod`, `angle`). Only applicable to classes that inherit from `util/math/vector.h`
+1. **Operators** - Operator overloads (e.g., `==`, `+`, `*`, comparison operators)
+1. **String representation** - `__repr__` (which also provides `__str__`), and string conversion methods like `to_string_in_degrees`
+1. **Module-level functions** - Standalone functions (e.g., trigonometric functions for S1Angle)

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -10,6 +10,7 @@ void bind_s1angle(py::module& m);
 void bind_s1interval(py::module& m);
 void bind_s2point(py::module& m);
 void bind_s2latlng(py::module& m);
+void bind_s2cell_id(py::module& m);
 
 PYBIND11_MODULE(s2geometry_bindings, m) {
   m.doc() = "S2 Geometry Python bindings using pybind11";
@@ -32,4 +33,5 @@ PYBIND11_MODULE(s2geometry_bindings, m) {
 
   // Deps: s1angle, s2point
   bind_s2latlng(m);
+  bind_s2cell_id(m);
 }

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -33,5 +33,7 @@ PYBIND11_MODULE(s2geometry_bindings, m) {
 
   // Deps: s1angle, s2point
   bind_s2latlng(m);
+
+  // Deps: s1angle, s2point, s2latlng, r2point, r2rect
   bind_s2cell_id(m);
 }

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -1,0 +1,419 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "s2/s2cell_id.h"
+#include "s2/s2latlng.h"
+
+namespace py = pybind11;
+
+namespace {
+
+void MaybeThrowNotValid(S2CellId id) {
+  if (!id.is_valid()) {
+    throw py::value_error("Invalid S2CellId: " + id.ToString());
+  }
+}
+
+void MaybeThrowLevelOutOfRange(int level, int min, int max) {
+  if (level < min || level > max) {
+    throw py::value_error("Level " + std::to_string(level) +
+                          " out of range [" + std::to_string(min) +
+                          ", " + std::to_string(max) + "]");
+  }
+}
+
+void MaybeThrowFaceOutOfRange(int face) {
+  if (face < 0 || face >= S2CellId::kNumFaces) {
+    throw py::value_error("Face " + std::to_string(face) +
+                          " out of range [0, " +
+                          std::to_string(S2CellId::kNumFaces - 1) + "]");
+  }
+}
+
+void MaybeThrowIfLeaf(S2CellId id) {
+  if (id.is_leaf()) {
+    throw py::value_error("Leaf cell has no children");
+  }
+}
+
+void MaybeThrowIfFace(S2CellId id) {
+  if (id.is_face()) {
+    throw py::value_error("Face cell has no parent");
+  }
+}
+
+void MaybeThrowChildPositionOutOfRange(int position) {
+  if (position < 0 || position > 3) {
+    throw py::value_error("Child position " + std::to_string(position) +
+                          " out of range [0, 3]");
+  }
+}
+
+// A range of S2CellIds at the same level, supporting len, indexing, iteration,
+// and reverse iteration. The range is [begin, end) where end is exclusive.
+struct S2CellIdRange {
+  S2CellId begin;
+  S2CellId end;
+
+  int64_t size() const {
+    return end.distance_from_begin() - begin.distance_from_begin();
+  }
+
+  S2CellId item(int64_t i) const {
+    int64_t len = size();
+    if (i < 0) i += len;
+    if (i < 0 || i >= len) {
+      throw py::index_error("index " + std::to_string(i) + " out of range");
+    }
+    return begin.advance(i);
+  }
+
+  bool contains(S2CellId cell) const {
+    return cell >= begin && cell < end &&
+           cell.level() == begin.level();
+  }
+};
+
+// Forward iterator for S2CellIdRange.
+struct S2CellIdForwardIter {
+  S2CellId cur;
+  S2CellId end;
+
+  S2CellId next() {
+    if (cur == end) throw py::stop_iteration();
+    S2CellId result = cur;
+    cur = cur.next();
+    return result;
+  }
+};
+
+// Reverse iterator for S2CellIdRange.
+struct S2CellIdReverseIter {
+  S2CellId cur;
+  S2CellId begin;
+  bool done;
+
+  S2CellId next() {
+    if (done) throw py::stop_iteration();
+    S2CellId result = cur;
+    if (cur == begin) {
+      done = true;
+    } else {
+      cur = cur.prev();
+    }
+    return result;
+  }
+};
+
+}  // namespace
+
+void bind_s2cell_id(py::module& m) {
+  py::class_<S2CellId>(m, "S2CellId",
+      "A 64-bit unsigned integer that uniquely identifies a cell in the\n"
+      "S2 cell decomposition.\n\n"
+      "See s2/s2cell_id.h for comprehensive documentation.")
+      // Constructors
+      .def(py::init([](uint64_t id) {
+               S2CellId cell(id);
+               MaybeThrowNotValid(cell);
+               return cell;
+           }),
+           py::arg("id"),
+           "Construct from a 64-bit cell id.\n\n"
+           "Raises ValueError if the id is not valid.")
+      .def(py::init([](const S2Point& p) {
+               return S2CellId(p);
+           }),
+           py::arg("point"),
+           "Construct a leaf cell containing the given point.\n\n"
+           "The point does not need to be normalized.")
+      .def(py::init([](const S2LatLng& ll) {
+               return S2CellId(ll);
+           }),
+           py::arg("latlng"),
+           "Construct a leaf cell containing the given S2LatLng.")
+
+      // Constants
+      .def_property_readonly_static("kMaxLevel",
+           [](py::object) { return S2CellId::kMaxLevel; },
+           "Maximum cell subdivision level (30)")
+      .def_property_readonly_static("kNumFaces",
+           [](py::object) { return S2CellId::kNumFaces; },
+           "Number of cube faces (6)")
+
+      // Factory methods
+      .def_static("from_face", [](int face) {
+               MaybeThrowFaceOutOfRange(face);
+               return S2CellId::FromFace(face);
+           }, py::arg("face"),
+           "Return the cell corresponding to a given S2 cube face (0..5).\n\n"
+           "Raises ValueError if face is out of range.")
+      .def_static("from_face_pos_level", [](int face, uint64_t pos, int level) {
+               MaybeThrowFaceOutOfRange(face);
+               MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
+               return S2CellId::FromFacePosLevel(face, pos, level);
+           },
+           py::arg("face"), py::arg("pos"), py::arg("level"),
+           "Return a cell given its face, Hilbert curve position, and level.\n\n"
+           "Raises ValueError if face or level is out of range.")
+      .def_static("from_token", [](const std::string& token) {
+               S2CellId cell = S2CellId::FromToken(token);
+               if (cell == S2CellId::None()) {
+                 throw py::value_error("Invalid S2CellId token: '" + token + "'");
+               }
+               return cell;
+           }, py::arg("token"),
+           "Return a cell from its token string.\n\n"
+           "Raises ValueError if the token is malformed.")
+      .def_static("from_debug_string", [](const std::string& str) {
+               S2CellId cell = S2CellId::FromDebugString(str);
+               if (cell == S2CellId::None()) {
+                 throw py::value_error(
+                     "Invalid S2CellId debug string: '" + str + "'");
+               }
+               return cell;
+           }, py::arg("str"),
+           "Return a cell from its debug string (e.g. \"3/02\").\n\n"
+           "Raises ValueError if the string is malformed.")
+      .def_static("from_face_ij", [](int face, int i, int j) {
+               MaybeThrowFaceOutOfRange(face);
+               return S2CellId::FromFaceIJ(face, i, j);
+           },
+           py::arg("face"), py::arg("i"), py::arg("j"),
+           "Return a leaf cell given its cube face and (i, j) coordinates")
+
+      // Properties
+      .def_property_readonly("id", &S2CellId::id,
+                             "The 64-bit unique identifier for this cell")
+
+      // Predicates
+      .def("is_leaf", &S2CellId::is_leaf,
+           "Return true if this is a leaf cell (level == kMaxLevel)")
+      .def("is_face", &S2CellId::is_face,
+           "Return true if this is a top-level face cell (level == 0)")
+
+      // Geometric operations
+      .def("face", &S2CellId::face,
+           "Return which cube face this cell belongs to (0..5)")
+      .def("pos", &S2CellId::pos,
+           "Return the position along the Hilbert curve over this face")
+      .def("level", &S2CellId::level,
+           "Return the subdivision level (0..kMaxLevel)")
+      .def("get_size_ij",
+           py::overload_cast<>(&S2CellId::GetSizeIJ, py::const_),
+           "Return the edge length of this cell in (i,j)-space")
+      .def_static("get_size_ij_for_level", [](int level) {
+               MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
+               return S2CellId::GetSizeIJ(level);
+           }, py::arg("level"),
+           "Return the edge length in (i,j)-space of cells at the given level")
+      .def("get_size_st",
+           py::overload_cast<>(&S2CellId::GetSizeST, py::const_),
+           "Return the edge length of this cell in (s,t)-space")
+      .def_static("get_size_st_for_level", [](int level) {
+               MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
+               return S2CellId::GetSizeST(level);
+           }, py::arg("level"),
+           "Return the edge length in (s,t)-space of cells at the given level")
+      .def("to_point", &S2CellId::ToPoint,
+           "Return the center of the cell as a normalized S2Point")
+      .def("to_point_raw", &S2CellId::ToPointRaw,
+           "Return the center of the cell as an S2Point (not normalized)")
+      .def("to_lat_lng", &S2CellId::ToLatLng,
+           "Return the S2LatLng corresponding to the center of the cell")
+      .def("get_center_st", &S2CellId::GetCenterST,
+           "Return the center of the cell in (s,t) coordinates")
+      .def("get_bound_st", &S2CellId::GetBoundST,
+           "Return the bounds of this cell in (s,t)-space")
+      .def("get_center_uv", &S2CellId::GetCenterUV,
+           "Return the center of the cell in (u,v) coordinates")
+      .def("get_bound_uv", &S2CellId::GetBoundUV,
+           "Return the bounds of this cell in (u,v)-space")
+      .def_static("expanded_by_distance_uv", &S2CellId::ExpandedByDistanceUV,
+           py::arg("uv"), py::arg("distance"),
+           "Expand a (u,v) rectangle to contain all points within the\n"
+           "given distance of the boundary")
+      .def("get_center_si_ti", [](S2CellId self) {
+               int si, ti;
+               int face = self.GetCenterSiTi(&si, &ti);
+               return py::make_tuple(face, si, ti);
+           },
+           "Return the (face, si, ti) coordinates of the cell center")
+      .def("to_face_ij_orientation", [](S2CellId self) {
+               int i, j, orientation;
+               int face = self.ToFaceIJOrientation(&i, &j, &orientation);
+               return py::make_tuple(face, i, j, orientation);
+           },
+           "Return (face, i, j, orientation) for this cell")
+      .def("child_position", [](S2CellId self) {
+               MaybeThrowLevelOutOfRange(self.level(), 1, S2CellId::kMaxLevel);
+               return self.child_position();
+           },
+           "Return the child position (0..3) within this cell's parent.\n\n"
+           "Raises ValueError if level < 1.")
+      .def("child_position_at_level", [](S2CellId self, int level) {
+               MaybeThrowLevelOutOfRange(level, 1, self.level());
+               return self.child_position(level);
+           }, py::arg("level"),
+           "Return the child position (0..3) of this cell's ancestor at\n"
+           "the given level within its parent.\n\n"
+           "Raises ValueError if level is out of range [1, self.level()].")
+      .def("to_token", &S2CellId::ToToken,
+           "Return a compact token string for this cell.\n\n"
+           "Tokens preserve ordering and the round-trip\n"
+           "from_token(cell.to_token()) == cell is guaranteed.")
+      .def("to_string", &S2CellId::ToString,
+           "Return the debug string (e.g. \"3/02\")")
+      .def("range_min", &S2CellId::range_min,
+           "Return the minimum cell id contained within this cell")
+      .def("range_max", &S2CellId::range_max,
+           "Return the maximum cell id contained within this cell")
+      .def("contains", &S2CellId::contains, py::arg("other"),
+           "Return true if the given cell is contained within this one")
+      .def("intersects", &S2CellId::intersects, py::arg("other"),
+           "Return true if the given cell intersects this one")
+      .def("get_common_ancestor_level", &S2CellId::GetCommonAncestorLevel,
+           py::arg("other"),
+           "Return the level of the lowest common ancestor.\n\n"
+           "Returns -1 if the cells are from different faces.")
+
+      // Traversal
+      .def("parent", [](S2CellId self) {
+               MaybeThrowIfFace(self);
+               return self.parent();
+           },
+           "Return the cell at the previous level.\n\n"
+           "Raises ValueError if this is already a face cell.")
+      .def("parent_at_level", [](S2CellId self, int level) {
+               MaybeThrowLevelOutOfRange(level, 0, self.level());
+               return self.parent(level);
+           }, py::arg("level"),
+           "Return the cell at the given level.\n\n"
+           "Raises ValueError if level is out of range [0, self.level()].")
+      .def("child", [](S2CellId self, int position) {
+               MaybeThrowIfLeaf(self);
+               MaybeThrowChildPositionOutOfRange(position);
+               return self.child(position);
+           }, py::arg("position"),
+           "Return the immediate child at the given position (0..3).\n\n"
+           "Raises ValueError if this is a leaf cell or position is out of range.")
+      .def("children", [](S2CellId self, py::object level_obj) {
+               MaybeThrowIfLeaf(self);
+               S2CellId begin, end;
+               if (level_obj.is_none()) {
+                 begin = self.child_begin();
+                 end = self.child_end();
+               } else {
+                 int level = level_obj.cast<int>();
+                 MaybeThrowLevelOutOfRange(level, self.level(),
+                                           S2CellId::kMaxLevel);
+                 begin = self.child_begin(level);
+                 end = self.child_end(level);
+               }
+               return S2CellIdRange{begin, end};
+           }, py::arg("level") = py::none(),
+           "Return a range over the children of this cell.\n\n"
+           "With no argument, returns the 4 immediate children.\n"
+           "With a level argument, returns all descendants at that level.\n"
+           "The range supports len(), indexing, iteration, and reversed().\n"
+           "Raises ValueError if this is a leaf cell or level is out of range.")
+      .def_static("cells", [](int level) {
+               MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
+               return S2CellIdRange{S2CellId::Begin(level),
+                                    S2CellId::End(level)};
+           }, py::arg("level"),
+           "Return a range over all cells at the given level across all 6 faces.\n\n"
+           "The range supports len(), indexing, iteration, and reversed().\n"
+           "Warning: the number of cells grows as 6 * 4^level.")
+      .def("__iter__", [](S2CellId self) {
+               return S2CellIdForwardIter{self, S2CellId::End(self.level())};
+           },
+           "Iterate along the Hilbert curve at this cell's level,\n"
+           "starting from this cell to the end of the level.")
+      .def("__reversed__", [](S2CellId self) {
+               return S2CellIdReverseIter{self, S2CellId::Begin(self.level()),
+                                          false};
+           },
+           "Iterate in reverse along the Hilbert curve at this cell's level,\n"
+           "starting from this cell back to the beginning of the level.")
+      .def("get_edge_neighbors", [](S2CellId self) {
+               S2CellId neighbors[4];
+               self.GetEdgeNeighbors(neighbors);
+               return py::make_tuple(neighbors[0], neighbors[1],
+                                     neighbors[2], neighbors[3]);
+           },
+           "Return the four cells adjacent across this cell's edges")
+      .def("get_vertex_neighbors", [](S2CellId self, int level) {
+               MaybeThrowLevelOutOfRange(level, 0, self.level() - 1);
+               std::vector<S2CellId> output;
+               self.AppendVertexNeighbors(level, &output);
+               return output;
+           }, py::arg("level"),
+           "Return the neighbors of the closest vertex at the given level.\n\n"
+           "Normally returns 4 neighbors, but may return 3 for cube vertices.\n"
+           "Raises ValueError if level >= self.level().")
+      .def("get_all_neighbors", [](S2CellId self, int level) {
+               MaybeThrowLevelOutOfRange(level, self.level(),
+                                         S2CellId::kMaxLevel);
+               std::vector<S2CellId> output;
+               self.AppendAllNeighbors(level, &output);
+               return output;
+           }, py::arg("level"),
+           "Return all neighbors of this cell at the given level.\n\n"
+           "Raises ValueError if level < self.level().")
+
+      // Operators
+      .def(py::self == py::self, "Return true if cell ids are equal")
+      .def(py::self != py::self, "Return true if cell ids are not equal")
+      .def(py::self < py::self, "Compare cell ids by their numeric value")
+      .def(py::self > py::self, "Compare cell ids by their numeric value")
+      .def(py::self <= py::self, "Compare cell ids by their numeric value")
+      .def(py::self >= py::self, "Compare cell ids by their numeric value")
+      .def("__hash__", [](S2CellId self) {
+        return absl::Hash<S2CellId>()(self);
+      })
+
+      // String representation
+      .def("__repr__", [](S2CellId id) {
+        std::ostringstream oss;
+        oss << "S2CellId(" << id << ")";
+        return oss.str();
+      })
+      .def("__str__", [](S2CellId id) {
+        std::ostringstream oss;
+        oss << id;
+        return oss.str();
+      });
+
+  py::class_<S2CellIdRange>(m, "S2CellIdRange")
+      .def("__len__", &S2CellIdRange::size)
+      .def("__getitem__", &S2CellIdRange::item, py::arg("index"))
+      .def("__contains__", &S2CellIdRange::contains, py::arg("cell"))
+      .def("__iter__", [](const S2CellIdRange& self) {
+        return S2CellIdForwardIter{self.begin, self.end};
+      })
+      .def("__reversed__", [](const S2CellIdRange& self) {
+        if (self.size() == 0) {
+          return S2CellIdReverseIter{self.begin, self.begin, true};
+        }
+        return S2CellIdReverseIter{self.end.prev(), self.begin, false};
+      });
+
+  py::class_<S2CellIdForwardIter>(m, "S2CellIdForwardIter")
+      .def("__iter__", [](S2CellIdForwardIter& self) -> S2CellIdForwardIter& {
+        return self;
+      })
+      .def("__next__", &S2CellIdForwardIter::next);
+
+  py::class_<S2CellIdReverseIter>(m, "S2CellIdReverseIter")
+      .def("__iter__", [](S2CellIdReverseIter& self) -> S2CellIdReverseIter& {
+        return self;
+      })
+      .def("__next__", &S2CellIdReverseIter::next);
+}

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -4,9 +4,9 @@
 
 #include <cstdint>
 #include <sstream>
-#include <string>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "s2/s2cell_id.h"
 #include "s2/s2latlng.h"
 
@@ -22,17 +22,16 @@ void MaybeThrowNotValid(S2CellId id) {
 
 void MaybeThrowLevelOutOfRange(int level, int min, int max) {
   if (level < min || level > max) {
-    throw py::value_error("Level " + std::to_string(level) +
-                          " out of range [" + std::to_string(min) +
-                          ", " + std::to_string(max) + "]");
+    throw py::value_error(
+        absl::StrCat("Level ", level, " out of range [", min, ", ", max, "]"));
   }
 }
 
 void MaybeThrowFaceOutOfRange(int face) {
   if (face < 0 || face >= S2CellId::kNumFaces) {
-    throw py::value_error("Face " + std::to_string(face) +
-                          " out of range [0, " +
-                          std::to_string(S2CellId::kNumFaces - 1) + "]");
+    throw py::value_error(
+        absl::StrCat("Face ", face, " out of range [0, ",
+                     S2CellId::kNumFaces - 1, "]"));
   }
 }
 
@@ -50,8 +49,8 @@ void MaybeThrowIfFace(S2CellId id) {
 
 void MaybeThrowChildPositionOutOfRange(int position) {
   if (position < 0 || position > 3) {
-    throw py::value_error("Child position " + std::to_string(position) +
-                          " out of range [0, 3]");
+    throw py::value_error(
+        absl::StrCat("Child position ", position, " out of range [0, 3]"));
   }
 }
 
@@ -69,7 +68,7 @@ struct S2CellIdRange {
     int64_t len = size();
     if (i < 0) i += len;
     if (i < 0 || i >= len) {
-      throw py::index_error("index " + std::to_string(i) + " out of range");
+      throw py::index_error(absl::StrCat("index ", i, " out of range"));
     }
     return begin.advance(i);
   }

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -16,7 +16,7 @@ namespace {
 
 void MaybeThrowNotValid(S2CellId id) {
   if (!id.is_valid()) {
-    throw py::value_error("Invalid S2CellId: " + id.ToString());
+    throw py::value_error(absl::StrCat("Invalid S2CellId: ", id.ToString()));
   }
 }
 
@@ -139,10 +139,10 @@ void bind_s2cell_id(py::module& m) {
            "Construct a leaf cell containing the given S2LatLng.")
 
       // Constants
-      .def_property_readonly_static("kMaxLevel",
+      .def_property_readonly_static("MAX_LEVEL",
            [](py::object) { return S2CellId::kMaxLevel; },
            "Maximum cell subdivision level (30)")
-      .def_property_readonly_static("kNumFaces",
+      .def_property_readonly_static("NUM_FACES",
            [](py::object) { return S2CellId::kNumFaces; },
            "Number of cube faces (6)")
 
@@ -222,34 +222,16 @@ void bind_s2cell_id(py::module& m) {
            "Return the edge length in (s,t)-space of cells at the given level")
       .def("to_point", &S2CellId::ToPoint,
            "Return the center of the cell as a normalized S2Point")
-      .def("to_point_raw", &S2CellId::ToPointRaw,
-           "Return the center of the cell as an S2Point (not normalized)")
       .def("to_lat_lng", &S2CellId::ToLatLng,
            "Return the S2LatLng corresponding to the center of the cell")
       .def("get_center_st", &S2CellId::GetCenterST,
-           "Return the center of the cell in (s,t) coordinates")
+           "Return the center of the cell in (s,t)-space")
       .def("get_bound_st", &S2CellId::GetBoundST,
            "Return the bounds of this cell in (s,t)-space")
       .def("get_center_uv", &S2CellId::GetCenterUV,
-           "Return the center of the cell in (u,v) coordinates")
+           "Return the center of the cell in (u,v)-space")
       .def("get_bound_uv", &S2CellId::GetBoundUV,
            "Return the bounds of this cell in (u,v)-space")
-      .def_static("expanded_by_distance_uv", &S2CellId::ExpandedByDistanceUV,
-           py::arg("uv"), py::arg("distance"),
-           "Expand a (u,v) rectangle to contain all points within the\n"
-           "given distance of the boundary")
-      .def("get_center_si_ti", [](S2CellId self) {
-               int si, ti;
-               int face = self.GetCenterSiTi(&si, &ti);
-               return py::make_tuple(face, si, ti);
-           },
-           "Return the (face, si, ti) coordinates of the cell center")
-      .def("to_face_ij_orientation", [](S2CellId self) {
-               int i, j, orientation;
-               int face = self.ToFaceIJOrientation(&i, &j, &orientation);
-               return py::make_tuple(face, i, j, orientation);
-           },
-           "Return (face, i, j, orientation) for this cell")
       .def("child_position", [](S2CellId self) {
                MaybeThrowLevelOutOfRange(self.level(), 1, S2CellId::kMaxLevel);
                return self.child_position();
@@ -267,8 +249,6 @@ void bind_s2cell_id(py::module& m) {
            "Return a compact token string for this cell.\n\n"
            "Tokens preserve ordering and the round-trip\n"
            "from_token(cell.to_token()) == cell is guaranteed.")
-      .def("to_string", &S2CellId::ToString,
-           "Return the debug string (e.g. \"3/02\")")
       .def("range_min", &S2CellId::range_min,
            "Return the minimum cell id contained within this cell")
       .def("range_max", &S2CellId::range_max,

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -164,22 +164,13 @@ void bind_s2cell_id(py::module& m) {
       .def_static("from_token", [](const std::string& token) {
                S2CellId cell = S2CellId::FromToken(token);
                if (cell == S2CellId::None()) {
-                 throw py::value_error("Invalid S2CellId token: '" + token + "'");
+                 throw py::value_error(
+                     absl::StrCat("Invalid S2CellId token: '", token, "'"));
                }
                return cell;
            }, py::arg("token"),
            "Return a cell from its token string.\n\n"
            "Raises ValueError if the token is malformed.")
-      .def_static("from_debug_string", [](const std::string& str) {
-               S2CellId cell = S2CellId::FromDebugString(str);
-               if (cell == S2CellId::None()) {
-                 throw py::value_error(
-                     "Invalid S2CellId debug string: '" + str + "'");
-               }
-               return cell;
-           }, py::arg("str"),
-           "Return a cell from its debug string (e.g. \"3/02\").\n\n"
-           "Raises ValueError if the string is malformed.")
       .def_static("from_face_ij", [](int face, int i, int j) {
                MaybeThrowFaceOutOfRange(face);
                return S2CellId::FromFaceIJ(face, i, j);

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -36,13 +36,20 @@ void MaybeThrowFaceOutOfRange(int face) {
 
 void MaybeThrowIfLeaf(S2CellId id) {
   if (id.is_leaf()) {
-    throw py::value_error("Leaf cell has no children");
+    throw py::value_error("Function invalid for leaf cells");
   }
 }
 
 void MaybeThrowIfFace(S2CellId id) {
   if (id.is_face()) {
-    throw py::value_error("Face cell has no parent");
+    throw py::value_error("Function invalid for face cells");
+  }
+}
+
+void MaybeThrowCellIdOutOfRange(const char* name, int value, int min, int max) {
+  if (value < min || value > max) {
+    throw py::value_error(
+        absl::StrCat(name, " ", value, " out of range [", min, ", ", max, "]"));
   }
 }
 
@@ -114,6 +121,8 @@ void bind_s2cell_id(py::module& m) {
            "Raises ValueError if the token is malformed.")
       .def_static("from_face_ij", [](int face, int i, int j) {
                MaybeThrowFaceOutOfRange(face);
+               MaybeThrowCellIdOutOfRange("i", i, 0, S2CellId::kMaxSize - 1);
+               MaybeThrowCellIdOutOfRange("j", j, 0, S2CellId::kMaxSize - 1);
                return S2CellId::FromFaceIJ(face, i, j);
            },
            py::arg("face"), py::arg("i"), py::arg("j"),
@@ -130,12 +139,12 @@ void bind_s2cell_id(py::module& m) {
            "Return true if this is a top-level face cell (level == 0)")
 
       // Geometric operations
-      .def("face", &S2CellId::face,
-           "Return which cube face this cell belongs to (0..5)")
-      .def("pos", &S2CellId::pos,
-           "Return the position along the Hilbert curve over this face")
-      .def("level", &S2CellId::level,
-           "Return the subdivision level (0..kMaxLevel)")
+      .def_property_readonly("face", &S2CellId::face,
+           "Which cube face this cell belongs to (0..5)")
+      .def_property_readonly("pos", &S2CellId::pos,
+           "The position along the Hilbert curve over this face")
+      .def_property_readonly("level", &S2CellId::level,
+           "The subdivision level (0..kMaxLevel)")
       .def("get_size_ij",
            py::overload_cast<>(&S2CellId::GetSizeIJ, py::const_),
            "Return the edge length of this cell in (i,j)-space")
@@ -222,6 +231,7 @@ void bind_s2cell_id(py::module& m) {
            },
            "Return the four cells adjacent across this cell's edges")
       .def("get_vertex_neighbors", [](S2CellId self, int level) {
+               MaybeThrowIfFace(self);
                MaybeThrowLevelOutOfRange(level, 0, self.level() - 1);
                std::vector<S2CellId> output;
                self.AppendVertexNeighbors(level, &output);

--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -2,7 +2,6 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
-#include <cstdint>
 #include <sstream>
 #include <vector>
 
@@ -54,62 +53,6 @@ void MaybeThrowChildPositionOutOfRange(int position) {
   }
 }
 
-// A range of S2CellIds at the same level, supporting len, indexing, iteration,
-// and reverse iteration. The range is [begin, end) where end is exclusive.
-struct S2CellIdRange {
-  S2CellId begin;
-  S2CellId end;
-
-  int64_t size() const {
-    return end.distance_from_begin() - begin.distance_from_begin();
-  }
-
-  S2CellId item(int64_t i) const {
-    int64_t len = size();
-    if (i < 0) i += len;
-    if (i < 0 || i >= len) {
-      throw py::index_error(absl::StrCat("index ", i, " out of range"));
-    }
-    return begin.advance(i);
-  }
-
-  bool contains(S2CellId cell) const {
-    return cell >= begin && cell < end &&
-           cell.level() == begin.level();
-  }
-};
-
-// Forward iterator for S2CellIdRange.
-struct S2CellIdForwardIter {
-  S2CellId cur;
-  S2CellId end;
-
-  S2CellId next() {
-    if (cur == end) throw py::stop_iteration();
-    S2CellId result = cur;
-    cur = cur.next();
-    return result;
-  }
-};
-
-// Reverse iterator for S2CellIdRange.
-struct S2CellIdReverseIter {
-  S2CellId cur;
-  S2CellId begin;
-  bool done;
-
-  S2CellId next() {
-    if (done) throw py::stop_iteration();
-    S2CellId result = cur;
-    if (cur == begin) {
-      done = true;
-    } else {
-      cur = cur.prev();
-    }
-    return result;
-  }
-};
-
 }  // namespace
 
 void bind_s2cell_id(py::module& m) {
@@ -139,11 +82,9 @@ void bind_s2cell_id(py::module& m) {
            "Construct a leaf cell containing the given S2LatLng.")
 
       // Constants
-      .def_property_readonly_static("MAX_LEVEL",
-           [](py::object) { return S2CellId::kMaxLevel; },
+      .def_readonly_static("MAX_LEVEL", &S2CellId::kMaxLevel,
            "Maximum cell subdivision level (30)")
-      .def_property_readonly_static("NUM_FACES",
-           [](py::object) { return S2CellId::kNumFaces; },
+      .def_readonly_static("NUM_FACES", &S2CellId::kNumFaces,
            "Number of cube faces (6)")
 
       // Factory methods
@@ -273,45 +214,6 @@ void bind_s2cell_id(py::module& m) {
            }, py::arg("position"),
            "Return the immediate child at the given position (0..3).\n\n"
            "Raises ValueError if this is a leaf cell or position is out of range.")
-      .def("children", [](S2CellId self, py::object level_obj) {
-               MaybeThrowIfLeaf(self);
-               S2CellId begin, end;
-               if (level_obj.is_none()) {
-                 begin = self.child_begin();
-                 end = self.child_end();
-               } else {
-                 int level = level_obj.cast<int>();
-                 MaybeThrowLevelOutOfRange(level, self.level(),
-                                           S2CellId::kMaxLevel);
-                 begin = self.child_begin(level);
-                 end = self.child_end(level);
-               }
-               return S2CellIdRange{begin, end};
-           }, py::arg("level") = py::none(),
-           "Return a range over the children of this cell.\n\n"
-           "With no argument, returns the 4 immediate children.\n"
-           "With a level argument, returns all descendants at that level.\n"
-           "The range supports len(), indexing, iteration, and reversed().\n"
-           "Raises ValueError if this is a leaf cell or level is out of range.")
-      .def_static("cells", [](int level) {
-               MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
-               return S2CellIdRange{S2CellId::Begin(level),
-                                    S2CellId::End(level)};
-           }, py::arg("level"),
-           "Return a range over all cells at the given level across all 6 faces.\n\n"
-           "The range supports len(), indexing, iteration, and reversed().\n"
-           "Warning: the number of cells grows as 6 * 4^level.")
-      .def("__iter__", [](S2CellId self) {
-               return S2CellIdForwardIter{self, S2CellId::End(self.level())};
-           },
-           "Iterate along the Hilbert curve at this cell's level,\n"
-           "starting from this cell to the end of the level.")
-      .def("__reversed__", [](S2CellId self) {
-               return S2CellIdReverseIter{self, S2CellId::Begin(self.level()),
-                                          false};
-           },
-           "Iterate in reverse along the Hilbert curve at this cell's level,\n"
-           "starting from this cell back to the beginning of the level.")
       .def("get_edge_neighbors", [](S2CellId self) {
                S2CellId neighbors[4];
                self.GetEdgeNeighbors(neighbors);
@@ -360,30 +262,4 @@ void bind_s2cell_id(py::module& m) {
         oss << id;
         return oss.str();
       });
-
-  py::class_<S2CellIdRange>(m, "S2CellIdRange")
-      .def("__len__", &S2CellIdRange::size)
-      .def("__getitem__", &S2CellIdRange::item, py::arg("index"))
-      .def("__contains__", &S2CellIdRange::contains, py::arg("cell"))
-      .def("__iter__", [](const S2CellIdRange& self) {
-        return S2CellIdForwardIter{self.begin, self.end};
-      })
-      .def("__reversed__", [](const S2CellIdRange& self) {
-        if (self.size() == 0) {
-          return S2CellIdReverseIter{self.begin, self.begin, true};
-        }
-        return S2CellIdReverseIter{self.end.prev(), self.begin, false};
-      });
-
-  py::class_<S2CellIdForwardIter>(m, "S2CellIdForwardIter")
-      .def("__iter__", [](S2CellIdForwardIter& self) -> S2CellIdForwardIter& {
-        return self;
-      })
-      .def("__next__", &S2CellIdForwardIter::next);
-
-  py::class_<S2CellIdReverseIter>(m, "S2CellIdReverseIter")
-      .def("__iter__", [](S2CellIdReverseIter& self) -> S2CellIdReverseIter& {
-        return self;
-      })
-      .def("__next__", &S2CellIdReverseIter::next);
 }

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -138,8 +138,8 @@ class TestS2CellId(unittest.TestCase):
         ll2 = cell.to_lat_lng()
         # The cell center may not exactly match the original point due to
         # quantization to the cell center.
-        self.assertAlmostEqual(ll.lat.degrees(), ll2.lat.degrees(), places=5)
-        self.assertAlmostEqual(ll.lng.degrees(), ll2.lng.degrees(), places=5)
+        self.assertAlmostEqual(ll.lat.degrees, ll2.lat.degrees, places=5)
+        self.assertAlmostEqual(ll.lng.degrees, ll2.lng.degrees, places=5)
 
     def test_get_center_st(self):
         cell = s2.S2CellId.from_face(0)

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -1,0 +1,477 @@
+"""Tests for S2CellId pybind11 bindings."""
+
+import unittest
+import s2geometry_pybind as s2
+
+
+class TestS2CellId(unittest.TestCase):
+    """Test cases for S2CellId bindings."""
+
+    # Constructors
+
+    def test_constructor_from_point(self):
+        p = s2.S2Point(1.0, 0.0, 0.0)
+        cell = s2.S2CellId(p)
+        self.assertTrue(cell.is_leaf())
+
+    def test_constructor_from_latlng(self):
+        ll = s2.S2LatLng.from_degrees(0.0, 0.0)
+        cell = s2.S2CellId(ll)
+        self.assertTrue(cell.is_leaf())
+
+    def test_constructor_from_uint64(self):
+        # Construct from a face cell, then use its id to reconstruct.
+        face_cell = s2.S2CellId.from_face(0)
+        cell = s2.S2CellId(face_cell.id)
+        self.assertEqual(cell, face_cell)
+
+    def test_constructor_from_invalid_uint64_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2CellId(0)
+
+    # Constants
+
+    def test_max_level(self):
+        self.assertEqual(s2.S2CellId.kMaxLevel, 30)
+
+    def test_num_faces(self):
+        self.assertEqual(s2.S2CellId.kNumFaces, 6)
+
+    # Factory methods
+
+    def test_from_face(self):
+        for face in range(6):
+            cell = s2.S2CellId.from_face(face)
+            self.assertEqual(cell.face(), face)
+            self.assertTrue(cell.is_face())
+
+    def test_from_face_out_of_range_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            s2.S2CellId.from_face(6)
+        self.assertEqual(str(cm.exception), "Face 6 out of range [0, 5]")
+        with self.assertRaises(ValueError):
+            s2.S2CellId.from_face(-1)
+
+    def test_from_face_pos_level(self):
+        cell = s2.S2CellId.from_face_pos_level(0, 0, 0)
+        self.assertEqual(cell.level(), 0)
+        self.assertEqual(cell.face(), 0)
+
+    def test_from_token_roundtrip(self):
+        cell = s2.S2CellId.from_face(3)
+        token = cell.to_token()
+        self.assertEqual(token, "7")
+        cell2 = s2.S2CellId.from_token(token)
+        self.assertEqual(cell, cell2)
+
+    def test_from_token_invalid_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            s2.S2CellId.from_token("invalid_token")
+        self.assertEqual(str(cm.exception),
+                         "Invalid S2CellId token: 'invalid_token'")
+
+    def test_from_debug_string(self):
+        cell = s2.S2CellId.from_debug_string("3/02")
+        self.assertEqual(cell.face(), 3)
+        self.assertEqual(cell.level(), 2)
+
+    def test_from_debug_string_invalid_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            s2.S2CellId.from_debug_string("bad")
+        self.assertEqual(str(cm.exception),
+                         "Invalid S2CellId debug string: 'bad'")
+
+    def test_from_face_ij(self):
+        cell = s2.S2CellId.from_face_ij(0, 0, 0)
+        self.assertTrue(cell.is_leaf())
+
+    def test_cells_level_out_of_range_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            s2.S2CellId.cells(31)
+        self.assertEqual(str(cm.exception), "Level 31 out of range [0, 30]")
+
+    # Properties
+
+    def test_id_property(self):
+        cell = s2.S2CellId.from_face(0)
+        self.assertIsInstance(cell.id, int)
+        self.assertGreater(cell.id, 0)
+
+    # Predicates
+
+    def test_is_leaf(self):
+        p = s2.S2Point(1.0, 0.0, 0.0)
+        leaf = s2.S2CellId(p)
+        self.assertTrue(leaf.is_leaf())
+        face = s2.S2CellId.from_face(0)
+        self.assertFalse(face.is_leaf())
+
+    def test_is_face(self):
+        face = s2.S2CellId.from_face(0)
+        self.assertTrue(face.is_face())
+        child = face.child(0)
+        self.assertFalse(child.is_face())
+
+    # Geometric operations
+
+    def test_face(self):
+        for f in range(6):
+            self.assertEqual(s2.S2CellId.from_face(f).face(), f)
+
+    def test_level(self):
+        face = s2.S2CellId.from_face(0)
+        self.assertEqual(face.level(), 0)
+        child = face.child(0)
+        self.assertEqual(child.level(), 1)
+
+    def test_to_point(self):
+        cell = s2.S2CellId.from_face(0)
+        p = cell.to_point()
+        # Face 0 center is approximately (1, 0, 0).
+        self.assertAlmostEqual(p.x, 1.0, places=1)
+        self.assertAlmostEqual(p.y, 0.0, places=1)
+        self.assertAlmostEqual(p.z, 0.0, places=1)
+
+    def test_to_lat_lng(self):
+        ll = s2.S2LatLng.from_degrees(45.0, 90.0)
+        cell = s2.S2CellId(ll)
+        ll2 = cell.to_lat_lng()
+        # The cell center may not exactly match the original point due to
+        # quantization to the cell center.
+        self.assertAlmostEqual(ll.lat.degrees(), ll2.lat.degrees(), places=5)
+        self.assertAlmostEqual(ll.lng.degrees(), ll2.lng.degrees(), places=5)
+
+    def test_get_center_st(self):
+        cell = s2.S2CellId.from_face(0)
+        st = cell.get_center_st()
+        self.assertIsInstance(st, s2.R2Point)
+
+    def test_get_bound_st(self):
+        cell = s2.S2CellId.from_face(0)
+        bound = cell.get_bound_st()
+        self.assertIsInstance(bound, s2.R2Rect)
+
+    def test_get_center_uv(self):
+        cell = s2.S2CellId.from_face(0)
+        uv = cell.get_center_uv()
+        self.assertIsInstance(uv, s2.R2Point)
+
+    def test_get_bound_uv(self):
+        cell = s2.S2CellId.from_face(0)
+        bound = cell.get_bound_uv()
+        self.assertIsInstance(bound, s2.R2Rect)
+
+    def test_get_size_ij(self):
+        face = s2.S2CellId.from_face(0)
+        self.assertEqual(face.get_size_ij(), 1 << 30)
+
+    def test_get_size_ij_for_level(self):
+        self.assertEqual(s2.S2CellId.get_size_ij_for_level(0), 1 << 30)
+        self.assertEqual(s2.S2CellId.get_size_ij_for_level(30), 1)
+
+    def test_get_size_st(self):
+        face = s2.S2CellId.from_face(0)
+        self.assertGreater(face.get_size_st(), 0.0)
+
+    def test_get_center_si_ti(self):
+        cell = s2.S2CellId.from_face(0)
+        face, si, ti = cell.get_center_si_ti()
+        self.assertEqual(face, 0)
+        self.assertIsInstance(si, int)
+        self.assertIsInstance(ti, int)
+
+    def test_to_face_ij_orientation(self):
+        cell = s2.S2CellId.from_face(0)
+        face, i, j, orientation = cell.to_face_ij_orientation()
+        self.assertEqual(face, 0)
+
+    def test_child_position(self):
+        face = s2.S2CellId.from_face(0)
+        for pos in range(4):
+            child = face.child(pos)
+            self.assertEqual(child.child_position(), pos)
+
+    def test_child_position_face_cell_raises(self):
+        face = s2.S2CellId.from_face(0)
+        with self.assertRaises(ValueError) as cm:
+            face.child_position()
+        self.assertEqual(str(cm.exception),
+                         "Level 0 out of range [1, 30]")
+
+    def test_child_position_at_level(self):
+        cell = s2.S2CellId.from_debug_string("0/012")
+        self.assertEqual(cell.child_position_at_level(1), 0)
+        self.assertEqual(cell.child_position_at_level(2), 1)
+        self.assertEqual(cell.child_position_at_level(3), 2)
+
+    def test_to_token(self):
+        cell = s2.S2CellId.from_face(0)
+        self.assertEqual(cell.to_token(), "1")
+
+    def test_to_string(self):
+        cell = s2.S2CellId.from_debug_string("3/02")
+        self.assertEqual(cell.to_string(), "3/02")
+
+    # Traversal
+
+    def test_range_min_max(self):
+        cell = s2.S2CellId.from_face(0)
+        self.assertTrue(cell.range_min() <= cell.range_max())
+
+    def test_contains(self):
+        face = s2.S2CellId.from_face(0)
+        child = face.child(0)
+        self.assertTrue(face.contains(child))
+        self.assertFalse(child.contains(face))
+
+    def test_intersects(self):
+        face = s2.S2CellId.from_face(0)
+        child = face.child(0)
+        self.assertTrue(face.intersects(child))
+        self.assertTrue(child.intersects(face))
+        # Different faces don't intersect.
+        face1 = s2.S2CellId.from_face(1)
+        self.assertFalse(face.intersects(face1))
+
+    def test_parent(self):
+        face = s2.S2CellId.from_face(0)
+        child = face.child(0)
+        self.assertEqual(child.parent(), face)
+
+    def test_parent_of_face_raises(self):
+        face = s2.S2CellId.from_face(0)
+        with self.assertRaises(ValueError) as cm:
+            face.parent()
+        self.assertEqual(str(cm.exception),
+                         "Face cell has no parent")
+
+    def test_parent_at_level(self):
+        cell = s2.S2CellId.from_debug_string("0/012")
+        self.assertEqual(cell.parent_at_level(0), s2.S2CellId.from_face(0))
+        self.assertEqual(cell.parent_at_level(3), cell)
+
+    def test_child(self):
+        face = s2.S2CellId.from_face(0)
+        for pos in range(4):
+            child = face.child(pos)
+            self.assertEqual(child.level(), 1)
+
+    def test_child_of_leaf_raises(self):
+        leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
+        with self.assertRaises(ValueError) as cm:
+            leaf.child(0)
+        self.assertEqual(str(cm.exception),
+                         "Leaf cell has no children")
+
+    def test_child_position_out_of_range_raises(self):
+        face = s2.S2CellId.from_face(0)
+        with self.assertRaises(ValueError) as cm:
+            face.child(4)
+        self.assertEqual(str(cm.exception),
+                         "Child position 4 out of range [0, 3]")
+
+    def test_children(self):
+        face = s2.S2CellId.from_face(0)
+        children = list(face.children())
+        self.assertEqual(len(children), 4)
+        for child in children:
+            self.assertEqual(child.level(), 1)
+
+    def test_children_positions(self):
+        face = s2.S2CellId.from_face(0)
+        children = list(face.children())
+        for i, child in enumerate(children):
+            self.assertEqual(child.child_position(), i)
+
+    def test_children_at_level(self):
+        face = s2.S2CellId.from_face(0)
+        # Level 2 descendants = 4^2 = 16 cells.
+        children = list(face.children(2))
+        self.assertEqual(len(children), 16)
+        for child in children:
+            self.assertEqual(child.level(), 2)
+
+    def test_children_of_leaf_raises(self):
+        leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
+        with self.assertRaises(ValueError) as cm:
+            list(leaf.children())
+        self.assertEqual(str(cm.exception),
+                         "Leaf cell has no children")
+
+    def test_children_for_loop(self):
+        face = s2.S2CellId.from_face(0)
+        count = 0
+        for child in face.children():
+            count += 1
+        self.assertEqual(count, 4)
+
+    def test_cells_level_0(self):
+        cells = list(s2.S2CellId.cells(0))
+        self.assertEqual(len(cells), 6)
+        for i, cell in enumerate(cells):
+            self.assertEqual(cell.face(), i)
+
+    def test_cells_level_1(self):
+        cells = list(s2.S2CellId.cells(1))
+        # 6 faces * 4 children = 24 cells.
+        self.assertEqual(len(cells), 24)
+        for cell in cells:
+            self.assertEqual(cell.level(), 1)
+
+    def test_iter_from_cell(self):
+        # Iterating from face 3 should yield faces 3, 4, 5.
+        face3 = s2.S2CellId.from_face(3)
+        cells = list(face3)
+        self.assertEqual(len(cells), 3)
+        self.assertEqual(cells[0].face(), 3)
+        self.assertEqual(cells[1].face(), 4)
+        self.assertEqual(cells[2].face(), 5)
+
+    def test_iter_from_last_face(self):
+        face5 = s2.S2CellId.from_face(5)
+        cells = list(face5)
+        self.assertEqual(len(cells), 1)
+        self.assertEqual(cells[0].face(), 5)
+
+    def test_reversed_from_cell(self):
+        # Reversed from face 3 should yield faces 3, 2, 1, 0.
+        face3 = s2.S2CellId.from_face(3)
+        cells = list(reversed(face3))
+        self.assertEqual(len(cells), 4)
+        self.assertEqual(cells[0].face(), 3)
+        self.assertEqual(cells[1].face(), 2)
+        self.assertEqual(cells[2].face(), 1)
+        self.assertEqual(cells[3].face(), 0)
+
+    def test_reversed_from_first_face(self):
+        face0 = s2.S2CellId.from_face(0)
+        cells = list(reversed(face0))
+        self.assertEqual(len(cells), 1)
+        self.assertEqual(cells[0].face(), 0)
+
+    def test_children_len(self):
+        face = s2.S2CellId.from_face(0)
+        self.assertEqual(len(face.children()), 4)
+        self.assertEqual(len(face.children(2)), 16)
+
+    def test_children_getitem(self):
+        face = s2.S2CellId.from_face(0)
+        children = face.children()
+        self.assertEqual(children[0].child_position(), 0)
+        self.assertEqual(children[3].child_position(), 3)
+        # Negative indexing.
+        self.assertEqual(children[-1].child_position(), 3)
+
+    def test_children_getitem_out_of_range_raises(self):
+        face = s2.S2CellId.from_face(0)
+        children = face.children()
+        with self.assertRaises(IndexError):
+            children[4]
+        with self.assertRaises(IndexError):
+            children[-5]
+
+    def test_children_contains(self):
+        face = s2.S2CellId.from_face(0)
+        children = face.children()
+        child0 = face.child(0)
+        self.assertIn(child0, children)
+        # A cell from a different face is not in the range.
+        other = s2.S2CellId.from_face(1).child(0)
+        self.assertNotIn(other, children)
+        # A cell at the wrong level is not in the range.
+        self.assertNotIn(face, children)
+
+    def test_children_reversed(self):
+        face = s2.S2CellId.from_face(0)
+        children = list(face.children())
+        rev_children = list(reversed(face.children()))
+        self.assertEqual(rev_children, list(reversed(children)))
+
+    def test_cells_len(self):
+        self.assertEqual(len(s2.S2CellId.cells(0)), 6)
+        self.assertEqual(len(s2.S2CellId.cells(1)), 24)
+
+    def test_cells_getitem(self):
+        cells = s2.S2CellId.cells(0)
+        self.assertEqual(cells[0].face(), 0)
+        self.assertEqual(cells[5].face(), 5)
+        self.assertEqual(cells[-1].face(), 5)
+
+    def test_cells_reversed(self):
+        cells = list(s2.S2CellId.cells(0))
+        rev_cells = list(reversed(s2.S2CellId.cells(0)))
+        self.assertEqual(rev_cells, list(reversed(cells)))
+
+    def test_get_common_ancestor_level(self):
+        cell1 = s2.S2CellId.from_debug_string("0/012")
+        cell2 = s2.S2CellId.from_debug_string("0/013")
+        self.assertEqual(cell1.get_common_ancestor_level(cell2), 2)
+
+    def test_get_common_ancestor_level_different_faces(self):
+        cell1 = s2.S2CellId.from_face(0)
+        cell2 = s2.S2CellId.from_face(1)
+        self.assertEqual(cell1.get_common_ancestor_level(cell2), -1)
+
+    def test_get_edge_neighbors(self):
+        cell = s2.S2CellId.from_face(0)
+        neighbors = cell.get_edge_neighbors()
+        self.assertEqual(len(neighbors), 4)
+
+    def test_get_vertex_neighbors(self):
+        cell = s2.S2CellId.from_debug_string("0/012")
+        neighbors = cell.get_vertex_neighbors(1)
+        self.assertGreaterEqual(len(neighbors), 3)
+        self.assertLessEqual(len(neighbors), 4)
+
+    def test_get_vertex_neighbors_level_too_high_raises(self):
+        cell = s2.S2CellId.from_face(0)
+        with self.assertRaises(ValueError):
+            cell.get_vertex_neighbors(0)  # level must be < cell level
+
+    def test_get_all_neighbors(self):
+        cell = s2.S2CellId.from_debug_string("0/0")
+        neighbors = cell.get_all_neighbors(1)
+        self.assertGreater(len(neighbors), 0)
+
+    # Operators
+
+    def test_equality(self):
+        a = s2.S2CellId.from_face(0)
+        b = s2.S2CellId.from_face(0)
+        c = s2.S2CellId.from_face(1)
+        self.assertTrue(a == b)
+        self.assertTrue(a != c)
+
+    def test_comparison(self):
+        a = s2.S2CellId.from_face(0)
+        b = s2.S2CellId.from_face(1)
+        self.assertTrue(a < b)
+        self.assertTrue(b > a)
+        self.assertTrue(a <= a)
+        self.assertTrue(a >= a)
+
+    def test_hash(self):
+        a = s2.S2CellId.from_face(0)
+        b = s2.S2CellId.from_face(0)
+        self.assertEqual(hash(a), hash(b))
+        # Can be used in sets/dicts.
+        s = {a, b}
+        self.assertEqual(len(s), 1)
+
+    # String representation
+
+    def test_repr(self):
+        cell = s2.S2CellId.from_face(0)
+        self.assertEqual(repr(cell), "S2CellId(0/)")
+
+    def test_str(self):
+        cell = s2.S2CellId.from_face(0)
+        self.assertEqual(str(cell), "0/")
+
+    def test_repr_child(self):
+        cell = s2.S2CellId.from_debug_string("3/02")
+        self.assertEqual(repr(cell), "S2CellId(3/02)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -42,7 +42,7 @@ class TestS2CellId(unittest.TestCase):
     def test_from_face(self):
         for face in range(6):
             cell = s2.S2CellId.from_face(face)
-            self.assertEqual(cell.face(), face)
+            self.assertEqual(cell.face, face)
             self.assertTrue(cell.is_face())
 
     def test_from_face_out_of_range_raises(self):
@@ -54,8 +54,8 @@ class TestS2CellId(unittest.TestCase):
 
     def test_from_face_pos_level(self):
         cell = s2.S2CellId.from_face_pos_level(0, 0, 0)
-        self.assertEqual(cell.level(), 0)
-        self.assertEqual(cell.face(), 0)
+        self.assertEqual(cell.level, 0)
+        self.assertEqual(cell.face, 0)
 
     def test_from_token_roundtrip(self):
         cell = s2.S2CellId.from_face(3)
@@ -73,6 +73,18 @@ class TestS2CellId(unittest.TestCase):
     def test_from_face_ij(self):
         cell = s2.S2CellId.from_face_ij(0, 0, 0)
         self.assertTrue(cell.is_leaf())
+
+    def test_from_face_ij_i_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2CellId.from_face_ij(0, -1, 0)
+        with self.assertRaises(ValueError):
+            s2.S2CellId.from_face_ij(0, 1 << s2.S2CellId.MAX_LEVEL, 0)
+
+    def test_from_face_ij_j_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            s2.S2CellId.from_face_ij(0, 0, -1)
+        with self.assertRaises(ValueError):
+            s2.S2CellId.from_face_ij(0, 0, 1 << s2.S2CellId.MAX_LEVEL)
 
     # Properties
 
@@ -100,13 +112,13 @@ class TestS2CellId(unittest.TestCase):
 
     def test_face(self):
         for f in range(6):
-            self.assertEqual(s2.S2CellId.from_face(f).face(), f)
+            self.assertEqual(s2.S2CellId.from_face(f).face, f)
 
     def test_level(self):
         face = s2.S2CellId.from_face(0)
-        self.assertEqual(face.level(), 0)
+        self.assertEqual(face.level, 0)
         child = face.child(0)
-        self.assertEqual(child.level(), 1)
+        self.assertEqual(child.level, 1)
 
     def test_to_point(self):
         cell = s2.S2CellId.from_face(0)
@@ -158,11 +170,11 @@ class TestS2CellId(unittest.TestCase):
     def test_get_size_ij(self):
         # In (i,j)-space a face spans 2^kMaxLevel = 2^30 units.
         face = s2.S2CellId.from_face(0)
-        self.assertEqual(face.get_size_ij(), 1 << 30)
+        self.assertEqual(face.get_size_ij(), 1 << s2.S2CellId.MAX_LEVEL)
 
     def test_get_size_ij_for_level(self):
         # Level 0 cells span 2^kMaxLevel in (i,j); leaf cells span 1.
-        self.assertEqual(s2.S2CellId.get_size_ij_for_level(0), 1 << 30)
+        self.assertEqual(s2.S2CellId.get_size_ij_for_level(0), 1 << s2.S2CellId.MAX_LEVEL)
         self.assertEqual(s2.S2CellId.get_size_ij_for_level(30), 1)
 
     def test_get_size_st(self):
@@ -252,7 +264,7 @@ class TestS2CellId(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             face.parent()
         self.assertEqual(str(cm.exception),
-                         "Face cell has no parent")
+                         "Function invalid for face cells")
 
     def test_parent_at_level(self):
         cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
@@ -263,14 +275,14 @@ class TestS2CellId(unittest.TestCase):
         face = s2.S2CellId.from_face(0)
         for pos in range(4):
             child = face.child(pos)
-            self.assertEqual(child.level(), 1)
+            self.assertEqual(child.level, 1)
 
     def test_child_of_leaf_raises(self):
         leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
         with self.assertRaises(ValueError) as cm:
             leaf.child(0)
         self.assertEqual(str(cm.exception),
-                         "Leaf cell has no children")
+                         "Function invalid for leaf cells")
 
     def test_child_position_out_of_range_raises(self):
         face = s2.S2CellId.from_face(0)

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -32,10 +32,10 @@ class TestS2CellId(unittest.TestCase):
     # Constants
 
     def test_max_level(self):
-        self.assertEqual(s2.S2CellId.kMaxLevel, 30)
+        self.assertEqual(s2.S2CellId.MAX_LEVEL, 30)
 
     def test_num_faces(self):
-        self.assertEqual(s2.S2CellId.kNumFaces, 6)
+        self.assertEqual(s2.S2CellId.NUM_FACES, 6)
 
     # Factory methods
 
@@ -173,18 +173,6 @@ class TestS2CellId(unittest.TestCase):
         face = s2.S2CellId.from_face(0)
         self.assertGreater(face.get_size_st(), 0.0)
 
-    def test_get_center_si_ti(self):
-        cell = s2.S2CellId.from_face(0)
-        face, si, ti = cell.get_center_si_ti()
-        self.assertEqual(face, 0)
-        self.assertIsInstance(si, int)
-        self.assertIsInstance(ti, int)
-
-    def test_to_face_ij_orientation(self):
-        cell = s2.S2CellId.from_face(0)
-        face, i, j, orientation = cell.to_face_ij_orientation()
-        self.assertEqual(face, 0)
-
     def test_child_position(self):
         face = s2.S2CellId.from_face(0)
         for pos in range(4):
@@ -207,10 +195,6 @@ class TestS2CellId(unittest.TestCase):
     def test_to_token(self):
         cell = s2.S2CellId.from_face(0)
         self.assertEqual(cell.to_token(), "1")
-
-    def test_to_string(self):
-        cell = s2.S2CellId.from_debug_string("3/02")
-        self.assertEqual(cell.to_string(), "3/02")
 
     # Traversal
 

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -181,6 +181,12 @@ class TestS2CellId(unittest.TestCase):
         # In (s,t)-space a face spans the full unit interval, so size is 1.0.
         self.assertAlmostEqual(s2.S2CellId.from_face(0).get_size_st(), 1.0)
 
+    def test_get_size_st_for_level(self):
+        # Level-0 cells span the full unit interval; level-30 cells span 1/2^30.
+        self.assertAlmostEqual(s2.S2CellId.get_size_st_for_level(0), 1.0)
+        self.assertAlmostEqual(s2.S2CellId.get_size_st_for_level(30),
+                               1.0 / (1 << 30))
+
     def test_child_position(self):
         face = s2.S2CellId.from_face(0)
         for pos in range(4):
@@ -302,10 +308,15 @@ class TestS2CellId(unittest.TestCase):
         self.assertGreaterEqual(len(neighbors), 3)
         self.assertLessEqual(len(neighbors), 4)
 
-    def test_get_vertex_neighbors_level_too_high_raises(self):
-        cell = s2.S2CellId.from_face(0)
+    def test_get_vertex_neighbors_face_cell_raises(self):
+        face = s2.S2CellId.from_face(0)
         with self.assertRaises(ValueError):
-            cell.get_vertex_neighbors(0)  # level must be < cell level
+            face.get_vertex_neighbors(0)
+
+    def test_get_vertex_neighbors_level_out_of_range_raises(self):
+        cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
+        with self.assertRaises(ValueError):
+            cell.get_vertex_neighbors(3)  # level must be < self.level() (3)
 
     def test_get_all_neighbors(self):
         cell = s2.S2CellId.from_face(0).child(0)

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -70,17 +70,6 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Invalid S2CellId token: 'invalid_token'")
 
-    def test_from_debug_string(self):
-        cell = s2.S2CellId.from_debug_string("3/02")
-        self.assertEqual(cell.face(), 3)
-        self.assertEqual(cell.level(), 2)
-
-    def test_from_debug_string_invalid_raises(self):
-        with self.assertRaises(ValueError) as cm:
-            s2.S2CellId.from_debug_string("bad")
-        self.assertEqual(str(cm.exception),
-                         "Invalid S2CellId debug string: 'bad'")
-
     def test_from_face_ij(self):
         cell = s2.S2CellId.from_face_ij(0, 0, 0)
         self.assertTrue(cell.is_leaf())
@@ -142,36 +131,48 @@ class TestS2CellId(unittest.TestCase):
         self.assertAlmostEqual(ll.lng.degrees, ll2.lng.degrees, places=5)
 
     def test_get_center_st(self):
-        cell = s2.S2CellId.from_face(0)
-        st = cell.get_center_st()
-        self.assertIsInstance(st, s2.R2Point)
+        # (s,t)-space covers [0,1] x [0,1] per face; a face cell's center
+        # is at (0.5, 0.5).
+        st = s2.S2CellId.from_face(0).get_center_st()
+        self.assertAlmostEqual(st.x, 0.5)
+        self.assertAlmostEqual(st.y, 0.5)
 
     def test_get_bound_st(self):
-        cell = s2.S2CellId.from_face(0)
-        bound = cell.get_bound_st()
-        self.assertIsInstance(bound, s2.R2Rect)
+        # A face cell in (s,t) spans the full [0,1] x [0,1] range.
+        bound = s2.S2CellId.from_face(0).get_bound_st()
+        self.assertAlmostEqual(bound.lo.x, 0.0)
+        self.assertAlmostEqual(bound.lo.y, 0.0)
+        self.assertAlmostEqual(bound.hi.x, 1.0)
+        self.assertAlmostEqual(bound.hi.y, 1.0)
 
     def test_get_center_uv(self):
-        cell = s2.S2CellId.from_face(0)
-        uv = cell.get_center_uv()
-        self.assertIsInstance(uv, s2.R2Point)
+        # (u,v)-space covers [-1,1] x [-1,1] per face; a face cell's center
+        # is at the origin.
+        uv = s2.S2CellId.from_face(0).get_center_uv()
+        self.assertAlmostEqual(uv.x, 0.0)
+        self.assertAlmostEqual(uv.y, 0.0)
 
     def test_get_bound_uv(self):
-        cell = s2.S2CellId.from_face(0)
-        bound = cell.get_bound_uv()
-        self.assertIsInstance(bound, s2.R2Rect)
+        # A face cell in (u,v) spans the full [-1,1] x [-1,1] range.
+        bound = s2.S2CellId.from_face(0).get_bound_uv()
+        self.assertAlmostEqual(bound.lo.x, -1.0)
+        self.assertAlmostEqual(bound.lo.y, -1.0)
+        self.assertAlmostEqual(bound.hi.x, 1.0)
+        self.assertAlmostEqual(bound.hi.y, 1.0)
 
     def test_get_size_ij(self):
+        # In (i,j)-space a face spans 2^kMaxLevel = 2^30 units.
         face = s2.S2CellId.from_face(0)
         self.assertEqual(face.get_size_ij(), 1 << 30)
 
     def test_get_size_ij_for_level(self):
+        # Level 0 cells span 2^kMaxLevel in (i,j); leaf cells span 1.
         self.assertEqual(s2.S2CellId.get_size_ij_for_level(0), 1 << 30)
         self.assertEqual(s2.S2CellId.get_size_ij_for_level(30), 1)
 
     def test_get_size_st(self):
-        face = s2.S2CellId.from_face(0)
-        self.assertGreater(face.get_size_st(), 0.0)
+        # In (s,t)-space a face spans the full unit interval, so size is 1.0.
+        self.assertAlmostEqual(s2.S2CellId.from_face(0).get_size_st(), 1.0)
 
     def test_child_position(self):
         face = s2.S2CellId.from_face(0)
@@ -187,7 +188,7 @@ class TestS2CellId(unittest.TestCase):
                          "Level 0 out of range [1, 30]")
 
     def test_child_position_at_level(self):
-        cell = s2.S2CellId.from_debug_string("0/012")
+        cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
         self.assertEqual(cell.child_position_at_level(1), 0)
         self.assertEqual(cell.child_position_at_level(2), 1)
         self.assertEqual(cell.child_position_at_level(3), 2)
@@ -198,9 +199,25 @@ class TestS2CellId(unittest.TestCase):
 
     # Traversal
 
-    def test_range_min_max(self):
-        cell = s2.S2CellId.from_face(0)
-        self.assertTrue(cell.range_min() <= cell.range_max())
+    def test_range_min_max_leaf(self):
+        # A leaf cell's range is just itself.
+        leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
+        self.assertEqual(leaf.range_min(), leaf)
+        self.assertEqual(leaf.range_max(), leaf)
+
+    def test_range_min_max_covers_children(self):
+        # range_min/range_max bound the leaf cells of this cell; every
+        # direct child's range must sit within the parent's range.
+        face = s2.S2CellId.from_face(0)
+        self.assertLess(face.range_min(), face.range_max())
+        for child in face.children():
+            self.assertGreaterEqual(child.range_min(), face.range_min())
+            self.assertLessEqual(child.range_max(), face.range_max())
+        # The first child's range_min equals the parent's, and likewise
+        # the last child's range_max equals the parent's.
+        children = list(face.children())
+        self.assertEqual(children[0].range_min(), face.range_min())
+        self.assertEqual(children[-1].range_max(), face.range_max())
 
     def test_contains(self):
         face = s2.S2CellId.from_face(0)
@@ -230,7 +247,7 @@ class TestS2CellId(unittest.TestCase):
                          "Face cell has no parent")
 
     def test_parent_at_level(self):
-        cell = s2.S2CellId.from_debug_string("0/012")
+        cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
         self.assertEqual(cell.parent_at_level(0), s2.S2CellId.from_face(0))
         self.assertEqual(cell.parent_at_level(3), cell)
 
@@ -282,13 +299,6 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Leaf cell has no children")
 
-    def test_children_for_loop(self):
-        face = s2.S2CellId.from_face(0)
-        count = 0
-        for child in face.children():
-            count += 1
-        self.assertEqual(count, 4)
-
     def test_cells_level_0(self):
         cells = list(s2.S2CellId.cells(0))
         self.assertEqual(len(cells), 6)
@@ -333,12 +343,16 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(len(cells), 1)
         self.assertEqual(cells[0].face(), 0)
 
-    def test_children_len(self):
+    # S2CellIdRange — tests for the range class returned by children()/cells().
+    # These exercise the range class itself; the factory methods that return a
+    # range (children, cells) are covered separately above.
+
+    def test_s2cell_id_range_len(self):
         face = s2.S2CellId.from_face(0)
         self.assertEqual(len(face.children()), 4)
         self.assertEqual(len(face.children(2)), 16)
 
-    def test_children_getitem(self):
+    def test_s2cell_id_range_getitem(self):
         face = s2.S2CellId.from_face(0)
         children = face.children()
         self.assertEqual(children[0].child_position(), 0)
@@ -346,15 +360,14 @@ class TestS2CellId(unittest.TestCase):
         # Negative indexing.
         self.assertEqual(children[-1].child_position(), 3)
 
-    def test_children_getitem_out_of_range_raises(self):
-        face = s2.S2CellId.from_face(0)
-        children = face.children()
+    def test_s2cell_id_range_getitem_out_of_range_raises(self):
+        children = s2.S2CellId.from_face(0).children()
         with self.assertRaises(IndexError):
             children[4]
         with self.assertRaises(IndexError):
             children[-5]
 
-    def test_children_contains(self):
+    def test_s2cell_id_range_contains(self):
         face = s2.S2CellId.from_face(0)
         children = face.children()
         child0 = face.child(0)
@@ -365,30 +378,18 @@ class TestS2CellId(unittest.TestCase):
         # A cell at the wrong level is not in the range.
         self.assertNotIn(face, children)
 
-    def test_children_reversed(self):
+    def test_s2cell_id_range_reversed(self):
         face = s2.S2CellId.from_face(0)
         children = list(face.children())
         rev_children = list(reversed(face.children()))
         self.assertEqual(rev_children, list(reversed(children)))
 
-    def test_cells_len(self):
-        self.assertEqual(len(s2.S2CellId.cells(0)), 6)
-        self.assertEqual(len(s2.S2CellId.cells(1)), 24)
-
-    def test_cells_getitem(self):
-        cells = s2.S2CellId.cells(0)
-        self.assertEqual(cells[0].face(), 0)
-        self.assertEqual(cells[5].face(), 5)
-        self.assertEqual(cells[-1].face(), 5)
-
-    def test_cells_reversed(self):
-        cells = list(s2.S2CellId.cells(0))
-        rev_cells = list(reversed(s2.S2CellId.cells(0)))
-        self.assertEqual(rev_cells, list(reversed(cells)))
-
     def test_get_common_ancestor_level(self):
-        cell1 = s2.S2CellId.from_debug_string("0/012")
-        cell2 = s2.S2CellId.from_debug_string("0/013")
+        # Two cells sharing the first two Hilbert curve steps on face 0
+        # diverge at level 2, so their common ancestor is at level 2.
+        base = s2.S2CellId.from_face(0).child(0).child(1)
+        cell1 = base.child(2)
+        cell2 = base.child(3)
         self.assertEqual(cell1.get_common_ancestor_level(cell2), 2)
 
     def test_get_common_ancestor_level_different_faces(self):
@@ -402,7 +403,7 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(len(neighbors), 4)
 
     def test_get_vertex_neighbors(self):
-        cell = s2.S2CellId.from_debug_string("0/012")
+        cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
         neighbors = cell.get_vertex_neighbors(1)
         self.assertGreaterEqual(len(neighbors), 3)
         self.assertLessEqual(len(neighbors), 4)
@@ -413,7 +414,7 @@ class TestS2CellId(unittest.TestCase):
             cell.get_vertex_neighbors(0)  # level must be < cell level
 
     def test_get_all_neighbors(self):
-        cell = s2.S2CellId.from_debug_string("0/0")
+        cell = s2.S2CellId.from_face(0).child(0)
         neighbors = cell.get_all_neighbors(1)
         self.assertGreater(len(neighbors), 0)
 
@@ -453,7 +454,7 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(str(cell), "0/")
 
     def test_repr_child(self):
-        cell = s2.S2CellId.from_debug_string("3/02")
+        cell = s2.S2CellId.from_face(3).child(0).child(2)
         self.assertEqual(repr(cell), "S2CellId(3/02)")
 
 

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -192,8 +192,6 @@ class TestS2CellId(unittest.TestCase):
         cell = s2.S2CellId.from_face(0)
         self.assertEqual(cell.to_token(), "1")
 
-    # Traversal
-
     def test_range_min_max_leaf(self):
         # A leaf cell's range is just itself.
         leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
@@ -228,6 +226,21 @@ class TestS2CellId(unittest.TestCase):
         # Different faces don't intersect.
         face1 = s2.S2CellId.from_face(1)
         self.assertFalse(face.intersects(face1))
+
+    def test_get_common_ancestor_level(self):
+        # Two cells sharing the first two Hilbert curve steps on face 0
+        # diverge at level 2, so their common ancestor is at level 2.
+        base = s2.S2CellId.from_face(0).child(0).child(1)
+        cell1 = base.child(2)
+        cell2 = base.child(3)
+        self.assertEqual(cell1.get_common_ancestor_level(cell2), 2)
+
+    def test_get_common_ancestor_level_different_faces(self):
+        cell1 = s2.S2CellId.from_face(0)
+        cell2 = s2.S2CellId.from_face(1)
+        self.assertEqual(cell1.get_common_ancestor_level(cell2), -1)
+
+    # Traversal
 
     def test_parent(self):
         face = s2.S2CellId.from_face(0)
@@ -265,19 +278,6 @@ class TestS2CellId(unittest.TestCase):
             face.child(4)
         self.assertEqual(str(cm.exception),
                          "Child position 4 out of range [0, 3]")
-
-    def test_get_common_ancestor_level(self):
-        # Two cells sharing the first two Hilbert curve steps on face 0
-        # diverge at level 2, so their common ancestor is at level 2.
-        base = s2.S2CellId.from_face(0).child(0).child(1)
-        cell1 = base.child(2)
-        cell2 = base.child(3)
-        self.assertEqual(cell1.get_common_ancestor_level(cell2), 2)
-
-    def test_get_common_ancestor_level_different_faces(self):
-        cell1 = s2.S2CellId.from_face(0)
-        cell2 = s2.S2CellId.from_face(1)
-        self.assertEqual(cell1.get_common_ancestor_level(cell2), -1)
 
     def test_get_edge_neighbors(self):
         cell = s2.S2CellId.from_face(0)

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -74,11 +74,6 @@ class TestS2CellId(unittest.TestCase):
         cell = s2.S2CellId.from_face_ij(0, 0, 0)
         self.assertTrue(cell.is_leaf())
 
-    def test_cells_level_out_of_range_raises(self):
-        with self.assertRaises(ValueError) as cm:
-            s2.S2CellId.cells(31)
-        self.assertEqual(str(cm.exception), "Level 31 out of range [0, 30]")
-
     # Properties
 
     def test_id_property(self):
@@ -210,12 +205,12 @@ class TestS2CellId(unittest.TestCase):
         # direct child's range must sit within the parent's range.
         face = s2.S2CellId.from_face(0)
         self.assertLess(face.range_min(), face.range_max())
-        for child in face.children():
+        children = [face.child(i) for i in range(4)]
+        for child in children:
             self.assertGreaterEqual(child.range_min(), face.range_min())
             self.assertLessEqual(child.range_max(), face.range_max())
         # The first child's range_min equals the parent's, and likewise
         # the last child's range_max equals the parent's.
-        children = list(face.children())
         self.assertEqual(children[0].range_min(), face.range_min())
         self.assertEqual(children[-1].range_max(), face.range_max())
 
@@ -270,119 +265,6 @@ class TestS2CellId(unittest.TestCase):
             face.child(4)
         self.assertEqual(str(cm.exception),
                          "Child position 4 out of range [0, 3]")
-
-    def test_children(self):
-        face = s2.S2CellId.from_face(0)
-        children = list(face.children())
-        self.assertEqual(len(children), 4)
-        for child in children:
-            self.assertEqual(child.level(), 1)
-
-    def test_children_positions(self):
-        face = s2.S2CellId.from_face(0)
-        children = list(face.children())
-        for i, child in enumerate(children):
-            self.assertEqual(child.child_position(), i)
-
-    def test_children_at_level(self):
-        face = s2.S2CellId.from_face(0)
-        # Level 2 descendants = 4^2 = 16 cells.
-        children = list(face.children(2))
-        self.assertEqual(len(children), 16)
-        for child in children:
-            self.assertEqual(child.level(), 2)
-
-    def test_children_of_leaf_raises(self):
-        leaf = s2.S2CellId(s2.S2Point(1.0, 0.0, 0.0))
-        with self.assertRaises(ValueError) as cm:
-            list(leaf.children())
-        self.assertEqual(str(cm.exception),
-                         "Leaf cell has no children")
-
-    def test_cells_level_0(self):
-        cells = list(s2.S2CellId.cells(0))
-        self.assertEqual(len(cells), 6)
-        for i, cell in enumerate(cells):
-            self.assertEqual(cell.face(), i)
-
-    def test_cells_level_1(self):
-        cells = list(s2.S2CellId.cells(1))
-        # 6 faces * 4 children = 24 cells.
-        self.assertEqual(len(cells), 24)
-        for cell in cells:
-            self.assertEqual(cell.level(), 1)
-
-    def test_iter_from_cell(self):
-        # Iterating from face 3 should yield faces 3, 4, 5.
-        face3 = s2.S2CellId.from_face(3)
-        cells = list(face3)
-        self.assertEqual(len(cells), 3)
-        self.assertEqual(cells[0].face(), 3)
-        self.assertEqual(cells[1].face(), 4)
-        self.assertEqual(cells[2].face(), 5)
-
-    def test_iter_from_last_face(self):
-        face5 = s2.S2CellId.from_face(5)
-        cells = list(face5)
-        self.assertEqual(len(cells), 1)
-        self.assertEqual(cells[0].face(), 5)
-
-    def test_reversed_from_cell(self):
-        # Reversed from face 3 should yield faces 3, 2, 1, 0.
-        face3 = s2.S2CellId.from_face(3)
-        cells = list(reversed(face3))
-        self.assertEqual(len(cells), 4)
-        self.assertEqual(cells[0].face(), 3)
-        self.assertEqual(cells[1].face(), 2)
-        self.assertEqual(cells[2].face(), 1)
-        self.assertEqual(cells[3].face(), 0)
-
-    def test_reversed_from_first_face(self):
-        face0 = s2.S2CellId.from_face(0)
-        cells = list(reversed(face0))
-        self.assertEqual(len(cells), 1)
-        self.assertEqual(cells[0].face(), 0)
-
-    # S2CellIdRange — tests for the range class returned by children()/cells().
-    # These exercise the range class itself; the factory methods that return a
-    # range (children, cells) are covered separately above.
-
-    def test_s2cell_id_range_len(self):
-        face = s2.S2CellId.from_face(0)
-        self.assertEqual(len(face.children()), 4)
-        self.assertEqual(len(face.children(2)), 16)
-
-    def test_s2cell_id_range_getitem(self):
-        face = s2.S2CellId.from_face(0)
-        children = face.children()
-        self.assertEqual(children[0].child_position(), 0)
-        self.assertEqual(children[3].child_position(), 3)
-        # Negative indexing.
-        self.assertEqual(children[-1].child_position(), 3)
-
-    def test_s2cell_id_range_getitem_out_of_range_raises(self):
-        children = s2.S2CellId.from_face(0).children()
-        with self.assertRaises(IndexError):
-            children[4]
-        with self.assertRaises(IndexError):
-            children[-5]
-
-    def test_s2cell_id_range_contains(self):
-        face = s2.S2CellId.from_face(0)
-        children = face.children()
-        child0 = face.child(0)
-        self.assertIn(child0, children)
-        # A cell from a different face is not in the range.
-        other = s2.S2CellId.from_face(1).child(0)
-        self.assertNotIn(other, children)
-        # A cell at the wrong level is not in the range.
-        self.assertNotIn(face, children)
-
-    def test_s2cell_id_range_reversed(self):
-        face = s2.S2CellId.from_face(0)
-        children = list(face.children())
-        rev_children = list(reversed(face.children()))
-        self.assertEqual(rev_children, list(reversed(children)))
 
     def test_get_common_ancestor_level(self):
         # Two cells sharing the first two Hilbert curve steps on face 0


### PR DESCRIPTION
Add pybind11 bindings for S2CellId.

Iteration-like methods (e.g. next(), prev(), Begin(), End()) are not included.

Also updates the README with new binding file organization sections (Constants, Traversal).

(Part of a series addressing https://github.com/google/s2geometry/pull/524)