### PR TITLE
pyproject.toml: Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,13 @@ requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: POSIX",
-    "License :: OSI Approved :: Apache Software License",
 ]
 dynamic = [
     "version",
 ]
 
-[project.license]
-file = "LICENSE"
-content-type = "text/plain"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE", "AUTHORS"]
 
 [project.urls]
 Source = "https://github.com/google/s2geometry"


### PR DESCRIPTION
Replace the deprecated [project.license] table and license classifier with the modern SPDX format.

Fixes SetuptoolsDeprecationWarning about `project.license` as a TOML table and deprecated license classifiers.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license