### PR TITLE
fix: replace alignof(expression) with alignof(S2Point)

### DIFF
--- a/src/s2/s2point_array.h
+++ b/src/s2/s2point_array.h
@@ -45,9 +45,9 @@ inline UniqueS2PointArray MakeS2PointArrayForOverwrite(int32_t size) {
   // Note that even `std::make_unique_for_overwrite<S2Point[]>(size)`
   // zero-initializes the memory, so we use `::operator new` directly.
   ABSL_DCHECK_GE(size, 0);
-  S2Point* p = static_cast<S2Point*>(::operator new(
-      size * sizeof(S2Point),
-      std::align_val_t(alignof(S2Point))));
+  void* raw = ::operator new(size * sizeof(S2Point),
+                             std::align_val_t(alignof(S2Point)));
+  S2Point* const p = static_cast<S2Point*>(raw);
   return UniqueS2PointArray(p);
 }
 

--- a/src/s2/s2point_array.h
+++ b/src/s2/s2point_array.h
@@ -32,7 +32,7 @@ namespace s2internal {
 
 struct S2PointArrayDeleter {
   void operator()(S2Point* p) const {
-    ::operator delete(p, std::align_val_t(alignof(*p)));
+    ::operator delete(p, std::align_val_t(alignof(S2Point)));
   }
 };
 
@@ -46,7 +46,7 @@ inline UniqueS2PointArray MakeS2PointArrayForOverwrite(int32_t size) {
   // zero-initializes the memory, so we use `::operator new` directly.
   ABSL_DCHECK_GE(size, 0);
   S2Point* p = static_cast<S2Point*>(
-      ::operator new(size * sizeof(*p), std::align_val_t(alignof(*p))));
+      ::operator new(size * sizeof(S2Point), std::align_val_t(alignof(S2Point))));
   return UniqueS2PointArray(p);
 }
 

--- a/src/s2/s2point_array.h
+++ b/src/s2/s2point_array.h
@@ -45,9 +45,8 @@ inline UniqueS2PointArray MakeS2PointArrayForOverwrite(int32_t size) {
   // Note that even `std::make_unique_for_overwrite<S2Point[]>(size)`
   // zero-initializes the memory, so we use `::operator new` directly.
   ABSL_DCHECK_GE(size, 0);
-  void* raw = ::operator new(size * sizeof(S2Point),
-                             std::align_val_t(alignof(S2Point)));
-  S2Point* const p = static_cast<S2Point*>(raw);
+  S2Point* p = static_cast<S2Point*>(::operator new(
+      size * sizeof(S2Point), std::align_val_t(alignof(S2Point))));
   return UniqueS2PointArray(p);
 }
 

--- a/src/s2/s2point_array.h
+++ b/src/s2/s2point_array.h
@@ -45,8 +45,9 @@ inline UniqueS2PointArray MakeS2PointArrayForOverwrite(int32_t size) {
   // Note that even `std::make_unique_for_overwrite<S2Point[]>(size)`
   // zero-initializes the memory, so we use `::operator new` directly.
   ABSL_DCHECK_GE(size, 0);
-  S2Point* p = static_cast<S2Point*>(
-      ::operator new(size * sizeof(S2Point), std::align_val_t(alignof(S2Point))));
+  S2Point* p = static_cast<S2Point*>(::operator new(
+      size * sizeof(S2Point),
+      std::align_val_t(alignof(S2Point))));
   return UniqueS2PointArray(p);
 }
 


### PR DESCRIPTION
Fixes #539
Replace **`alignof(*p)`** and **`sizeof(*p)`** in **`MakeS2PointArrayForOverwrite()`** / **`S2PointArrayDeleter`** with **`alignof(S2Point)`** / **`sizeof(S2Point)`** so allocation uses only standard **`alignof(type)`**, eliminating **`-Wgnu-alignof-expression`** on Clang.