### PR TITLE
python: Fix/suppress CMake/SWIG warnings

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -36,11 +36,11 @@ set_property(SOURCE s2.i PROPERTY CPLUSPLUS ON)
 swig_add_library(s2geometry LANGUAGE python SOURCES s2.i)
 
 if (WITH_PYTHON_LIMITED_API)
-    swig_link_libraries(s2geometry Python3::SABIModule s2)
+    target_link_libraries(s2geometry Python3::SABIModule s2)
     # https://www.swig.org/Doc4.2/Python.html#Python_stable_abi
     target_compile_definitions(s2geometry PRIVATE Py_LIMITED_API=0x030a0000)
 else()
-    swig_link_libraries(s2geometry Python3::Module s2)
+    target_link_libraries(s2geometry Python3::Module s2)
 endif()
 
 enable_testing()

--- a/src/python/coder.i
+++ b/src/python/coder.i
@@ -124,6 +124,9 @@
 %unignore Encoder::putdouble(double);
 %unignore Encoder::putfloat(float);
 %unignore Encoder::reset(void *, size_t);
+// Silence SWIG Warning 362: operator= can't be wrapped in Python.
+// %ignoreall is active but the warning fires at parse time regardless.
+%ignore Encoder::operator=;
 
 %include "s2/util/coding/coder.h"
 

--- a/src/python/s2_common.i
+++ b/src/python/s2_common.i
@@ -548,12 +548,19 @@ public:
 %unignore S2BooleanOperation::S2BooleanOperation(OpType, S2Builder::Layer*, const Options&);
 %ignore S2BooleanOperation::S2BooleanOperation(OpType, std::unique_ptr<S2Builder::Layer>, const Options&);
 %ignore S2BooleanOperation::S2BooleanOperation(OpType, std::unique_ptr<S2Builder::Layer>);
+// Silence SWIG Warning 362: operator= can't be wrapped in Python.
+%ignore S2BooleanOperation::operator=;
 %unignore S2BufferOperation;
 %unignore S2BufferOperation::Build;
 %unignore S2BufferOperation::Options;
 %unignore S2BufferOperation::S2BufferOperation(S2Builder::Layer*);
 %ignore S2BufferOperation::S2BufferOperation(std::unique_ptr<S2Builder::Layer>);
 %ignore S2BufferOperation::S2BufferOperation(std::unique_ptr<S2Builder::Layer>, const Options&);
+// Silence SWIG Warning 362: operator= can't be wrapped in Python.
+%ignore S2BufferOperation::operator=;
+// Silence SWIG Warning 325: nested class Options can't be wrapped directly.
+// S2BufferOperationOptions provides a workaround wrapper.
+%warnfilter(325) S2BufferOperation;
 %unignore S2BufferOperationOptions;
 %unignore S2BufferOperationOptions::set_buffer_radius;
 %unignore S2BufferOperationOptions::set_error_fraction;


### PR DESCRIPTION
Replace deprecated swig_link_libraries() with target_link_libraries() (CMake 4.3 deprecation, works in all supported CMake versions).

Add targeted %ignore directives for operator= on Encoder, S2BooleanOperation, and S2BufferOperation to silence SWIG Warning 362. These operators can't be wrapped in Python and are already covered by %ignoreall, but the warning fires at parse time regardless.

Add %warnfilter(325) for S2BufferOperation to silence the nested class warning for Options, which already has a workaround wrapper (S2BufferOperationOptions).