### PR TITLE
Bump required Abseil to 20260526.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if (NOT TARGET absl::base)
         message(STATUS "Downloading and building abseil-cpp...")
         FetchContent_Declare(
             absl
-            URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20250814.1.zip
+            URL https://github.com/abseil/abseil-cpp/archive/refs/tags/20260526.0.zip
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         set(ABSL_PROPAGATE_CXX_STD ON CACHE BOOL "" FORCE)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This issue may require revision of boringssl or exactfloat.
     [g++ >= 7.5](https://gcc.gnu.org/) or
     [clang >= 14.0.0](https://clang.llvm.org/)
 *   [Abseil](https://github.com/abseil/abseil-cpp) LTS
-    [`20250814`](https://github.com/abseil/abseil-cpp/releases/tag/20250814.1)
+    [`20260526`](https://github.com/abseil/abseil-cpp/releases/tag/20260526.0)
     (standard library extensions). This exact version must be used.
 *   [googletest testing framework >= 1.10](https://github.com/google/googletest)
     (to build tests and example programs, optional)

--- a/src/MODULE.bazel
+++ b/src/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 )
 
 # Production dependencies
-bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "abseil-cpp", version = "20260526.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_cc", version = "0.2.22")
 

--- a/src/s2/util/gtl/compact_array.h
+++ b/src/s2/util/gtl/compact_array.h
@@ -49,9 +49,9 @@
 #include <type_traits>
 #include <utility>
 
-#include "absl/base/internal/throw_delegate.h"
 #include "absl/base/macros.h"
 #include "absl/base/optimization.h"
+#include "absl/base/throw_delegate.h"
 #include "absl/log/absl_check.h"
 #include "absl/meta/type_traits.h"
 #include "absl/numeric/bits.h"
@@ -245,8 +245,7 @@ class compact_array_base {
   // This Insert() is private because it might return the end().
   iterator Insert(const_iterator p, const value_type& v) {
     if (ABSL_PREDICT_FALSE(size() >= kMaxSize)) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdLengthError("compact_array size exceeded");
+      absl::ThrowStdLengthError("compact_array size exceeded");
     }
     iterator r = make_hole(p, 1);
     *r = v;
@@ -260,8 +259,7 @@ class compact_array_base {
 
   void insert(const_iterator p, size_type n, const value_type& v) {
     if (ABSL_PREDICT_FALSE(n > kMaxSize - size())) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdLengthError("compact_array size exceeded");
+      absl::ThrowStdLengthError("compact_array size exceeded");
     }
     value_insert(p, n, v);
   }
@@ -321,16 +319,14 @@ class compact_array_base {
 
   reference at(size_type n) {
     if (ABSL_PREDICT_FALSE(n >= size_)) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdOutOfRange("compact_array_base::at");
+      absl::ThrowStdOutOfRange("compact_array_base::at");
     }
     return Array()[n];
   }
 
   const_reference at(size_type n) const {
     if (ABSL_PREDICT_FALSE(n >= size_)) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdOutOfRange("compact_array_base::at");
+      absl::ThrowStdOutOfRange("compact_array_base::at");
     }
     return ConstArray()[n];
   }
@@ -477,8 +473,7 @@ class compact_array_base {
 
   void value_insert(const_iterator p, size_type n, const value_type& v) {
     if (ABSL_PREDICT_FALSE(n > kMaxSize - size())) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdLengthError("compact_array size exceeded");
+      absl::ThrowStdLengthError("compact_array size exceeded");
     }
     iterator hole = make_hole(p, n);
     std::fill(hole, hole + n, v);
@@ -498,8 +493,7 @@ class compact_array_base {
                     std::forward_iterator_tag) {
     size_type n = std::distance(first, last);
     if (ABSL_PREDICT_FALSE(n > kMaxSize - size())) {
-      // NOLINTNEXTLINE(build/namespaces)
-      absl::base_internal::ThrowStdLengthError("compact_array size exceeded");
+      absl::ThrowStdLengthError("compact_array size exceeded");
     }
     std::copy(first, last, make_hole(p, n));
   }


### PR DESCRIPTION
Abseil LTS 20260526 moved the ThrowStd* helpers from absl/base/internal/throw_delegate.h (namespace absl::base_internal) to absl/base/throw_delegate.h (namespace absl). Update compact_array.h to use the new header and public namespace.

I understand this package uses specific version of abseil, so will wait for next update or closing also fine.

Ref: #645