### PR TITLE
pybind: Remove in-place mutation operators from hashable types

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -57,6 +57,7 @@ The Python bindings follow the C++ API closely but with Pythonic conventions:
 
 **Operators:**
 - Standard Python operators work as expected: `+`, `-`, `*`, `==`, `!=`, `<`, `>` (for C++ classes that implement those operators)
+- Binding types are intentionally immutable. In-place mutation operators are not supported. Augmented assignment (`+=`, `-=`, `*=`, `/=`) still works: Python falls back to the binary operator and rebinds the variable (e.g. `a += b` is equivalent to `a = a + b`).
 
 **Method Overloads:**
 - Instead of Python overloads, C++ overloaded methods are exposed under distinct names. For different argument types, the short name is used for the same-type argument and a longer name for other types (e.g., `R2Rect.contains(other: R2Rect)` and `R2Rect.contains_point(p: R2Point)`). For overloads with significantly different behavior, descriptive names are chosen (e.g., `R2Rect.vertex(k)` for CCW vertex index and `R2Rect.vertex_ij(i, j)` for axis-direction vertex access).

--- a/src/python/r2point_bindings.cc
+++ b/src/python/r2point_bindings.cc
@@ -64,14 +64,6 @@ void bind_r2point(py::module& m) {
       .def(-py::self, "Negate point")
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
-      .def(py::self += py::self, "In-place addition")
-      .def(py::self -= py::self, "In-place subtraction")
-      .def("__imul__", [](R2Point& self, double v) -> R2Point& {
-        return self *= v;
-      }, py::arg("v"), "In-place multiplication by scalar")
-      .def("__itruediv__", [](R2Point& self, double v) -> R2Point& {
-        return self /= v;
-      }, py::arg("v"), "In-place division by scalar")
 
       // String representation
       .def("__repr__", [](const R2Point& p) {

--- a/src/python/r2point_test.py
+++ b/src/python/r2point_test.py
@@ -147,25 +147,25 @@ class TestR2Point(unittest.TestCase):
         self.assertEqual(p1, p2)
         self.assertNotEqual(p1, p3)
 
-    def test_in_place_addition(self):
+    def test_add_assign(self):
         p = s2.R2Point(1.0, 2.0)
         p += s2.R2Point(3.0, 4.0)
         self.assertAlmostEqual(p.x, 4.0)
         self.assertAlmostEqual(p.y, 6.0)
 
-    def test_in_place_subtraction(self):
+    def test_sub_assign(self):
         p = s2.R2Point(3.0, 4.0)
         p -= s2.R2Point(1.0, 2.0)
         self.assertAlmostEqual(p.x, 2.0)
         self.assertAlmostEqual(p.y, 2.0)
 
-    def test_in_place_multiplication(self):
+    def test_mul_assign(self):
         p = s2.R2Point(1.0, 2.0)
         p *= 3.0
         self.assertAlmostEqual(p.x, 3.0)
         self.assertAlmostEqual(p.y, 6.0)
 
-    def test_in_place_division(self):
+    def test_div_assign(self):
         p = s2.R2Point(4.0, 6.0)
         p /= 2.0
         self.assertAlmostEqual(p.x, 2.0)

--- a/src/python/s1angle_bindings.cc
+++ b/src/python/s1angle_bindings.cc
@@ -138,14 +138,6 @@ void bind_s1angle(py::module& m) {
       .def("__truediv__", [](const S1Angle& a, const S1Angle& b) -> double {
         return a / b;
       }, py::arg("other"), "Divide two angles, returning a scalar ratio")
-      .def(py::self += py::self, "In-place addition")
-      .def(py::self -= py::self, "In-place subtraction")
-      .def("__imul__", [](S1Angle& self, double m) -> S1Angle& {
-        return self *= m;
-      }, py::arg("m"), "In-place multiplication by scalar")
-      .def("__itruediv__", [](S1Angle& self, double m) -> S1Angle& {
-        return self /= m;
-      }, py::arg("m"), "In-place division by scalar")
 
       // String representation
       .def("__repr__", [](S1Angle a) {

--- a/src/python/s1angle_test.py
+++ b/src/python/s1angle_test.py
@@ -246,22 +246,22 @@ class TestS1Angle(unittest.TestCase):
         ratio = a / b
         self.assertAlmostEqual(ratio, 2.0)
 
-    def test_in_place_addition(self):
+    def test_add_assign(self):
         a = s2.S1Angle.from_degrees(30.0)
         a += s2.S1Angle.from_degrees(60.0)
         self.assertAlmostEqual(a.degrees, 90.0)
 
-    def test_in_place_subtraction(self):
+    def test_sub_assign(self):
         a = s2.S1Angle.from_degrees(90.0)
         a -= s2.S1Angle.from_degrees(30.0)
         self.assertAlmostEqual(a.degrees, 60.0)
 
-    def test_in_place_scalar_multiplication(self):
+    def test_mul_assign(self):
         a = s2.S1Angle.from_degrees(45.0)
         a *= 2.0
         self.assertAlmostEqual(a.degrees, 90.0)
 
-    def test_in_place_scalar_division(self):
+    def test_div_assign(self):
         a = s2.S1Angle.from_degrees(90.0)
         a /= 2.0
         self.assertAlmostEqual(a.degrees, 45.0)

--- a/src/python/s2point_bindings.cc
+++ b/src/python/s2point_bindings.cc
@@ -62,14 +62,6 @@ void bind_s2point(py::module& m) {
       .def(-py::self, "Negate point")
       .def(py::self == py::self, "Return true if points are exactly equal")
       .def(py::self != py::self, "Return true if points are not exactly equal")
-      .def(py::self += py::self, "In-place addition")
-      .def(py::self -= py::self, "In-place subtraction")
-      .def("__imul__", [](S2Point& self, double v) -> S2Point& {
-        return self *= v;
-      }, py::arg("v"), "In-place multiplication by scalar")
-      .def("__itruediv__", [](S2Point& self, double v) -> S2Point& {
-        return self /= v;
-      }, py::arg("v"), "In-place division by scalar")
 
       // String representation
       // __repr__ prefixes class name, __str__ delegates to C++ operator<<


### PR DESCRIPTION
In-place arithmetic operators (`__iadd__`, `__isub__`, `__imul__`, `__itruediv__`) mutate the object in place. If the object is used as a dictionary key or set member, mutation corrupts the hash table entry.

Removes these operators from `S1Angle`, `R2Point`, and `S2Point`. Augmented assignment (`+=`, `-=`, `*=`, `/=`) still works: Python falls back to the binary operator and rebinds the variable, so `a += b` is equivalent to `a = a + b`.

Tests renamed to `test_add_assign` / `test_sub_assign` / `test_mul_assign` / `test_div_assign` to reflect the fallback semantics.