### PR TITLE
workflows: Add macOS Bazel CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,13 @@ jobs:
             --repeat until-pass:3
         working-directory: build/
   bazel:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 15
 
     # We would like to test on the oldest and newest supported.


### PR DESCRIPTION
CMake already runs on many platforms including macOS, but Bazel only ran on ubuntu-latest. Add macos-latest to catch macOS-specific Bazel build issues.