### PR TITLE
pybind: Wire up S2Cell.get_cap_bound()

### DIFF
--- a/src/python/s2cell_bindings.cc
+++ b/src/python/s2cell_bindings.cc
@@ -9,6 +9,7 @@
 #include "absl/hash/hash.h"
 #include "absl/strings/str_cat.h"
 #include "s2/s1chord_angle.h"
+#include "s2/s2cap.h"
 #include "s2/s2cell.h"
 #include "s2/s2cell_id.h"
 #include "s2/s2latlng.h"
@@ -190,6 +191,9 @@ void bind_s2cell(py::module& m) {
            "Return a list of S2CellIds whose union covers this cell.\n\n"
            "For a single S2Cell, this always returns a list containing\n"
            "just this cell's id.")
+      .def("get_cap_bound", &S2Cell::GetCapBound,
+           "Return a bounding cap for this cell.")
+      // get_rect_bound() is deferred until S2LatLngRect is bound.
       .def("contains", py::overload_cast<const S2Cell&>(
                &S2Cell::Contains, py::const_),
            py::arg("cell"),
@@ -245,8 +249,6 @@ void bind_s2cell(py::module& m) {
       .value("LEFT_EDGE",   S2Cell::kLeftEdge)
       .export_values();
 
-  // TODO: The following S2Cell methods are not yet bound because they depend
-  // on types that have not been bound yet:
-  //   - get_cap_bound()   -> S2Cap
-  //   - get_rect_bound()  -> S2LatLngRect
+  // TODO: get_rect_bound() is not yet bound because it depends on
+  // S2LatLngRect, which has not been bound yet.
 }

--- a/src/python/s2cell_test.py
+++ b/src/python/s2cell_test.py
@@ -256,6 +256,14 @@ class TestS2Cell(unittest.TestCase):
         self.assertEqual(len(bound), 1)
         self.assertEqual(bound[0], cell.id)
 
+    def test_get_cap_bound(self):
+        cell = s2.S2Cell.from_face(0)
+        bound = cell.get_cap_bound()
+        # The bounding cap must contain the cell's center and all vertices.
+        self.assertTrue(bound.contains_point(cell.center()))
+        for k in range(4):
+            self.assertTrue(bound.contains_point(cell.vertex(k)))
+
     def test_contains_cell(self):
         face = s2.S2Cell.from_face(0)
         child = s2.S2Cell(face.id.child(0))


### PR DESCRIPTION
PR #646 claimed to resolve the TODO in `s2cell_bindings.cc` by binding `S2Cell.get_cap_bound()`, since `S2Cap` is now registered before `S2Cell` in the module initialization order. However, the actual `.def()` call was never added, leaving both the TODO comment and the binding absent.

This change adds the missing binding for `S2Cell::GetCapBound`, following the same pattern used for `S2Cap.cap_bound()`. It also updates the TODO comment to reflect the current state: only `get_rect_bound()` remains deferred, pending `S2LatLngRect` bindings.

## Testing

```sh
bazel test //python:s2cell_test //python:s2cap_test
```

Both test suites pass locally, including a new `test_get_cap_bound` test that verifies the returned cap contains the cell's center and all of its vertices.

Fixes #650 
