### PR TITLE
workflows: Use -O1 to speed up tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           - macos-26-intel     # x86-64
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set NUM_CORES
@@ -53,6 +53,7 @@ jobs:
           -DWITH_PYTHON=ON
           -DWITH_PYTHON_LIMITED_API=${{ !startsWith(matrix.runs-on, 'ubuntu-22') && 'ON' || 'OFF' }}
           -DFETCH_ABSEIL=ON
+          -DCMAKE_BUILD_TYPE=Dev
           -DCMAKE_CXX_STANDARD=17
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -65,6 +66,7 @@ jobs:
         working-directory: build/
   bazel:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # We would like to test on the oldest and newest supported.
     # https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
@@ -91,12 +93,13 @@ jobs:
       run: |
         bazel test \
           --config=ci \
+          --config=dev \
           --keep_going \
           --test_verbose_timeout_warnings \
           //...
       working-directory: src
   python:
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       matrix:
         runs-on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 3.18)
 # see https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md#macos
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum macOS version")
 
+# Custom "Dev" build type: optimized but without -DNDEBUG so that asserts remain
+# active.  Use with -DCMAKE_BUILD_TYPE=Dev.  Defining the _INIT variables before
+# project() seeds the cache via the same mechanism CMake uses for the built-in
+# build types (Debug, Release, etc.).
+set(CMAKE_CXX_FLAGS_DEV_INIT "-O1")
+
 project(s2-geometry
         VERSION 0.12.0)
 

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -3,6 +3,9 @@ common --enable_bzlmod
 common --cxxopt=-std=c++20
 common --announce_rc
 
+# Faster tests than fastbuild (-O0).
+build:dev --copt=-O1
+
 # CI-specific flags
 common:ci --color=yes
 build:ci --show_progress_rate_limit=10


### PR DESCRIPTION
The default build (no CMAKE_BUILD_TYPE / bazel fastbuild) uses -O0, making tests slower than necessary. Add a "Dev" build type for CMake and a "dev" config for Bazel that use -O1, and enable them in the CI workflow.