### PR TITLE
workflows: Add AArch64 big-endian cross-compile/test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,71 @@ jobs:
       - if: always()
         run: ctest --parallel ${{ env.NUM_CORES }} --output-on-failure
         working-directory: build/
+  cmake-big-endian:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    env:
+      ARM_TOOLCHAIN_VERSION: "13.3.rel1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set NUM_CORES
+        run: |
+          NUM_CORES=$(getconf _NPROCESSORS_ONLN)
+          echo "NUM_CORES=$NUM_CORES" >> $GITHUB_ENV
+          echo "Detected $NUM_CORES cores"
+      - name: Install QEMU user-mode
+        run: sudo apt-get update && sudo apt-get install -y qemu-user
+      - name: Download Arm GNU Toolchain
+        run: |
+          TARBALL="arm-gnu-toolchain-${ARM_TOOLCHAIN_VERSION}-aarch64-aarch64_be-none-linux-gnu.tar.xz"
+          URL="https://developer.arm.com/-/media/Files/downloads/gnu/${ARM_TOOLCHAIN_VERSION}/binrel/${TARBALL}"
+          wget -q "$URL" "$URL.sha256asc"
+          sha256sum --check "$TARBALL.sha256asc"
+          tar xf "$TARBALL" -C /opt
+          TOOLCHAIN_DIR="/opt/arm-gnu-toolchain-${ARM_TOOLCHAIN_VERSION}-aarch64-aarch64_be-none-linux-gnu"
+          echo "${TOOLCHAIN_DIR}/bin" >> $GITHUB_PATH
+          echo "TOOLCHAIN_DIR=${TOOLCHAIN_DIR}" >> $GITHUB_ENV
+      - name: Create CMake toolchain file
+        run: |
+          cat > toolchain-aarch64_be.cmake << 'EOF'
+          set(CMAKE_SYSTEM_NAME Linux)
+          set(CMAKE_SYSTEM_PROCESSOR aarch64)
+          set(CMAKE_C_COMPILER   aarch64_be-none-linux-gnu-gcc)
+          set(CMAKE_CXX_COMPILER aarch64_be-none-linux-gnu-g++)
+          set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+          set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+          set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+          EOF
+      - run: mkdir build
+      - run: >
+          cmake
+          -DCMAKE_TOOLCHAIN_FILE=../toolchain-aarch64_be.cmake
+          -DCMAKE_CROSSCOMPILING_EMULATOR="qemu-aarch64_be;-L;${{ env.TOOLCHAIN_DIR }}/aarch64_be-none-linux-gnu/libc"
+          -DWITH_PYTHON=OFF
+          -DFETCH_ABSEIL=ON
+          -DSKIP_OPENSSL_TESTS=ON
+          -DCMAKE_BUILD_TYPE=Dev
+          -DCMAKE_CXX_STANDARD=17
+          ..
+        working-directory: build/
+      - run: cmake --build . --parallel ${{ env.NUM_CORES }}
+        working-directory: build/
+      - if: always()
+        name: Run tests
+        run: |
+          # Known failures due to unimplemented big-endian encoding/decoding.
+          EXCLUDE="EncodedS2PointVectorTest\.(Empty|OnePoint|AllExceptionsBlock|RoundtripEncodingFast)"
+          EXCLUDE+="|EncodedS2ShapeIndex\.(OneEdge|RegularLoops|OverlappingPointClouds|OverlappingPolylines|OverlappingLoops|JavaByteCompatibility)"
+          EXCLUDE+="|S2LaxPolygonShape\.(EmptyPolygon|FullPolygon|ManyLoopPolygon|InvertedLoops|S2CoderWorks)"
+          EXCLUDE+="|S2LaxPolygonShapeTest\.BadLoopOffsets"
+          EXCLUDE+="|S2LaxPolylineShape\.S2CoderWorks"
+          EXCLUDE+="|S2Point\.CoderWorks"
+          EXCLUDE+="|S2RegionEncodeDecodeTest\.S2(Loop|Polygon|Polyline)"
+          EXCLUDE+="|FastEncodeTaggedShapes\.MixedShapes"
+          EXCLUDE+="|DecodeTaggedShapes\.(DecodeFromByteString|DecodeFromEncoded)"
+          EXCLUDE+="|OutgoingEdgeButNoIncomingEdge"
+          ctest --parallel ${{ env.NUM_CORES }} --output-on-failure -E "$EXCLUDE"
+        working-directory: build/
   bazel:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,10 @@ else()
     add_definitions(-Wno-attributes)
     add_definitions(-Wno-deprecated-declarations)
     add_definitions(-Wno-nullability-completeness)
+    # Suppress noisy AArch64 ABI notes about parameter passing changes in
+    # GCC 10.1.  Irrelevant since we don't mix objects from old compilers.
+    # TODO: Use check_cxx_compiler_flag(-Wno-psabi) to guard this.
+    add_compile_options(-Wno-psabi)
     # Some files use sized deallocation, which should be enabled by
     # default for C++14 and later.  There appears to be a bug with clang
     # < 19 causing this not to be enabled.
@@ -137,6 +141,7 @@ endif()
 # If OpenSSL is installed in a non-standard location, configure with
 # something like:
 # OPENSSL_ROOT_DIR=/usr/local/opt/openssl cmake ..
+# TODO: Unused?  bignum_test uses target_include_directories instead.
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 if (WITH_PYTHON)
@@ -303,7 +308,12 @@ set_target_properties(s2 PROPERTIES
     VERSION ${PROJECT_VERSION})
 
 if (BUILD_TESTS)
-  find_package(OpenSSL REQUIRED)
+  # Used to avoid otherwise unneeded dependency for AArch64-BE cross-compilation.
+  # Currently only bignum_test requires OpenSSL.
+  option(SKIP_OPENSSL_TESTS "Skip tests that require OpenSSL." OFF)
+  if (NOT SKIP_OPENSSL_TESTS)
+    find_package(OpenSSL REQUIRED)
+  endif()
 
   # We could use a pre-installed benchmark with
   # `find_package(benchmark QUIET)` then, `if (NOT benchmark_FOUND)`, but
@@ -477,9 +487,13 @@ if (BUILD_TESTS)
       src/s2/s2wrapped_shape_test.cc
       src/s2/sequence_lexicon_test.cc
       src/s2/value_lexicon_test.cc
-      src/s2/util/math/exactfloat/bignum_test.cc
       src/s2/util/math/exactfloat/exactfloat_test.cc
       src/s2/util/math/exactfloat/exactfloat_underflow_test.cc)
+
+  if (NOT SKIP_OPENSSL_TESTS)
+    list(APPEND S2TestFiles
+         src/s2/util/math/exactfloat/bignum_test.cc)
+  endif()
 
   enable_testing()
 
@@ -510,12 +524,14 @@ if (BUILD_TESTS)
     gtest_discover_tests(${test})
   endforeach()
 
-  target_link_libraries(
-    bignum_test
-    ${OPENSSL_LIBRARIES})
+  if (NOT SKIP_OPENSSL_TESTS)
+    target_link_libraries(
+      bignum_test
+      ${OPENSSL_LIBRARIES})
 
-  target_include_directories(
-    bignum_test PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_include_directories(
+      bignum_test PRIVATE ${OPENSSL_INCLUDE_DIR})
+  endif()
 
 endif()
 


### PR DESCRIPTION
Cross-compile for aarch64_be using the Arm GNU Toolchain on the ubuntu-24.04-arm runner and run tests under qemu-aarch64_be user-mode emulation. Since aarch64 LE and BE share the same ISA, QEMU only needs to handle byte swapping, so test execution is fast.

Add a SKIP_OPENSSL_TESTS CMake option (default OFF) to allow building tests without OpenSSL. Currently only bignum_test requires it. The big-endian CI job uses this to avoid cross-compiling OpenSSL.