### PR TITLE
pybind: Drop get_ prefix from S2CellId and S2LatLng method names

### DIFF
--- a/src/python/s2cell_id_bindings.cc
+++ b/src/python/s2cell_id_bindings.cc
@@ -148,18 +148,18 @@ void bind_s2cell_id(py::module& m) {
            "The position along the Hilbert curve over this face")
       .def_property_readonly("level", &S2CellId::level,
            "The subdivision level (0..kMaxLevel)")
-      .def("get_size_ij",
+      .def("size_ij",
            py::overload_cast<>(&S2CellId::GetSizeIJ, py::const_),
            "Return the edge length of this cell in (i,j)-space")
-      .def_static("get_size_ij_for_level", [](int level) {
+      .def_static("size_ij_for_level", [](int level) {
                MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
                return S2CellId::GetSizeIJ(level);
            }, py::arg("level"),
            "Return the edge length in (i,j)-space of cells at the given level")
-      .def("get_size_st",
+      .def("size_st",
            py::overload_cast<>(&S2CellId::GetSizeST, py::const_),
            "Return the edge length of this cell in (s,t)-space")
-      .def_static("get_size_st_for_level", [](int level) {
+      .def_static("size_st_for_level", [](int level) {
                MaybeThrowLevelOutOfRange(level, 0, S2CellId::kMaxLevel);
                return S2CellId::GetSizeST(level);
            }, py::arg("level"),
@@ -168,13 +168,13 @@ void bind_s2cell_id(py::module& m) {
            "Return the center of the cell as a normalized S2Point")
       .def("to_lat_lng", &S2CellId::ToLatLng,
            "Return the S2LatLng corresponding to the center of the cell")
-      .def("get_center_st", &S2CellId::GetCenterST,
+      .def("center_st", &S2CellId::GetCenterST,
            "Return the center of the cell in (s,t)-space")
-      .def("get_bound_st", &S2CellId::GetBoundST,
+      .def("bound_st", &S2CellId::GetBoundST,
            "Return the bounds of this cell in (s,t)-space")
-      .def("get_center_uv", &S2CellId::GetCenterUV,
+      .def("center_uv", &S2CellId::GetCenterUV,
            "Return the center of the cell in (u,v)-space")
-      .def("get_bound_uv", &S2CellId::GetBoundUV,
+      .def("bound_uv", &S2CellId::GetBoundUV,
            "Return the bounds of this cell in (u,v)-space")
       .def("child_position", [](S2CellId self) {
                MaybeThrowLevelOutOfRange(self.level(), 1, S2CellId::kMaxLevel);
@@ -201,7 +201,7 @@ void bind_s2cell_id(py::module& m) {
            "Return true if the given cell is contained within this one")
       .def("intersects", &S2CellId::intersects, py::arg("other"),
            "Return true if the given cell intersects this one")
-      .def("get_common_ancestor_level", &S2CellId::GetCommonAncestorLevel,
+      .def("common_ancestor_level", &S2CellId::GetCommonAncestorLevel,
            py::arg("other"),
            "Return the level of the lowest common ancestor.\n\n"
            "Returns -1 if the cells are from different faces.")
@@ -226,14 +226,14 @@ void bind_s2cell_id(py::module& m) {
            }, py::arg("position"),
            "Return the immediate child at the given position (0..3).\n\n"
            "Raises ValueError if this is a leaf cell or position is out of range.")
-      .def("get_edge_neighbors", [](S2CellId self) {
+      .def("edge_neighbors", [](S2CellId self) {
                S2CellId neighbors[4];
                self.GetEdgeNeighbors(neighbors);
                return py::make_tuple(neighbors[0], neighbors[1],
                                      neighbors[2], neighbors[3]);
            },
            "Return the four cells adjacent across this cell's edges")
-      .def("get_vertex_neighbors", [](S2CellId self, int level) {
+      .def("vertex_neighbors", [](S2CellId self, int level) {
                MaybeThrowIfFace(self);
                MaybeThrowLevelOutOfRange(level, 0, self.level() - 1);
                std::vector<S2CellId> output;
@@ -243,7 +243,7 @@ void bind_s2cell_id(py::module& m) {
            "Return the neighbors of the closest vertex at the given level.\n\n"
            "Normally returns 4 neighbors, but may return 3 for cube vertices.\n"
            "Raises ValueError if level >= self.level().")
-      .def("get_all_neighbors", [](S2CellId self, int level) {
+      .def("all_neighbors", [](S2CellId self, int level) {
                MaybeThrowLevelOutOfRange(level, self.level(),
                                          S2CellId::kMaxLevel);
                std::vector<S2CellId> output;

--- a/src/python/s2cell_id_test.py
+++ b/src/python/s2cell_id_test.py
@@ -141,54 +141,54 @@ class TestS2CellId(unittest.TestCase):
         self.assertAlmostEqual(ll.lat.degrees, ll2.lat.degrees, places=5)
         self.assertAlmostEqual(ll.lng.degrees, ll2.lng.degrees, places=5)
 
-    def test_get_center_st(self):
+    def test_center_st(self):
         # (s,t)-space covers [0,1] x [0,1] per face; a face cell's center
         # is at (0.5, 0.5).
-        st = s2.S2CellId.from_face(0).get_center_st()
+        st = s2.S2CellId.from_face(0).center_st()
         self.assertAlmostEqual(st.x, 0.5)
         self.assertAlmostEqual(st.y, 0.5)
 
-    def test_get_bound_st(self):
+    def test_bound_st(self):
         # A face cell in (s,t) spans the full [0,1] x [0,1] range.
-        bound = s2.S2CellId.from_face(0).get_bound_st()
+        bound = s2.S2CellId.from_face(0).bound_st()
         self.assertAlmostEqual(bound.lo.x, 0.0)
         self.assertAlmostEqual(bound.lo.y, 0.0)
         self.assertAlmostEqual(bound.hi.x, 1.0)
         self.assertAlmostEqual(bound.hi.y, 1.0)
 
-    def test_get_center_uv(self):
+    def test_center_uv(self):
         # (u,v)-space covers [-1,1] x [-1,1] per face; a face cell's center
         # is at the origin.
-        uv = s2.S2CellId.from_face(0).get_center_uv()
+        uv = s2.S2CellId.from_face(0).center_uv()
         self.assertAlmostEqual(uv.x, 0.0)
         self.assertAlmostEqual(uv.y, 0.0)
 
-    def test_get_bound_uv(self):
+    def test_bound_uv(self):
         # A face cell in (u,v) spans the full [-1,1] x [-1,1] range.
-        bound = s2.S2CellId.from_face(0).get_bound_uv()
+        bound = s2.S2CellId.from_face(0).bound_uv()
         self.assertAlmostEqual(bound.lo.x, -1.0)
         self.assertAlmostEqual(bound.lo.y, -1.0)
         self.assertAlmostEqual(bound.hi.x, 1.0)
         self.assertAlmostEqual(bound.hi.y, 1.0)
 
-    def test_get_size_ij(self):
+    def test_size_ij(self):
         # In (i,j)-space a face spans 2^kMaxLevel = 2^30 units.
         face = s2.S2CellId.from_face(0)
-        self.assertEqual(face.get_size_ij(), 1 << s2.S2CellId.MAX_LEVEL)
+        self.assertEqual(face.size_ij(), 1 << s2.S2CellId.MAX_LEVEL)
 
-    def test_get_size_ij_for_level(self):
+    def test_size_ij_for_level(self):
         # Level 0 cells span 2^kMaxLevel in (i,j); leaf cells span 1.
-        self.assertEqual(s2.S2CellId.get_size_ij_for_level(0), 1 << s2.S2CellId.MAX_LEVEL)
-        self.assertEqual(s2.S2CellId.get_size_ij_for_level(30), 1)
+        self.assertEqual(s2.S2CellId.size_ij_for_level(0), 1 << s2.S2CellId.MAX_LEVEL)
+        self.assertEqual(s2.S2CellId.size_ij_for_level(30), 1)
 
-    def test_get_size_st(self):
+    def test_size_st(self):
         # In (s,t)-space a face spans the full unit interval, so size is 1.0.
-        self.assertAlmostEqual(s2.S2CellId.from_face(0).get_size_st(), 1.0)
+        self.assertAlmostEqual(s2.S2CellId.from_face(0).size_st(), 1.0)
 
-    def test_get_size_st_for_level(self):
+    def test_size_st_for_level(self):
         # Level-0 cells span the full unit interval; level-30 cells span 1/2^30.
-        self.assertAlmostEqual(s2.S2CellId.get_size_st_for_level(0), 1.0)
-        self.assertAlmostEqual(s2.S2CellId.get_size_st_for_level(30),
+        self.assertAlmostEqual(s2.S2CellId.size_st_for_level(0), 1.0)
+        self.assertAlmostEqual(s2.S2CellId.size_st_for_level(30),
                                1.0 / (1 << 30))
 
     def test_child_position(self):
@@ -249,18 +249,18 @@ class TestS2CellId(unittest.TestCase):
         face1 = s2.S2CellId.from_face(1)
         self.assertFalse(face.intersects(face1))
 
-    def test_get_common_ancestor_level(self):
+    def test_common_ancestor_level(self):
         # Two cells sharing the first two Hilbert curve steps on face 0
         # diverge at level 2, so their common ancestor is at level 2.
         base = s2.S2CellId.from_face(0).child(0).child(1)
         cell1 = base.child(2)
         cell2 = base.child(3)
-        self.assertEqual(cell1.get_common_ancestor_level(cell2), 2)
+        self.assertEqual(cell1.common_ancestor_level(cell2), 2)
 
-    def test_get_common_ancestor_level_different_faces(self):
+    def test_common_ancestor_level_different_faces(self):
         cell1 = s2.S2CellId.from_face(0)
         cell2 = s2.S2CellId.from_face(1)
-        self.assertEqual(cell1.get_common_ancestor_level(cell2), -1)
+        self.assertEqual(cell1.common_ancestor_level(cell2), -1)
 
     # Traversal
 
@@ -301,30 +301,30 @@ class TestS2CellId(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Child position 4 out of range [0, 3]")
 
-    def test_get_edge_neighbors(self):
+    def test_edge_neighbors(self):
         cell = s2.S2CellId.from_face(0)
-        neighbors = cell.get_edge_neighbors()
+        neighbors = cell.edge_neighbors()
         self.assertEqual(len(neighbors), 4)
 
-    def test_get_vertex_neighbors(self):
+    def test_vertex_neighbors(self):
         cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
-        neighbors = cell.get_vertex_neighbors(1)
+        neighbors = cell.vertex_neighbors(1)
         self.assertGreaterEqual(len(neighbors), 3)
         self.assertLessEqual(len(neighbors), 4)
 
-    def test_get_vertex_neighbors_face_cell_raises(self):
+    def test_vertex_neighbors_face_cell_raises(self):
         face = s2.S2CellId.from_face(0)
         with self.assertRaises(ValueError):
-            face.get_vertex_neighbors(0)
+            face.vertex_neighbors(0)
 
-    def test_get_vertex_neighbors_level_out_of_range_raises(self):
+    def test_vertex_neighbors_level_out_of_range_raises(self):
         cell = s2.S2CellId.from_face(0).child(0).child(1).child(2)
         with self.assertRaises(ValueError):
-            cell.get_vertex_neighbors(3)  # level must be < self.level() (3)
+            cell.vertex_neighbors(3)  # level must be < self.level() (3)
 
-    def test_get_all_neighbors(self):
+    def test_all_neighbors(self):
         cell = s2.S2CellId.from_face(0).child(0)
-        neighbors = cell.get_all_neighbors(1)
+        neighbors = cell.all_neighbors(1)
         self.assertGreater(len(neighbors), 0)
 
     # Operators

--- a/src/python/s2latlng_bindings.cc
+++ b/src/python/s2latlng_bindings.cc
@@ -129,7 +129,7 @@ void bind_s2latlng(py::module& m) {
       // Geometric operations
       .def("to_point", &S2LatLng::ToPoint,
            "Convert to the equivalent unit-length S2Point")
-      .def("get_distance", &S2LatLng::GetDistance,
+      .def("distance", &S2LatLng::GetDistance,
            py::arg("other"),
            "Return the surface distance to another S2LatLng.\n\n"
            "Uses the Haversine formula.")
@@ -142,7 +142,7 @@ void bind_s2latlng(py::module& m) {
            py::arg("max_error") = S1Angle::Radians(1e-15),
            "Return true if approximately equal to 'other'.\n\n"
            "Note: this compares coordinates in rectangular lat/lng space.\n"
-           "For points near the poles, consider using get_distance() instead.")
+           "For points near the poles, consider using distance() instead.")
 
       // Operators
       .def(py::self == py::self, "Return true if exactly equal")

--- a/src/python/s2latlng_test.py
+++ b/src/python/s2latlng_test.py
@@ -187,15 +187,15 @@ class TestS2LatLng(unittest.TestCase):
         self.assertAlmostEqual(ll.lat.radians, ll2.lat.radians)
         self.assertAlmostEqual(ll.lng.radians, ll2.lng.radians)
 
-    def test_get_distance(self):
+    def test_distance(self):
         # Distance between two points on the equator, 90 degrees apart.
         a = s2.S2LatLng.from_degrees(0.0, 0.0)
         b = s2.S2LatLng.from_degrees(0.0, 90.0)
-        self.assertAlmostEqual(a.get_distance(b).degrees, 90.0)
+        self.assertAlmostEqual(a.distance(b).degrees, 90.0)
 
-    def test_get_distance_same_point(self):
+    def test_distance_same_point(self):
         ll = s2.S2LatLng.from_degrees(37.0, -122.0)
-        self.assertAlmostEqual(ll.get_distance(ll).radians, 0.0)
+        self.assertAlmostEqual(ll.distance(ll).radians, 0.0)
 
     def test_to_string_in_degrees(self):
         ll = s2.S2LatLng.from_degrees(37.794, -122.395)


### PR DESCRIPTION
### Summary

Renames Python binding methods whose C++ names begin with `Get`, following the convention that the `Get` prefix is dropped in Python.

**S2CellId:** `size_ij`, `size_ij_for_level`, `size_st`, `size_st_for_level`, `center_st`, `bound_st`, `center_uv`, `bound_uv`, `common_ancestor_level`, `edge_neighbors`, `vertex_neighbors`, `all_neighbors`

**S2LatLng:** `distance`

### Test Plan

```
bazel test //python/...
```