### PR TITLE
workflow: Fix setup-bazel caching config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         disk-cache: true
         repository-cache: true
         # The Bazel workspace is in the src directory.
-        workspace-root: src
+        module-root: src
 
     - name: Build and Test
       run: |


### PR DESCRIPTION
Replace `workspace-root` (not a valid input, was being ignored with a warning) with `module-root` so setup-bazel correctly finds MODULE.bazel and BUILD files under src/ for cache key hashing.

https://github.com/bazel-contrib/setup-bazel#module-root