### PR TITLE
Fix MSVC build

### DIFF
--- a/src/s2/util/math/exactfloat/bignum.cc
+++ b/src/s2/util/math/exactfloat/bignum.cc
@@ -83,7 +83,7 @@ int Bignum::Compare(const Bignum& b) const {
 
 std::optional<Bignum> Bignum::FromString(absl::string_view s) {
   // A chunk is up to 19 decimal digits, which can always fit into a Bigit.
-  constexpr size_t kMaxChunkDigits = std::numeric_limits<Bigit>::digits10;
+  static constexpr size_t kMaxChunkDigits = std::numeric_limits<Bigit>::digits10;
 
   // NOTE: We use a simple multiply-and-add (aka Horner's) method here for the
   // sake of simplicity. This isn't the fastest algorithm, being quadratic in
@@ -110,16 +110,16 @@ std::optional<Bignum> Bignum::FromString(absl::string_view s) {
   bool negative = false;
 
   // Consume optional +/- at the front.
-  auto begin = s.cbegin();
+  const char* begin = s.data();
   if ((*begin == '+' || *begin == '-')) {
     negative = (s[0] == '-');
     ++begin;
   }
 
-  const auto end = s.cend();
+  const char* end = s.data() + s.size();
   while (begin < end) {
-    size_t chunk_len = std::min(static_cast<size_t>(std::distance(begin, end)),
-                                kMaxChunkDigits);
+    size_t chunk_len =
+        std::min(static_cast<size_t>(end - begin), kMaxChunkDigits);
     Bigit chunk = 0;
     auto result = std::from_chars(begin, begin + chunk_len, chunk);
     if (result.ec != std::errc() ||

--- a/src/s2/util/math/exactfloat/bignum.cc
+++ b/src/s2/util/math/exactfloat/bignum.cc
@@ -110,7 +110,7 @@ std::optional<Bignum> Bignum::FromString(absl::string_view s) {
   bool negative = false;
 
   // Consume optional +/- at the front.
-  const char* begin = s.data();
+  const char* begin = s.data();  // std::from_chars needs pointers, not iterators
   if ((*begin == '+' || *begin == '-')) {
     negative = (s[0] == '-');
     ++begin;
@@ -118,8 +118,7 @@ std::optional<Bignum> Bignum::FromString(absl::string_view s) {
 
   const char* end = s.data() + s.size();
   while (begin < end) {
-    size_t chunk_len =
-        std::min(static_cast<size_t>(end - begin), kMaxChunkDigits);
+    size_t chunk_len = std::min(end - begin, kMaxChunkDigits);
     Bigit chunk = 0;
     auto result = std::from_chars(begin, begin + chunk_len, chunk);
     if (result.ec != std::errc() ||

--- a/src/s2/util/math/exactfloat/bignum.cc
+++ b/src/s2/util/math/exactfloat/bignum.cc
@@ -118,7 +118,8 @@ std::optional<Bignum> Bignum::FromString(absl::string_view s) {
 
   const char* end = s.data() + s.size();
   while (begin < end) {
-    size_t chunk_len = std::min(end - begin, kMaxChunkDigits);
+    size_t chunk_len =
+        std::min(static_cast<size_t>(end - begin), kMaxChunkDigits);
     Bigit chunk = 0;
     auto result = std::from_chars(begin, begin + chunk_len, chunk);
     if (result.ec != std::errc() ||

--- a/src/s2/util/math/exactfloat/exactfloat.cc
+++ b/src/s2/util/math/exactfloat/exactfloat.cc
@@ -56,8 +56,8 @@ ExactFloat::ExactFloat(double v) {
     // by the number of mantissa bits in a double (53, including the leading
     // "1") then the result is always an integer.
     int exp;
-    double f = frexp(fabs(v), &exp);
-    uint64_t m = static_cast<uint64_t>(ldexp(f, kDoubleMantissaBits));
+    double f = std::frexp(std::fabs(v), &exp);
+    uint64_t m = static_cast<uint64_t>(std::ldexp(f, kDoubleMantissaBits));
     bn_ = Bignum(m);
     bn_exp_ = exp - kDoubleMantissaBits;
     Canonicalize();
@@ -146,7 +146,7 @@ ExactFloat::operator double() const {
 double ExactFloat::ToDoubleHelper() const {
   ABSL_DCHECK_LE(bit_width(bn_), kDoubleMantissaBits);
   if (!isnormal(*this)) {
-    if (is_zero()) return copysign(0, sign_);
+    if (is_zero()) return std::copysign(0, sign_);
     if (isinf(*this)) {
       return std::copysign(std::numeric_limits<double>::infinity(), sign_);
     }
@@ -157,7 +157,7 @@ double ExactFloat::ToDoubleHelper() const {
 
   // We rely on ldexp() to handle overflow and underflow.  (It will return a
   // signed zero or infinity if the result is too small or too large.)
-  return sign_ * ldexp(d_mantissa, bn_exp_);
+  return sign_ * std::ldexp(d_mantissa, bn_exp_);
 }
 
 ExactFloat ExactFloat::RoundToMaxPrec(int max_prec, RoundingMode mode) const {
@@ -244,7 +244,7 @@ int ExactFloat::NumSignificantDigitsForPrec(int prec) {
   //
   // Since either of these bounds can be too large by 0, 1, or 2 digits, we
   // stick with the simpler first bound.
-  return static_cast<int>(1 + ceil(prec * (M_LN2 / M_LN10)));
+  return static_cast<int>(1 + std::ceil(prec * (M_LN2 / M_LN10)));
 }
 
 // Numbers are always formatted with at least this many significant digits.


### PR DESCRIPTION
While working on https://github.com/conda-forge/s2geometry-feedstock/pull/35, I ran into three separate issues with MSVC which are all fixed here.

### Problem 1: constexpr

```
%SRC_DIR%\src\s2\util\math\exactfloat\bignum.cc(96): error C3493: 'kMaxChunkDigits' cannot be implicitly captured because no default capture mode has been specified
```
fixed by making `kMaxChunkDigits` be of `static` storage duration

### Problem 2: namespace confusion between C(++) stdlib vs. ExactFloat implementations

```
│ │ FAILED: [code=2] CMakeFiles/s2.dir/src/s2/util/math/exactfloat/exactfloat.cc.obj
│ │ C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe /nologo /TP -DABSL_CONSUME_DLL -DABSL_MIN_LOG_LEVEL=1 -DNOMINMAX -DS2GEOMETRY_BUILDING_S2GEOMETRY -D_USE_MATH_DEFINES -Ds2_EXPORTS -I%SRC_DIR%\src -external:I%PREFIX%\Library\include -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /O2 /Ob2 /DNDEBUG -std:c++17 -MD -J /showIncludes /FoCMakeFiles\s2.dir\src\s2\util\math\exactfloat\exactfloat.cc.obj /FdCMakeFiles\s2.dir\ /FS -c %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(59): error C2440: 'initializing': cannot convert from 'exactfloat::ExactFloat' to 'double'
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(59): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(60): error C2440: 'static_cast': cannot convert from 'exactfloat::ExactFloat' to 'uint64_t'
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(60): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(149): error C2440: 'return': cannot convert from 'exactfloat::ExactFloat' to 'double'
│ │ %SRC_DIR%\src\s2\util\math\exactfloat\exactfloat.cc(149): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
```

Fixed by qualifying the respective calls with `std::` (since `<cmath>` is already included)

### Problem 3: `std::from_chars` for integers takes pointers, not iterators

```
 │ │ FAILED: [code=2] CMakeFiles/s2.dir/src/s2/util/math/exactfloat/bignum.cc.obj 
 │ │ C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP -DABSL_CONSUME_DLL -DABSL_MIN_LOG_LEVEL=1 -DNOMINMAX -DS2GEOMETRY_BUILDING_S2GEOMETRY -D_USE_MATH_DEFINES -Ds2_EXPORTS -I%SRC_DIR%\src -external:I%PREFIX%\Library\include -external:W0 /DWIN32 /D_WINDOWS /GR /EHsc /O2 /Ob2 /DNDEBUG -std:c++17 -MD   -J /showIncludes /FoCMakeFiles\s2.dir\src\s2\util\math\exactfloat\bignum.cc.obj /FdCMakeFiles\s2.dir\ /FS -c %SRC_DIR%\src\s2\util\math\exactfloat\bignum.cc
 │ │ %SRC_DIR%\src\s2\util\math\exactfloat\bignum.cc(124): error C2665: 'std::from_chars': no overloaded function could convert all the argument types
 │ │ C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\charconv(1960): note: could be 'std::from_chars_result std::from_chars(const char *const ,const char *const ,long double &,const std::chars_format) noexcept'
 │ │ %SRC_DIR%\src\s2\util\math\exactfloat\bignum.cc(124): note: 'std::from_chars_result std::from_chars(const char *const ,const char *const ,long double &,const std::chars_format) noexcept': cannot convert argument 1 from 'std::_String_view_iterator<_Traits>' to 'const char *const '
 │ │         with
 │ │         [
 │ │             _Traits=std::char_traits<char>
 │ │         ]
```

Fixed by using pointers.