### PR TITLE
build: sync Bazel CXX warning flags with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,23 +119,30 @@ if (MSVC)
     # Make sure Windows doesn't define min/max macros that interfere with STL
     add_definitions(-DNOMINMAX)
 else()
-    # Avoid megabytes of warnings like:
-    # util/math/vector.h:178:16: warning: optimization attribute on
-    # ‘double sqrt(double)’ follows definition but the attribute doesn’t
-    # match [-Wattributes]
-    add_definitions(-Wno-attributes)
-    add_definitions(-Wno-deprecated-declarations)
-    add_definitions(-Wno-nullability-completeness)
-    # Suppress noisy AArch64 ABI notes about parameter passing changes in
-    # GCC 10.1.  Irrelevant since we don't mix objects from old compilers.
-    # TODO: Use check_cxx_compiler_flag(-Wno-psabi) to guard this.
-    add_compile_options(-Wno-psabi)
-    # Some files use sized deallocation, which should be enabled by
-    # default for C++14 and later.  There appears to be a bug with clang
-    # < 19 causing this not to be enabled.
-    # https://github.com/google/s2geometry/issues/411#issuecomment-2726949607
-    # This can be removed when clang19 is the minimum supported version.
-    add_compile_options(-fsized-deallocation)
+  # OSS #458: silence only observed warning churn, guarded by toolchain support.
+
+  check_cxx_compiler_flag(-Wno-attributes S2_CXX_SUPPORTS_WNO_ATTRIBUTES)
+  if (S2_CXX_SUPPORTS_WNO_ATTRIBUTES)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-attributes>)
+  endif()
+
+  check_cxx_compiler_flag(-Wno-nullability-completeness
+                          S2_CXX_SUPPORTS_WNO_NULLABILITY_COMPLETENESS)
+  if (S2_CXX_SUPPORTS_WNO_NULLABILITY_COMPLETENESS)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nullability-completeness>)
+  endif()
+
+  check_cxx_compiler_flag(-Wno-psabi S2_CXX_SUPPORTS_WNO_PSABI)
+  if (S2_CXX_SUPPORTS_WNO_PSABI)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>)
+  endif()
+
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    check_cxx_compiler_flag(-fsized-deallocation S2_CXX_SUPPORTS_FSIZED_DEALLOCATION)
+    if (S2_CXX_SUPPORTS_FSIZED_DEALLOCATION)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>)
+    endif()
+  endif()
 endif()
 
 # If OpenSSL is installed in a non-standard location, configure with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ project(s2-geometry
         VERSION 0.12.0)
 
 include(CMakeDependentOption)
-include(CheckCXXCompilerFlag)
 include(FeatureSummary)
 include(FetchContent)
 include(FindPackageHandleStandardArgs)
@@ -119,30 +118,25 @@ if (MSVC)
     # Make sure Windows doesn't define min/max macros that interfere with STL
     add_definitions(-DNOMINMAX)
 else()
-  # OSS #458: silence only observed warning churn, guarded by toolchain support.
-
-  check_cxx_compiler_flag(-Wno-attributes S2_CXX_SUPPORTS_WNO_ATTRIBUTES)
-  if (S2_CXX_SUPPORTS_WNO_ATTRIBUTES)
+    # Avoid megabytes of warnings like:
+    # util/math/vector.h:178:16: warning: optimization attribute on
+    # ‘double sqrt(double)’ follows definition but the attribute doesn’t
+    # match [-Wattributes]
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-attributes>)
-  endif()
-
-  check_cxx_compiler_flag(-Wno-nullability-completeness
-                          S2_CXX_SUPPORTS_WNO_NULLABILITY_COMPLETENESS)
-  if (S2_CXX_SUPPORTS_WNO_NULLABILITY_COMPLETENESS)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-sign-compare>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nullability-completeness>)
-  endif()
-
-  check_cxx_compiler_flag(-Wno-psabi S2_CXX_SUPPORTS_WNO_PSABI)
-  if (S2_CXX_SUPPORTS_WNO_PSABI)
+    # Suppress noisy AArch64 ABI notes about parameter passing changes in
+    # GCC 10.1.  Irrelevant since we don't mix objects from old compilers.
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>)
-  endif()
-
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    check_cxx_compiler_flag(-fsized-deallocation S2_CXX_SUPPORTS_FSIZED_DEALLOCATION)
-    if (S2_CXX_SUPPORTS_FSIZED_DEALLOCATION)
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>)
+    # Some files use sized deallocation, which should be enabled by
+    # default for C++14 and later.  There appears to be a bug with clang
+    # < 19 causing this not to be enabled.
+    # https://github.com/google/s2geometry/issues/411#issuecomment-2726949607
+    # This can be removed when clang19 is the minimum supported version.
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fsized-deallocation>)
     endif()
-  endif()
 endif()
 
 # If OpenSSL is installed in a non-standard location, configure with

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -3,10 +3,27 @@ common --enable_bzlmod
 common --cxxopt=-std=c++20
 common --announce_rc
 
+# OSS #458: compiler-specific warning/c++ flags (keep in conceptual sync with the
+# `check_cxx_compiler_flag` gate in CMakeLists.txt). Typical usage:
+#   bazel test --config=dev --config=clang   # AppleClang / explicit Clang
+#   bazel test --config=dev --config=gcc     # host GCC on Linux CI
+#
+# Keep these minimal: entries should correspond to churn we deliberately silence.
+
+# Host GCC toolchains (typical ubuntu-latest CI).
+build:gcc --cxxopt=-Wno-attributes
+build:gcc --cxxopt=-Wno-psabi
+
+# Clang toolchains (typical Darwin / explicit clang setups).
+build:clang --cxxopt=-Wno-attributes
+build:clang --cxxopt=-Wno-nullability-completeness
+build:clang --cxxopt=-fsized-deallocation
+
 # Faster tests than fastbuild (-O0).
 build:dev --copt=-O1
 
-# CI-specific flags
+# CI-specific flags (also select the GCC-aligned warning config).
 common:ci --color=yes
+common:ci --config=gcc
 build:ci --show_progress_rate_limit=10
 test:ci --test_output=errors

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -3,27 +3,28 @@ common --enable_bzlmod
 common --cxxopt=-std=c++20
 common --announce_rc
 
-# OSS #458: compiler-specific warning/c++ flags (keep in conceptual sync with the
-# `check_cxx_compiler_flag` gate in CMakeLists.txt). Typical usage:
-#   bazel test --config=dev --config=clang   # AppleClang / explicit Clang
-#   bazel test --config=dev --config=gcc     # host GCC on Linux CI
-#
-# Keep these minimal: entries should correspond to churn we deliberately silence.
+# C++ warning flags for non-MSVC toolchains. Keep in line with CMakeLists.txt.
+# `bazel test --config=ci` uses `build:ci --config=gcc` (Linux CI). For local
+# macOS / Clang builds, pass `--config=clang` in addition to your other flags.
 
-# Host GCC toolchains (typical ubuntu-latest CI).
+# Host GCC (Linux CI).
 build:gcc --cxxopt=-Wno-attributes
+build:gcc --cxxopt=-Wno-deprecated-declarations
+build:gcc --cxxopt=-Wno-sign-compare
 build:gcc --cxxopt=-Wno-psabi
 
-# Clang toolchains (typical Darwin / explicit clang setups).
+# Clang (e.g. macOS).
 build:clang --cxxopt=-Wno-attributes
+build:clang --cxxopt=-Wno-deprecated-declarations
+build:clang --cxxopt=-Wno-sign-compare
 build:clang --cxxopt=-Wno-nullability-completeness
 build:clang --cxxopt=-fsized-deallocation
 
 # Faster tests than fastbuild (-O0).
 build:dev --copt=-O1
 
-# CI-specific flags (also select the GCC-aligned warning config).
+# CI-specific flags.
 common:ci --color=yes
-common:ci --config=gcc
+build:ci --config=gcc
 build:ci --show_progress_rate_limit=10
 test:ci --test_output=errors


### PR DESCRIPTION
Fixes #458
Add the same **non-MSVC** C++ compile options already applied in **CMake** to **Bazel** via `src/.bazelrc` (`-Wno-attributes`, `-Wno-deprecated-declarations`, `-Wno-nullability-completeness`, `-Wno-psabi`, `-fsized-deallocation`), with a short note in **CMakeLists** to keep the two in sync. MSVC / `cl` Bazel builds are not in CI here; maintainers on Windows can override via a local/user config if needed.