### PR TITLE
pybind: Add __hash__ to all binding types 

### DIFF
--- a/src/python/BUILD.bazel
+++ b/src/python/BUILD.bazel
@@ -43,6 +43,7 @@ pybind_library(
     srcs = ["r1interval_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
     ],
 )
 
@@ -51,6 +52,7 @@ pybind_library(
     srcs = ["r2point_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
     ],
 )
 
@@ -59,6 +61,7 @@ pybind_library(
     srcs = ["r2rect_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
     ],
 )
 
@@ -67,6 +70,8 @@ pybind_library(
     srcs = ["s1angle_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/strings",
     ],
 )
 
@@ -85,6 +90,7 @@ pybind_library(
     srcs = ["s1interval_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
         "@abseil-cpp//absl/strings",
     ],
 )
@@ -94,6 +100,7 @@ pybind_library(
     srcs = ["s2point_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
     ],
 )
 
@@ -102,6 +109,7 @@ pybind_library(
     srcs = ["s2latlng_bindings.cc"],
     deps = [
         "//:s2",
+        "@abseil-cpp//absl/hash",
         "@abseil-cpp//absl/strings",
     ],
 )

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -57,6 +57,7 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 
 **Operators:**
 - Standard Python operators work as expected: `+`, `-`, `*`, `==`, `!=`, `<`, `>` (for C++ classes that implement those operators)
+- Types that define `__eq__` also define `__hash__`, so they can be used as dictionary keys and in sets.
 - Binding types are intentionally immutable. In-place mutation operators are not supported. Augmented assignment (`+=`, `-=`, `*=`, `/=`) still works: Python falls back to the binary operator and rebinds the variable (e.g. `a += b` is equivalent to `a = a + b`).
 
 **Method Overloads:**

--- a/src/python/r1interval_bindings.cc
+++ b/src/python/r1interval_bindings.cc
@@ -3,6 +3,7 @@
 
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "s2/r1interval.h"
 
 namespace py = pybind11;
@@ -101,6 +102,10 @@ void bind_r1interval(py::module& m) {
       // Operators
       .def(py::self == py::self, "Return true if two intervals contain the same set of points")
       .def(py::self != py::self, "Return true if two intervals do not contain the same set of points")
+      .def("__hash__", [](const R1Interval& self) {
+        return absl::Hash<std::pair<double, double>>()(
+            std::make_pair(self.lo(), self.hi()));
+      })
 
       // String representation
       .def("__repr__", [](const R1Interval& i) {

--- a/src/python/r1interval_bindings.cc
+++ b/src/python/r1interval_bindings.cc
@@ -103,8 +103,7 @@ void bind_r1interval(py::module& m) {
       .def(py::self == py::self, "Return true if two intervals contain the same set of points")
       .def(py::self != py::self, "Return true if two intervals do not contain the same set of points")
       .def("__hash__", [](const R1Interval& self) {
-        return absl::Hash<std::pair<double, double>>()(
-            std::make_pair(self.lo(), self.hi()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/r1interval_test.py
+++ b/src/python/r1interval_test.py
@@ -252,6 +252,12 @@ class TestR1Interval(unittest.TestCase):
         e2 = s2.R1Interval()
         self.assertTrue(e1 == e2)
 
+    def test_hash(self):
+        a = s2.R1Interval(0.0, 1.0)
+        b = s2.R1Interval(0.0, 1.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_string_representation(self):

--- a/src/python/r2point_bindings.cc
+++ b/src/python/r2point_bindings.cc
@@ -66,8 +66,7 @@ void bind_r2point(py::module& m) {
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
       .def("__hash__", [](const R2Point& self) {
-        return absl::Hash<std::pair<double, double>>()(
-            std::make_pair(self.x(), self.y()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/r2point_bindings.cc
+++ b/src/python/r2point_bindings.cc
@@ -3,6 +3,7 @@
 
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "s2/r2.h"
 
 namespace py = pybind11;
@@ -64,6 +65,10 @@ void bind_r2point(py::module& m) {
       .def(-py::self, "Negate point")
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
+      .def("__hash__", [](const R2Point& self) {
+        return absl::Hash<std::pair<double, double>>()(
+            std::make_pair(self.x(), self.y()));
+      })
 
       // String representation
       .def("__repr__", [](const R2Point& p) {

--- a/src/python/r2point_test.py
+++ b/src/python/r2point_test.py
@@ -171,6 +171,12 @@ class TestR2Point(unittest.TestCase):
         self.assertAlmostEqual(p.x, 2.0)
         self.assertAlmostEqual(p.y, 3.0)
 
+    def test_hash(self):
+        a = s2.R2Point(1.0, 2.0)
+        b = s2.R2Point(1.0, 2.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_string_representation(self):

--- a/src/python/r2rect_bindings.cc
+++ b/src/python/r2rect_bindings.cc
@@ -3,6 +3,7 @@
 
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "s2/r2rect.h"
 
 namespace py = pybind11;
@@ -163,6 +164,11 @@ void bind_r2rect(py::module& m) {
       // Operators
       .def(py::self == py::self, "Return true if two rectangles are equal")
       .def(py::self != py::self, "Return true if two rectangles are not equal")
+      .def("__hash__", [](const R2Rect& self) {
+        return absl::Hash<std::tuple<double, double, double, double>>()(
+            std::make_tuple(self.lo().x(), self.lo().y(),
+                            self.hi().x(), self.hi().y()));
+      })
 
       // String representation
       .def("__repr__", [](const R2Rect& r) {

--- a/src/python/r2rect_bindings.cc
+++ b/src/python/r2rect_bindings.cc
@@ -165,9 +165,7 @@ void bind_r2rect(py::module& m) {
       .def(py::self == py::self, "Return true if two rectangles are equal")
       .def(py::self != py::self, "Return true if two rectangles are not equal")
       .def("__hash__", [](const R2Rect& self) {
-        return absl::Hash<std::tuple<double, double, double, double>>()(
-            std::make_tuple(self.lo().x(), self.lo().y(),
-                            self.hi().x(), self.hi().y()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/r2rect_test.py
+++ b/src/python/r2rect_test.py
@@ -279,6 +279,12 @@ class TestR2Rect(unittest.TestCase):
         e2 = s2.R2Rect()
         self.assertTrue(e1 == e2)
 
+    def test_hash(self):
+        a = s2.R2Rect(s2.R2Point(0.0, 0.0), s2.R2Point(1.0, 1.0))
+        b = s2.R2Rect(s2.R2Point(0.0, 0.0), s2.R2Point(1.0, 1.0))
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_string_representation(self):

--- a/src/python/s1angle_bindings.cc
+++ b/src/python/s1angle_bindings.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "absl/strings/str_cat.h"
 #include "s2/s1angle.h"
 #include "s2/s2point.h"
@@ -138,6 +139,9 @@ void bind_s1angle(py::module& m) {
       .def("__truediv__", [](const S1Angle& a, const S1Angle& b) -> double {
         return a / b;
       }, py::arg("other"), "Divide two angles, returning a scalar ratio")
+      .def("__hash__", [](S1Angle self) {
+        return absl::Hash<double>()(self.radians());
+      })
 
       // String representation
       .def("__repr__", [](S1Angle a) {

--- a/src/python/s1angle_bindings.cc
+++ b/src/python/s1angle_bindings.cc
@@ -140,7 +140,7 @@ void bind_s1angle(py::module& m) {
         return a / b;
       }, py::arg("other"), "Divide two angles, returning a scalar ratio")
       .def("__hash__", [](S1Angle self) {
-        return absl::Hash<double>()(self.radians());
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/s1angle_test.py
+++ b/src/python/s1angle_test.py
@@ -266,6 +266,12 @@ class TestS1Angle(unittest.TestCase):
         a /= 2.0
         self.assertAlmostEqual(a.degrees, 45.0)
 
+    def test_hash(self):
+        a = s2.S1Angle.from_degrees(45.0)
+        b = s2.S1Angle.from_degrees(45.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_repr(self):

--- a/src/python/s1interval_bindings.cc
+++ b/src/python/s1interval_bindings.cc
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 
+#include "absl/hash/hash.h"
 #include "absl/strings/str_cat.h"
 #include "s2/s1interval.h"
 
@@ -134,6 +135,10 @@ void bind_s1interval(py::module& m) {
           "Return true if two intervals contain the same set of points")
       .def(py::self != py::self,
           "Return true if two intervals do not contain the same set of points")
+      .def("__hash__", [](const S1Interval& self) {
+        return absl::Hash<std::pair<double, double>>()(
+            std::make_pair(self.lo(), self.hi()));
+      })
 
       // String representation
       .def("__repr__", [](const S1Interval& i) {

--- a/src/python/s1interval_bindings.cc
+++ b/src/python/s1interval_bindings.cc
@@ -136,8 +136,7 @@ void bind_s1interval(py::module& m) {
       .def(py::self != py::self,
           "Return true if two intervals do not contain the same set of points")
       .def("__hash__", [](const S1Interval& self) {
-        return absl::Hash<std::pair<double, double>>()(
-            std::make_pair(self.lo(), self.hi()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/s1interval_test.py
+++ b/src/python/s1interval_test.py
@@ -257,6 +257,12 @@ class TestS1Interval(unittest.TestCase):
         self.assertTrue(interval1 == interval2)
         self.assertTrue(interval1 != interval3)
 
+    def test_hash(self):
+        a = s2.S1Interval(0.0, 1.0)
+        b = s2.S1Interval(0.0, 1.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_string_representation(self):

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "absl/strings/str_cat.h"
 #include "s2/s1angle.h"
 #include "s2/s2latlng.h"
@@ -180,6 +181,10 @@ void bind_s2latlng(py::module& m) {
            "Multiply by scalar (reversed operands).\n\n"
            "The result is automatically normalized.\n"
            "Note: the native C++ implementation does not normalize.")
+      .def("__hash__", [](const S2LatLng& self) {
+        return absl::Hash<std::pair<double, double>>()(
+            std::make_pair(self.lat().radians(), self.lng().radians()));
+      })
 
       // String representation
       .def("to_string_in_degrees", &S2LatLng::ToStringInDegrees,

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -182,8 +182,7 @@ void bind_s2latlng(py::module& m) {
            "The result is automatically normalized.\n"
            "Note: the native C++ implementation does not normalize.")
       .def("__hash__", [](const S2LatLng& self) {
-        return absl::Hash<std::pair<double, double>>()(
-            std::make_pair(self.lat().radians(), self.lng().radians()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -306,6 +306,12 @@ class TestS2LatLng(unittest.TestCase):
         # 240 degrees longitude -> wrapped to -120
         self.assertAlmostEqual(result.lng.degrees, -120.0)
 
+    def test_hash(self):
+        a = s2.S2LatLng.from_degrees(45.0, 90.0)
+        b = s2.S2LatLng.from_degrees(45.0, 90.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_repr(self):

--- a/src/python/s2point_bindings.cc
+++ b/src/python/s2point_bindings.cc
@@ -3,6 +3,7 @@
 
 #include <sstream>
 
+#include "absl/hash/hash.h"
 #include "s2/s2point.h"
 
 namespace py = pybind11;
@@ -62,6 +63,10 @@ void bind_s2point(py::module& m) {
       .def(-py::self, "Negate point")
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
+      .def("__hash__", [](const S2Point& self) {
+        return absl::Hash<std::tuple<double, double, double>>()(
+            std::make_tuple(self.x(), self.y(), self.z()));
+      })
 
       // String representation
       // __repr__ prefixes class name, __str__ delegates to C++ operator<<

--- a/src/python/s2point_bindings.cc
+++ b/src/python/s2point_bindings.cc
@@ -64,8 +64,7 @@ void bind_s2point(py::module& m) {
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
       .def("__hash__", [](const S2Point& self) {
-        return absl::Hash<std::tuple<double, double, double>>()(
-            std::make_tuple(self.x(), self.y(), self.z()));
+        return absl::HashOf(self);
       })
 
       // String representation

--- a/src/python/s2point_test.py
+++ b/src/python/s2point_test.py
@@ -137,6 +137,12 @@ class TestS2Point(unittest.TestCase):
         self.assertEqual(p1, p2)
         self.assertNotEqual(p1, p3)
 
+    def test_hash(self):
+        a = s2.S2Point(1.0, 0.0, 0.0)
+        b = s2.S2Point(1.0, 0.0, 0.0)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)
+
     # String representation
 
     def test_string_representation(self):

--- a/src/s2/r1interval.h
+++ b/src/s2/r1interval.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <ostream>
 
+#include "absl/hash/hash.h"
 #include "absl/log/absl_check.h"
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/util/math/vector.h"  // IWYU pragma: export
@@ -224,6 +225,11 @@ class R1Interval {
 
 inline std::ostream& operator<<(std::ostream& os, const R1Interval& x) {
   return os << "[" << x.lo() << ", " << x.hi() << "]";
+}
+
+template <typename H>
+H AbslHashValue(H h, const R1Interval& interval) {
+  return H::combine(std::move(h), interval.lo(), interval.hi());
 }
 
 #endif  // S2_R1INTERVAL_H_

--- a/src/s2/r1interval_test.cc
+++ b/src/s2/r1interval_test.cc
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include "absl/hash/hash_testing.h"
 #include "absl/strings/string_view.h"
 
 using absl::string_view;
@@ -186,4 +187,15 @@ TEST(R1Interval, ApproxEquals) {
   EXPECT_FALSE(R1Interval(1 + kHi, 2 - kLo).ApproxEquals(R1Interval(1, 2)));
   EXPECT_FALSE(R1Interval(1 - kLo, 2 + kHi).ApproxEquals(R1Interval(1, 2)));
   EXPECT_FALSE(R1Interval(1 + kLo, 2 - kHi).ApproxEquals(R1Interval(1, 2)));
+}
+
+TEST(R1Interval, SupportsAbslHash) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+    R1Interval::Empty(),
+    R1Interval(0, 0),
+    R1Interval(0, 1),
+    R1Interval(1, 2),
+    R1Interval(-1, 1),
+    R1Interval(0.5, 1.5),
+  }));
 }

--- a/src/s2/r2rect.h
+++ b/src/s2/r2rect.h
@@ -21,6 +21,7 @@
 #include <iosfwd>
 #include <ostream>
 
+#include "absl/hash/hash.h"
 #include "absl/log/absl_check.h"
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/r1interval.h"
@@ -250,5 +251,10 @@ inline bool R2Rect::operator!=(const R2Rect& other) const {
 }
 
 std::ostream& operator<<(std::ostream& os, const R2Rect& r);
+
+template <typename H>
+H AbslHashValue(H h, const R2Rect& rect) {
+  return H::combine(std::move(h), rect.x(), rect.y());
+}
 
 #endif  // S2_R2RECT_H_

--- a/src/s2/r2rect_test.cc
+++ b/src/s2/r2rect_test.cc
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include "absl/hash/hash_testing.h"
 #include "absl/strings/string_view.h"
 #include "s2/r1interval.h"
 #include "s2/r2.h"
@@ -236,4 +237,15 @@ TEST(R2Rect, Expanded) {
               ApproxEquals(R2Rect(R2Point(0.1, 0.5), R2Point(0.4, 0.6))));
   EXPECT_TRUE(R2Rect(R2Point(0.2, 0.4), R2Point(0.3, 0.7)).Expanded(0.1).
               ApproxEquals(R2Rect(R2Point(0.1, 0.3), R2Point(0.4, 0.8))));
+}
+
+TEST(R2Rect, SupportsAbslHash) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+    R2Rect::Empty(),
+    R2Rect(R2Point(0, 0), R2Point(0, 0)),
+    R2Rect(R2Point(0, 0), R2Point(1, 1)),
+    R2Rect(R2Point(1, 2), R2Point(3, 4)),
+    R2Rect(R2Point(-1, -2), R2Point(1, 2)),
+    R2Rect(R1Interval(0, 1), R1Interval(2, 3)),
+  }));
 }

--- a/src/s2/s1angle.h
+++ b/src/s2/s1angle.h
@@ -24,6 +24,7 @@
 #include <ostream>
 #include <type_traits>
 
+#include "absl/hash/hash.h"
 #include "absl/log/absl_check.h"
 #include "s2/util/coding/coder.h"
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
@@ -386,5 +387,10 @@ inline constexpr S1Angle S1Angle::UnsignedE7(uint32_t e7) {
 // Writes the angle in degrees with 7 digits of precision after the
 // decimal point, e.g. "17.3745904".
 std::ostream& operator<<(std::ostream& os, S1Angle a);
+
+template <typename H>
+H AbslHashValue(H h, S1Angle angle) {
+  return H::combine(std::move(h), angle.radians());
+}
 
 #endif  // S2_S1ANGLE_H_

--- a/src/s2/s1angle_test.cc
+++ b/src/s2/s1angle_test.cc
@@ -24,6 +24,7 @@
 #include <benchmark/benchmark.h>
 #include <gtest/gtest.h>
 
+#include "absl/hash/hash_testing.h"
 #include "absl/log/log_streamer.h"
 #include "absl/random/random.h"
 
@@ -272,4 +273,16 @@ TEST(S1Angle, DegreesVsRadians) {
   // We also spot check a couple of non-identities.
   EXPECT_NE(S1Angle::Degrees(3), S1Angle::Radians(M_PI / 60));
   EXPECT_NE(60, S1Angle::Degrees(60).degrees());
+}
+
+TEST(S1Angle, SupportsAbslHash) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+    S1Angle::Zero(),
+    S1Angle::Radians(1),
+    S1Angle::Radians(-1),
+    S1Angle::Degrees(90),
+    S1Angle::Degrees(180),
+    S1Angle::Degrees(-90),
+    S1Angle::Infinity(),
+  }));
 }

--- a/src/s2/s1interval.h
+++ b/src/s2/s1interval.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <ostream>
 
+#include "absl/hash/hash.h"
 #include "absl/log/absl_check.h"
 #include "s2/_fp_contract_off.h"  // IWYU pragma: keep
 #include "s2/util/math/vector.h"  // IWYU pragma: export
@@ -274,6 +275,11 @@ inline void S1Interval::set_hi(double p) {
 
 inline std::ostream& operator<<(std::ostream& os, const S1Interval& x) {
   return os << "[" << x.lo() << ", " << x.hi() << "]";
+}
+
+template <typename H>
+H AbslHashValue(H h, const S1Interval& interval) {
+  return H::combine(std::move(h), interval.lo(), interval.hi());
 }
 
 #endif  // S2_S1INTERVAL_H_

--- a/src/s2/s1interval_test.cc
+++ b/src/s2/s1interval_test.cc
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include "absl/hash/hash_testing.h"
 #include "absl/strings/string_view.h"
 
 using absl::string_view;
@@ -488,4 +489,16 @@ TEST_F(S1IntervalTestBase, GetDirectedHausdorffDistance) {
                   S1Interval(0.1, 0.2).GetDirectedHausdorffDistance(in));
   EXPECT_FLOAT_EQ(3.0 - 0.1,
                   S1Interval(-0.2, -0.1).GetDirectedHausdorffDistance(in));
+}
+
+TEST(S1Interval, SupportsAbslHash) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+    S1Interval::Empty(),
+    S1Interval::Full(),
+    S1Interval(0, 1),
+    S1Interval(-1, 1),
+    S1Interval(M_PI / 2, M_PI),
+    S1Interval(-M_PI, -M_PI / 2),
+    S1Interval(M_PI - 0.1, -M_PI + 0.1),  // inverted (wraps around)
+  }));
 }


### PR DESCRIPTION
In Python 3, defining `__eq__` without `__hash__` implicitly sets `__hash__ = None`, making the type unhashable. All seven affected types raised:

```
TypeError: unhashable type: 's2geometry_bindings.S1Angle'
```

Adds `__hash__` to `S1Angle`, `S1Interval`, `R1Interval`, `R2Point`, `R2Rect`, `S2LatLng`, and `S2Point` using `absl::Hash` on their underlying values.