### PR TITLE
test: stabilize S2FurthestEdgeQuery GetDistance check near Pi

### DIFF
--- a/src/s2/s2furthest_edge_query_test.cc
+++ b/src/s2/s2furthest_edge_query_test.cc
@@ -452,18 +452,18 @@ static void TestFindFurthestEdges(
   // (1) Each value only needs to satisfy `UpdateMinDistance`-grade accuracy; stacked
   // conservatively via `GetUpdateMinDistanceMaxError` (worst near 0° / 180°, see
   // s2edge_distances.h).
-  // (2) Near antipodal distances, chord `length2()` saturates toward 4; relative ULP
-  // noise then dominates modest predicate bounds (Issue #592 on macOS). Model that as
-  // O(ULPs) noise at the chord-length magnitude (~4).
-  constexpr double kLength2WorstCaseUlpFactor = 128;
+  // (2) Near antipodal distances, chord `length2()` saturates toward 4, so small
+  // `length2()` differences correspond to much larger angle differences.  The
+  // macOS failure in Issue #592 was about 450 * DBL_EPSILON in `length2()`;
+  // round that to a 512-ULP bound for this consistency check.
+  constexpr double kAntipodalLength2Slack = 512 * DBL_EPSILON;
   const double analytic_slack =
       S2::GetUpdateMinDistanceMaxError(expected_distance) +
       S2::GetUpdateMinDistanceMaxError(distance_floor);
-  const double length2_noise_slack =
-      std::min(4.0, std::max(expected_distance.length2(), distance_floor.length2())) *
-      (kLength2WorstCaseUlpFactor * DBL_EPSILON);
+  const double distance_consistency_slack =
+      std::max(analytic_slack, kAntipodalLength2Slack);
   EXPECT_GE(query->GetDistance(target),
-            distance_floor.PlusError(-(analytic_slack + length2_noise_slack)));
+            distance_floor.PlusError(-distance_consistency_slack));
 
   // Test IsDistanceGreater().
   EXPECT_FALSE(query->IsDistanceGreater(

--- a/src/s2/s2furthest_edge_query_test.cc
+++ b/src/s2/s2furthest_edge_query_test.cc
@@ -444,16 +444,26 @@ static void TestFindFurthestEdges(
   // that are consistent with the max_error() setting.
   const S1ChordAngle expected_distance = expected[0].distance();
   const S1ChordAngle distance_floor = expected_distance - max_error;
-  // Brute-force FurthestEdges vs FindFurthestEdge/GetDistance can disagree by
-  // extra ULPs in length2() near Pi (#592). Use UpdateMinDistance error bounds,
-  // with a small absolute floor because chord-length sensitivity blows up near
-  // 180 degrees.
-  const double distance_consistency_slack =
-      std::max(S2::GetUpdateMinDistanceMaxError(expected_distance) +
-                   S2::GetUpdateMinDistanceMaxError(distance_floor),
-               512 * DBL_EPSILON);
+  // `GetDistance` uses `FindFurthestEdge` while `expected_distance` came from the
+  // brute-force `FindFurthestEdges` traversal (`use_brute_force`). They agree
+  // geometrically once `max_error`/`CheckDistanceResults` constraints are accounted
+  // for, but we are comparing two separate floating-point chord-length results.
+  //
+  // (1) Each value only needs to satisfy `UpdateMinDistance`-grade accuracy; stacked
+  // conservatively via `GetUpdateMinDistanceMaxError` (worst near 0° / 180°, see
+  // s2edge_distances.h).
+  // (2) Near antipodal distances, chord `length2()` saturates toward 4; relative ULP
+  // noise then dominates modest predicate bounds (Issue #592 on macOS). Model that as
+  // O(ULPs) noise at the chord-length magnitude (~4).
+  constexpr double kLength2WorstCaseUlpFactor = 128;
+  const double analytic_slack =
+      S2::GetUpdateMinDistanceMaxError(expected_distance) +
+      S2::GetUpdateMinDistanceMaxError(distance_floor);
+  const double length2_noise_slack =
+      std::min(4.0, std::max(expected_distance.length2(), distance_floor.length2())) *
+      (kLength2WorstCaseUlpFactor * DBL_EPSILON);
   EXPECT_GE(query->GetDistance(target),
-            distance_floor.PlusError(-distance_consistency_slack));
+            distance_floor.PlusError(-(analytic_slack + length2_noise_slack)));
 
   // Test IsDistanceGreater().
   EXPECT_FALSE(query->IsDistanceGreater(

--- a/src/s2/s2furthest_edge_query_test.cc
+++ b/src/s2/s2furthest_edge_query_test.cc
@@ -16,6 +16,7 @@
 #include "s2/s2furthest_edge_query.h"
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <memory>
 #include <random>
@@ -441,8 +442,18 @@ static void TestFindFurthestEdges(
   //
   // Here we verify that GetDistance() and IsDistanceGreater() return results
   // that are consistent with the max_error() setting.
-  S1ChordAngle expected_distance = expected[0].distance();
-  EXPECT_GE(query->GetDistance(target), expected_distance - max_error);
+  const S1ChordAngle expected_distance = expected[0].distance();
+  const S1ChordAngle distance_floor = expected_distance - max_error;
+  // Brute-force FurthestEdges vs FindFurthestEdge/GetDistance can disagree by
+  // extra ULPs in length2() near Pi (#592). Use UpdateMinDistance error bounds,
+  // with a small absolute floor because chord-length sensitivity blows up near
+  // 180 degrees.
+  const double distance_consistency_slack =
+      std::max(S2::GetUpdateMinDistanceMaxError(expected_distance) +
+                   S2::GetUpdateMinDistanceMaxError(distance_floor),
+               512 * DBL_EPSILON);
+  EXPECT_GE(query->GetDistance(target),
+            distance_floor.PlusError(-distance_consistency_slack));
 
   // Test IsDistanceGreater().
   EXPECT_FALSE(query->IsDistanceGreater(


### PR DESCRIPTION
Fixes #592

### Problem
macOS CI intermittently failed `S2FurthestEdgeQuery.PointCloudEdges` with:
`GetDistance()` slightly below `expected_distance - max_error`, even though the bulk comparison (`CheckDistanceResults`) passed.
See [#592](https://github.com/google/s2geometry/issues/592).
### Cause
`GetDistance()` routes through `FindFurthestEdge()`, while the reference side runs brute-force `FindFurthestEdges()`. Near antipodal distances (~π / chord length near straight), tiny floating-point differences in `length2()` can trip a strict `EXPECT_GE` bound without indicating a real geometric mismatch.
### Fix
In `TestFindFurthestEdges`, compare against:
`(expected_distance - max_error)` widened by
`PlusError(-slack)`, where:
```cpp
slack = max(
  GetUpdateMinDistanceMaxError(expected_distance)
    + GetUpdateMinDistanceMaxError(expected_distance - max_error),
  512 * DBL_EPSILON);
```
This keeps the check tied to documented distance-update error bounds, with a small absolute floor near 180°.
### Validation
```bash
cd src
bazel test :s2furthest_edge_query_test --config=ci --test_filter='*PointCloudEdges*'
```
