### PR TITLE
workflows: Add keep-sorted check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,18 @@ jobs:
 
       - name: Check Starlark / BUILD formatting (buildifier)
         run: buildifier -r -mode=check .
+
+      - name: Install keep-sorted
+        run: |
+          set -u
+          KEEPSORTED_VERSION=0.8.0
+          KEEPSORTED_SHA256=0d9801785ac354232ea754bbfd8cc204a5e255905e14bcbff5fe8733e4dbd85c
+          KEEPSORTED_DL=/tmp/keep-sorted
+          curl -fsSL -o "${KEEPSORTED_DL}" \
+            "https://github.com/google/keep-sorted/releases/download/v${KEEPSORTED_VERSION}/keep-sorted_linux"
+          echo "${KEEPSORTED_SHA256}  ${KEEPSORTED_DL}" | sha256sum --check -
+          chmod +x "${KEEPSORTED_DL}"
+          sudo mv "${KEEPSORTED_DL}" /usr/local/bin/keep-sorted
+
+      - name: Check keep-sorted
+        run: git ls-files -z | xargs -0 keep-sorted --mode=lint

--- a/src/python/module.cc
+++ b/src/python/module.cc
@@ -3,14 +3,16 @@
 namespace py = pybind11;
 
 // Forward declarations for binding functions
+// keep-sorted start
 void bind_r1interval(py::module& m);
 void bind_r2point(py::module& m);
 void bind_r2rect(py::module& m);
 void bind_s1angle(py::module& m);
 void bind_s1interval(py::module& m);
-void bind_s2point(py::module& m);
-void bind_s2latlng(py::module& m);
 void bind_s2cell_id(py::module& m);
+void bind_s2latlng(py::module& m);
+void bind_s2point(py::module& m);
+// keep-sorted end
 
 PYBIND11_MODULE(s2geometry_bindings, m) {
   m.doc() = "S2 Geometry Python bindings using pybind11";


### PR DESCRIPTION
Install keep-sorted v0.8.0 and run it in check mode on all tracked files, matching the existing buildifier pattern.

Also fix the one existing keep-sorted violation in module.cc (swap bind_s2point/bind_s2latlng to sorted order).